### PR TITLE
Add test demonstrating issue #13

### DIFF
--- a/Test/Emit/EmitAndCompileSmoke.lean
+++ b/Test/Emit/EmitAndCompileSmoke.lean
@@ -57,7 +57,16 @@ def samples : List (String × String) := [
    "type Mode = \"a\" | \"b\" | \"c\";\n" ++
    "function cmpZero(): Signed { return 0; }\n" ++
    "function pick(): Mode { return \"a\"; }\n" ++
-   "function quadratic(x: Signed): number { return x * x + 1; }")
+   "function quadratic(x: Signed): number { return x * x + 1; }"),
+  -- Single-record `type` aliases must lower to a Lean `structure` so
+  -- field projections elaborate. Today they collapse to `abbrev T :=
+  -- Unit`, breaking `range.start` / `range.endPort`.
+  -- https://github.com/jessealama/thales/issues/13
+  ("SingleRecordTypeAlias",
+   "type PortRange = { start: bigint; endPort: bigint };\n" ++
+   "function portInRange(port: bigint, range: PortRange): boolean {\n" ++
+   "  return range.start <= port && port <= range.endPort;\n" ++
+   "}")
 ]
 
 def runSmoke : IO Unit := do


### PR DESCRIPTION
## Summary

Adds a `SingleRecordTypeAlias` sample to `Test/Emit/EmitAndCompileSmoke.lean` that exercises the bug reported in https://github.com/jessealama/thales/issues/13: a single-record `type` alias is emitted as `abbrev T := Unit`, so field projections (`range.start`, `range.endPort`) fail to elaborate.

The TS source is the issue's minimal repro:

```typescript
type PortRange = { start: bigint; endPort: bigint };

function portInRange(port: bigint, range: PortRange): boolean {
  return range.start <= port && port <= range.endPort;
}
```

I verified locally with `lean 4.29.0` that the emitted shape from the issue (`abbrev PortRange := Unit` plus the function) fails with the exact errors the issue cites:

```
error: Invalid field `start`: The environment does not contain `PUnit.start`
error: Invalid field `endPort`: The environment does not contain `PUnit.endPort`
```

The smoke harness already runs `lake env lean` on each sample and fails the test when elaboration fails, so no harness changes are needed — the sample fails until the emitter learns to lower single-record `type` aliases the same way it handles `interface`.

Draft because this only adds the failing test; the emitter fix lives in `Thales/Emit/Lean.lean` (`emitTypeAlias` falls through to `abbrev_` when the body isn't a union, regardless of whether it's a single-record object).

## Test plan

- [x] `lake build ThalesTest` — confirm the new sample fails before the fix.
- [ ] After the emitter fix lands, `lake build ThalesTest` should pass and the smoke test should report `[smoke ok] SingleRecordTypeAlias`.
