### PR TITLE
Support local variable mutation via Id.run do

### DIFF
--- a/Test/Emit/DoModeEmitTest.lean
+++ b/Test/Emit/DoModeEmitTest.lean
@@ -120,6 +120,29 @@ console.log(h(true));"
     ["if c then", "n := (n + 1.000000)", "return n", "else", "return 0.000000"]
     (forbidden := ["return ()"])
 
+-- ── function-level lowerability fallback (#40/#41): even with eligible
+-- mutation, an unlowerable body shape must keep the PURE emission path
+-- (SubsetCheck rejects these programs; the emitter gate is the
+-- defense-in-depth that turns a checker regression into a pure-path
+-- emission instead of a miscompile) ──
+
+-- try/catch in the body: no do-mode
+def testTryBodyStaysPure : IO Unit :=
+  expectEmit
+    "function f(x: number): number { let n = 0; n = 5; try { return x; } catch (e) { return n; } }
+console.log(f(3));"
+    ["def f"]
+    (forbidden := ["Id.run do", "let mut"])
+
+-- narrowing-dependent read (null-tested `x` read outside its test): no
+-- do-mode; the pure path lowers the null test to an Option match
+def testNarrowedReadStaysPure : IO Unit :=
+  expectEmit
+    "function f(x: string | null): number { let n = 0; n += 1; if (x === null) { return n; } return x.length; }
+console.log(f(\"abc\"));"
+    ["def f", "match x with"]
+    (forbidden := ["Id.run do", "let mut"])
+
 #eval testStraightLineDo
 #eval testPureStaysPure
 #eval testMixedLets
@@ -130,3 +153,5 @@ console.log(h(true));"
 #eval testBranchMutationDo
 #eval testEarlyReturnDo
 #eval testIfElseBothReturn
+#eval testTryBodyStaysPure
+#eval testNarrowedReadStaysPure

--- a/Test/Emit/DoModeEmitTest.lean
+++ b/Test/Emit/DoModeEmitTest.lean
@@ -52,6 +52,29 @@ console.log(f());"
     ["Id.run do", "let k := 10.000000", "let mut n := 0.000000", "n := (n + k)"]
     (forbidden := ["let mut k"])
 
+-- `n++` / `n--` desugar to plain reassignment on the underlying binop
+def testUpdateDesugar : IO Unit :=
+  expectEmit
+    "function f(): number { let n = 0; n++; n--; return n; }
+console.log(f());"
+    ["Id.run do",
+     "n := (n + 1.000000)",
+     "n := (n - 1.000000)"]
+
+-- compound ops desugar to `n := n OP e`; `**=` lowers through `^`
+def testCompoundDesugar : IO Unit :=
+  expectEmit
+    "function f(): number { let m = 10; m += 2; m -= 1; m *= 4; m /= 8; m **= 2; return m; }
+console.log(f());"
+    ["Id.run do",
+     "m := (m + 2.000000)",
+     "m := (m - 1.000000)",
+     "m := (m * 4.000000)",
+     "m := (m / 8.000000)",
+     "m := (m ^ 2.000000)"]
+
 #eval testStraightLineDo
 #eval testPureStaysPure
 #eval testMixedLets
+#eval testUpdateDesugar
+#eval testCompoundDesugar

--- a/Test/Emit/DoModeEmitTest.lean
+++ b/Test/Emit/DoModeEmitTest.lean
@@ -73,8 +73,30 @@ console.log(f());"
      "m := (m / 8.000000)",
      "m := (m ^ 2.000000)"]
 
+-- mutated parameters self-shadow as `let mut x := x` (JS param mutation
+-- never affects the caller, so a local mutable copy is exact)
+def testParamSelfShadow : IO Unit :=
+  expectEmit
+    "function pad(n: number): number { n = n + 1; return n; }
+console.log(pad(2));"
+    ["def pad (n : Float) : Float :=",
+     "Id.run do",
+     "let mut n := n",
+     "n := (n + 1.000000)",
+     "return n"]
+
+-- unmutated parameters get no shadow
+def testUnmutatedParamNoShadow : IO Unit :=
+  expectEmit
+    "function f(x: number, y: number): number { x += y; return x; }
+console.log(f(1, 2));"
+    ["let mut x := x"]
+    (forbidden := ["let mut y"])
+
 #eval testStraightLineDo
 #eval testPureStaysPure
 #eval testMixedLets
 #eval testUpdateDesugar
 #eval testCompoundDesugar
+#eval testParamSelfShadow
+#eval testUnmutatedParamNoShadow

--- a/Test/Emit/DoModeEmitTest.lean
+++ b/Test/Emit/DoModeEmitTest.lean
@@ -1,0 +1,57 @@
+/-
+  Test/Emit/DoModeEmitTest.lean
+  Pins #24 do-mode emission: a function body containing an eligible
+  statement-position mutation lowers to `Id.run do` with `let mut`;
+  functions without eligible mutation keep the pure expression path.
+-/
+import Thales.Emit.Lean
+import Thales.Parser.Native
+
+open Thales.Emit
+open Thales.Parser
+
+private def containsSubstr (hay needle : String) : Bool :=
+  (hay.splitOn needle).length ≥ 2
+
+def expectEmit (src : String) (needles : List String) (forbidden : List String := []) : IO Unit := do
+  match parseTSSourceNative src with
+  | .error e => throw (IO.userError s!"parse: {e}")
+  | .ok prog =>
+    let out := emit prog "M"
+    for n in needles do
+      unless containsSubstr out n do
+        throw (IO.userError s!"missing '{n}' in:\n{out}")
+    for n in forbidden do
+      if containsSubstr out n then
+        throw (IO.userError s!"unexpected '{n}' in:\n{out}")
+
+-- straight-line plain reassignment lowers to Id.run do / let mut
+def testStraightLineDo : IO Unit :=
+  expectEmit
+    "function inc(): number { let n = 0; n = n + 1; return n; }
+console.log(inc());"
+    ["def inc : Float :=",
+     "Id.run do",
+     "let mut n := 0.000000",
+     "n := (n + 1.000000)",
+     "return n"]
+
+-- a function without mutation keeps the pure let-chain path (no do-block)
+def testPureStaysPure : IO Unit :=
+  expectEmit
+    "function sq(x: number): number { const y = x * x; return y; }
+console.log(sq(3));"
+    ["def sq"]
+    (forbidden := ["Id.run do", "let mut"])
+
+-- non-mutated lets inside a do-mode body stay immutable `let`
+def testMixedLets : IO Unit :=
+  expectEmit
+    "function f(): number { const k = 10; let n = 0; n = n + k; return n; }
+console.log(f());"
+    ["Id.run do", "let k := 10.000000", "let mut n := 0.000000", "n := (n + k)"]
+    (forbidden := ["let mut k"])
+
+#eval testStraightLineDo
+#eval testPureStaysPure
+#eval testMixedLets

--- a/Test/Emit/DoModeEmitTest.lean
+++ b/Test/Emit/DoModeEmitTest.lean
@@ -93,6 +93,33 @@ console.log(f(1, 2));"
     ["let mut x := x"]
     (forbidden := ["let mut y"])
 
+-- no-else `if` with mutation: the branch lowers WITHOUT the continuation
+-- appended (do-notation has statement semantics), so the post-branch
+-- mutation stays visible after the `if`
+def testBranchMutationDo : IO Unit :=
+  expectEmit
+    "function f(c: boolean): number { let n = 0; if (c) { n += 5; } n += 1; return n; }
+console.log(f(true));"
+    ["Id.run do", "if c then", "n := (n + 5.000000)",
+     "n := (n + 1.000000)", "return n"]
+
+-- early return inside a branch is do-notation's native `return`
+def testEarlyReturnDo : IO Unit :=
+  expectEmit
+    "function g(n: number): number { let m = n; if (m > 10) { return 100; } m += 1; return m; }
+console.log(g(20));
+console.log(g(1));"
+    ["let mut m := n", "if (m > 10.000000) then", "return 100.000000",
+     "m := (m + 1.000000)", "return m"]
+
+-- if/else where both branches return: no dead trailing `return ()`
+def testIfElseBothReturn : IO Unit :=
+  expectEmit
+    "function h(c: boolean): number { let n = 1; if (c) { n += 1; return n; } else { return 0; } }
+console.log(h(true));"
+    ["if c then", "n := (n + 1.000000)", "return n", "else", "return 0.000000"]
+    (forbidden := ["return ()"])
+
 #eval testStraightLineDo
 #eval testPureStaysPure
 #eval testMixedLets
@@ -100,3 +127,6 @@ console.log(f(1, 2));"
 #eval testCompoundDesugar
 #eval testParamSelfShadow
 #eval testUnmutatedParamNoShadow
+#eval testBranchMutationDo
+#eval testEarlyReturnDo
+#eval testIfElseBothReturn

--- a/Test/Emit/EscapeAnalysisTest.lean
+++ b/Test/Emit/EscapeAnalysisTest.lean
@@ -4,6 +4,9 @@
   reference to it occurs in the declaring function's own body — no
   reference from any nested function/arrow — and it is a parameter or an
   initialized `let`, and it is not entangled with narrowing tests.
+  Also pins the function-level `doModeLowerable` gate (#40/#41): bodies
+  with try/catch, unlowerable switch shapes, or narrowing-dependent reads
+  stay on the pure path.
 -/
 import Thales.Emit.EscapeAnalysis
 import Thales.Parser.Native
@@ -68,22 +71,63 @@ def t9 : IO Unit := do
   unless info.consts.contains "c" do throw (IO.userError "c not in consts")
   if info.initializedLets.contains "c" then throw (IO.userError "c wrongly in initializedLets")
 
--- switch shapes: all-arms-return is lowerable; a non-returning arm or a
--- `default` arm is not (do-mode would need post-switch join emission)
+-- switch shapes: a discriminated-shape (`ident.field`) switch with
+-- all-arms-return is lowerable; a non-returning arm, a `default` arm, or
+-- a non-member scrutinee (no do-mode lowering exists for it) is not
 def expectUnloweredSwitch (src : String) (expected : Bool) : IO Unit := do
   let info ← analyzeFirstFunc src
   unless info.hasUnloweredSwitchShape == expected do
     throw (IO.userError s!"hasUnloweredSwitchShape = {!expected}, expected {expected}")
 
 def t10 : IO Unit := expectUnloweredSwitch
-  "function f(x: string): number { let n = 0; switch (x) { case \"a\": n = 1; return n; case \"b\": return 2; } return n; }"
+  "type S = { kind: string };
+function f(s: S): number { let n = 0; switch (s.kind) { case \"a\": n = 1; return n; case \"b\": return 2; } return n; }"
   false
 def t11 : IO Unit := expectUnloweredSwitch
-  "function f(x: string): number { let n = 0; switch (x) { case \"a\": n = 1; break; case \"b\": return 2; } return n; }"
+  "type S = { kind: string };
+function f(s: S): number { let n = 0; switch (s.kind) { case \"a\": n = 1; break; case \"b\": return 2; } return n; }"
   true
 def t12 : IO Unit := expectUnloweredSwitch
-  "function f(x: string): number { let n = 0; switch (x) { case \"a\": return 1; default: return 2; } }"
+  "type S = { kind: string };
+function f(s: S): number { let n = 0; switch (s.kind) { case \"a\": return 1; default: return 2; } }"
   true
+-- plain-identifier scrutinee: no do-mode lowering, even with all-return arms
+def t13 : IO Unit := expectUnloweredSwitch
+  "function f(x: string): number { let n = 0; switch (x) { case \"a\": return 1; case \"b\": return 2; } return n; }"
+  true
+
+-- ── function-level do-mode lowerability (#40/#41) ──
+
+def expectLowerable (src : String) (expected : Bool) : IO Unit := do
+  let info ← analyzeFirstFunc src
+  unless info.doModeLowerable == expected do
+    throw (IO.userError s!"doModeLowerable = {!expected}, expected {expected} in: {src}")
+
+-- try/catch anywhere in the body keeps the function out of do-mode (#41)
+def t14 : IO Unit := expectLowerable
+  "function f(x: number): number { let n = 0; n = 1; try { return x; } catch (e) { return n; } }"
+  false
+-- a narrow-tested variable read outside its test (#40): not lowerable …
+def t15 : IO Unit := expectLowerable
+  "function f(x: string | null): number { let n = 0; n += 1; if (x === null) { return n; } return x.length; }"
+  false
+-- … but a var that only ever appears in its test leaves the function
+-- lowerable (the t7b source)
+def t16 : IO Unit := expectLowerable
+  "function f(x: string | null): number { let n = 0; if (x === null) { n = 1; } return n; }"
+  true
+-- a nested arrow reading the narrow-tested var also blocks (#40)
+def t17 : IO Unit := expectLowerable
+  "function f(x: string | null): number { let n = 0; n = 1; if (x === null) { return 0; } const g = () => x; return n; }"
+  false
+
+-- undefined tests count the same as null tests (#42), both operand orders
+def t18 : IO Unit := expectEligible
+  "function f(x: string | undefined): number { let n = 0; if (x === undefined) { n = 1; } return n; }" "x" false
+def t18b : IO Unit := expectEligible
+  "function f(x: string | undefined): number { let n = 0; if (undefined !== x) { n = 1; } return n; }" "x" false
+def t18c : IO Unit := expectEligible
+  "function f(x: string | undefined): number { let n = 0; if (x === undefined) { n = 1; } return n; }" "n" true
 
 #eval t1
 #eval t2
@@ -99,3 +143,11 @@ def t12 : IO Unit := expectUnloweredSwitch
 #eval t10
 #eval t11
 #eval t12
+#eval t13
+#eval t14
+#eval t15
+#eval t16
+#eval t17
+#eval t18
+#eval t18b
+#eval t18c

--- a/Test/Emit/EscapeAnalysisTest.lean
+++ b/Test/Emit/EscapeAnalysisTest.lean
@@ -68,6 +68,23 @@ def t9 : IO Unit := do
   unless info.consts.contains "c" do throw (IO.userError "c not in consts")
   if info.initializedLets.contains "c" then throw (IO.userError "c wrongly in initializedLets")
 
+-- switch shapes: all-arms-return is lowerable; a non-returning arm or a
+-- `default` arm is not (do-mode would need post-switch join emission)
+def expectUnloweredSwitch (src : String) (expected : Bool) : IO Unit := do
+  let info ← analyzeFirstFunc src
+  unless info.hasUnloweredSwitchShape == expected do
+    throw (IO.userError s!"hasUnloweredSwitchShape = {!expected}, expected {expected}")
+
+def t10 : IO Unit := expectUnloweredSwitch
+  "function f(x: string): number { let n = 0; switch (x) { case \"a\": n = 1; return n; case \"b\": return 2; } return n; }"
+  false
+def t11 : IO Unit := expectUnloweredSwitch
+  "function f(x: string): number { let n = 0; switch (x) { case \"a\": n = 1; break; case \"b\": return 2; } return n; }"
+  true
+def t12 : IO Unit := expectUnloweredSwitch
+  "function f(x: string): number { let n = 0; switch (x) { case \"a\": return 1; default: return 2; } }"
+  true
+
 #eval t1
 #eval t2
 #eval t3
@@ -79,3 +96,6 @@ def t9 : IO Unit := do
 #eval t7c
 #eval t8
 #eval t9
+#eval t10
+#eval t11
+#eval t12

--- a/Test/Emit/EscapeAnalysisTest.lean
+++ b/Test/Emit/EscapeAnalysisTest.lean
@@ -1,0 +1,81 @@
+/-
+  Test/Emit/EscapeAnalysisTest.lean
+  Pins the #24 eligibility rule: a binding is mutable-eligible iff every
+  reference to it occurs in the declaring function's own body — no
+  reference from any nested function/arrow — and it is a parameter or an
+  initialized `let`, and it is not entangled with narrowing tests.
+-/
+import Thales.Emit.EscapeAnalysis
+import Thales.Parser.Native
+
+open Thales.Emit.EscapeAnalysis
+open Thales.Parser
+open Thales.AST
+open Thales.TypeCheck
+
+/-- Parse `src`, find the first annotated function decl, analyze its body. -/
+def analyzeFirstFunc (src : String) : IO MutationInfo := do
+  match parseTSSourceNative src with
+  | .error e => throw (IO.userError s!"parse error: {e}")
+  | .ok prog =>
+    for ts in prog.body do
+      if let .annotatedFuncDecl _ _ _ params _ body _ _ _ _ := ts then
+        return analyze (params.map (·.1)) body
+    throw (IO.userError "no function decl found")
+
+def expectEligible (src : String) (name : String) (expected : Bool) : IO Unit := do
+  let info ← analyzeFirstFunc src
+  let got := info.eligible name
+  unless got == expected do
+    throw (IO.userError s!"eligible '{name}' = {got}, expected {expected} in: {src}")
+
+-- straight-line local mutation: eligible
+def t1 : IO Unit := expectEligible
+  "function f(): number { let n = 0; n = 1; return n; }" "n" true
+-- read from a nested arrow: NOT eligible
+def t2 : IO Unit := expectEligible
+  "function f(): number { let n = 0; const g = () => n; n = 1; return g(); }" "n" false
+-- write from a nested arrow: NOT eligible
+def t3 : IO Unit := expectEligible
+  "function f(): number { let n = 0; const g = () => { n = 1; }; g(); return n; }" "n" false
+-- parameter: eligible
+def t4 : IO Unit := expectEligible
+  "function f(x: number): number { x = x + 1; return x; }" "x" true
+-- let without initializer: NOT eligible
+def t5 : IO Unit := expectEligible
+  "function f(): number { let n: number; n = 1; return n; }" "n" false
+-- arrow not mentioning the mutated var does not disqualify it
+def t6 : IO Unit := expectEligible
+  "function f(): number { let n = 0; const g = (y: number) => y + 1; n = 1; return g(n); }" "n" true
+-- null-tested var: NOT eligible (conservative v1 guard) …
+def t7 : IO Unit := expectEligible
+  "function f(x: string | null): number { let n = 0; if (x === null) { n = 1; } return n; }" "x" false
+-- … but the merely-branch-assigned var in the same source IS eligible
+def t7b : IO Unit := expectEligible
+  "function f(x: string | null): number { let n = 0; if (x === null) { n = 1; } return n; }" "n" true
+-- refinement-predicate-tested var (call with single ident arg in condition): NOT eligible
+def t7c : IO Unit := expectEligible
+  "function f(x: number): number { x = 0; if (isInteger(x)) { return 1; } return x; }" "x" false
+
+-- mutated-set sanity: n++ and n += 1 both count as mutation sites
+def t8 : IO Unit := do
+  let info ← analyzeFirstFunc "function f(): number { let n = 0; n++; n += 1; return n; }"
+  unless info.mutated.contains "n" do throw (IO.userError "n not in mutated")
+
+-- const declarations are recorded as consts, not initializedLets
+def t9 : IO Unit := do
+  let info ← analyzeFirstFunc "function f(): number { const c = 1; let n = 0; n = c; return n; }"
+  unless info.consts.contains "c" do throw (IO.userError "c not in consts")
+  if info.initializedLets.contains "c" then throw (IO.userError "c wrongly in initializedLets")
+
+#eval t1
+#eval t2
+#eval t3
+#eval t4
+#eval t5
+#eval t6
+#eval t7
+#eval t7b
+#eval t7c
+#eval t8
+#eval t9

--- a/Test/Emit/LeanSyntaxDoTest.lean
+++ b/Test/Emit/LeanSyntaxDoTest.lean
@@ -1,0 +1,102 @@
+/-
+  Test/Emit/LeanSyntaxDoTest.lean
+  Golden tests for the LDoStmt / Id.run do rendering (#24). The expected
+  strings pin the renderer's actual conventions: binOp always
+  parenthesizes, floats render with full precision (`0.000000`), and
+  nested do-blocks indent by two spaces per level.
+-/
+import Thales.Emit.LeanSyntax
+
+open Thales.Emit.LeanSyntax
+
+private def expectRender (got expected : String) : IO Unit := do
+  unless got == expected do
+    throw (IO.userError s!"render mismatch:\n---got---\n{got}\n---want---\n{expected}")
+
+def counterBody : LExpr :=
+  .idRunDo [
+    .letMut "n" (some (.const "Float")) (.float 0.0),
+    .assign "n" (.binOp "+" (.var "n") (.float 1.0)),
+    .ifDo (.binOp "==" (.var "n") (.float 1.0))
+      [.assign "n" (.binOp "+" (.var "n") (.float 2.0))] [],
+    .ret (.var "n")
+  ]
+
+def counterExpected : String :=
+  "Id.run do\n" ++
+  "  let mut n : Float := 0.000000\n" ++
+  "  n := (n + 1.000000)\n" ++
+  "  if (n == 1.000000) then\n" ++
+  "    n := (n + 2.000000)\n" ++
+  "  return n"
+
+def t1 : IO Unit := expectRender (renderExpr counterBody) counterExpected
+
+-- if/else with both branches, unannotated let mut, pure let in do
+def branchBody : LExpr :=
+  .idRunDo [
+    .letMut "m" none (.var "x"),
+    .letPure "limit" none (.float 10.0),
+    .ifDo (.binOp ">" (.var "m") (.var "limit"))
+      [.ret (.var "limit")]
+      [.assign "m" (.binOp "+" (.var "m") (.float 1.0))],
+    .ret (.var "m")
+  ]
+
+def branchExpected : String :=
+  "Id.run do\n" ++
+  "  let mut m := x\n" ++
+  "  let limit := 10.000000\n" ++
+  "  if (m > limit) then\n" ++
+  "    return limit\n" ++
+  "  else\n" ++
+  "    m := (m + 1.000000)\n" ++
+  "  return m"
+
+def t2 : IO Unit := expectRender (renderExpr branchBody) branchExpected
+
+-- empty branch renders `pure ()`; matchDo arms hold statement lists
+def emptyThen : LExpr :=
+  .idRunDo [
+    .ifDo (.var "c") [] [.assign "n" (.float 0.0)],
+    .ret (.var "n")
+  ]
+
+def emptyThenExpected : String :=
+  "Id.run do\n" ++
+  "  if c then\n" ++
+  "    pure ()\n" ++
+  "  else\n" ++
+  "    n := 0.000000\n" ++
+  "  return n"
+
+def t3 : IO Unit := expectRender (renderExpr emptyThen) emptyThenExpected
+
+def matchBody : LExpr :=
+  .idRunDo [
+    .letMut "area" none (.float 0.0),
+    .matchDo (.var "shape") [
+      (.ctor "circle" [.var "r"], [
+        .assign "area" (.binOp "*" (.var "r") (.var "r")),
+        .ret (.var "area")
+      ]),
+      (.wildcard, [.ret (.float 0.0)])
+    ]
+  ]
+
+def matchExpected : String :=
+  "Id.run do\n" ++
+  "  let mut area := 0.000000\n" ++
+  "  match shape with\n" ++
+  "  | .circle r =>\n" ++
+  "    area := (r * r)\n" ++
+  "    return area\n" ++
+  "  | _ =>\n" ++
+  "    return 0.000000"
+
+def t4 : IO Unit := expectRender (renderExpr matchBody) matchExpected
+
+#eval t1
+#eval t2
+#eval t3
+#eval t4

--- a/Test/Emit/MutationCheckTest.lean
+++ b/Test/Emit/MutationCheckTest.lean
@@ -78,6 +78,11 @@ def testBitAndAssignAllowed : IO Unit := expectNoCode
 def testArrowOwnLocalStillTH1 : IO Unit := expectCode
   "const g = (): number => { let n = 0; n = 1; return n; };" 1
 
+-- A switch with a `break`-style (non-returning) arm or a `default` keeps
+-- the function's mutation rejected: do-mode lowers all-arms-return only
+def testSwitchBreakArmStillTH1 : IO Unit := expectCode
+  "function f(x: string): number { let n = 0; switch (x) { case \"a\": n = 1; break; case \"b\": return 2; } return n; }" 1
+
 -- Still-rejected forms keep TH0001
 def testUninitializedLet : IO Unit := expectCode
   "function f(): number { let n: number; n = 1; return n; }" 1
@@ -104,5 +109,6 @@ def testLogicalAssignStaysTH1 : IO Unit := expectCode
 #eval testModAssignAllowed
 #eval testBitAndAssignAllowed
 #eval testArrowOwnLocalStillTH1
+#eval testSwitchBreakArmStillTH1
 #eval testUninitializedLet
 #eval testLogicalAssignStaysTH1

--- a/Test/Emit/MutationCheckTest.lean
+++ b/Test/Emit/MutationCheckTest.lean
@@ -89,6 +89,24 @@ def testUninitializedLet : IO Unit := expectCode
 def testLogicalAssignStaysTH1 : IO Unit := expectCode
   "function f(x: boolean): boolean { let b = x; b &&= x; return b; }" 1
 
+-- Function-level lowerability (#40/#41): mutation OUTSIDE a try, in a
+-- function whose body contains one, is TH0001 (do-mode can't thread the
+-- exception path; TH0007 covers only mutation inside the try)
+def testMutationBesideTryTH1 : IO Unit := expectCode
+  "function f(x: number): number { let n = 0; n = 5; try { return x; } catch (e) { return n; } }" 1
+-- Mutation in a function that reads a null-tested variable outside its
+-- test: TH0001 (#40 — do-mode's plain `if` carries no narrowing evidence)
+def testNarrowedReadMutationTH1 : IO Unit := expectCode
+  "function f(x: string | null): number { let n = 0; n += 1; if (x === null) { return n; } return x.length; }" 1
+-- Mutating an undefined-tested variable: TH0001 (#42 — undefined tests
+-- count the same as null tests)
+def testUndefinedTestedMutationTH1 : IO Unit := expectCode
+  "function f(x: string | undefined): number { if (x === undefined) { x = \"d\"; } return x.length; }" 1
+-- A plain-identifier switch scrutinee has no do-mode lowering, even with
+-- all-return arms: the function's mutation stays TH0001
+def testPlainIdentSwitchTH1 : IO Unit := expectCode
+  "function f(x: string): number { let n = 0; n = 1; switch (x) { case \"a\": return 1; case \"b\": return 2; } return n; }" 1
+
 #eval testReassignment
 #eval testCompoundAssignment
 #eval testIncrement
@@ -112,3 +130,7 @@ def testLogicalAssignStaysTH1 : IO Unit := expectCode
 #eval testSwitchBreakArmStillTH1
 #eval testUninitializedLet
 #eval testLogicalAssignStaysTH1
+#eval testMutationBesideTryTH1
+#eval testNarrowedReadMutationTH1
+#eval testUndefinedTestedMutationTH1
+#eval testPlainIdentSwitchTH1

--- a/Test/Emit/MutationCheckTest.lean
+++ b/Test/Emit/MutationCheckTest.lean
@@ -61,10 +61,18 @@ def testMutationInTry : IO Unit := expectCode
 def testMutationInThrowsFn : IO Unit := expectCode
   "/** @throws RangeError */\nfunction f(x: number): number { let n = 0; n = x; if (x === 0) { throw new RangeError(\"z\"); } return n; }" 7
 
--- Eligible function-local mutation: still TH0001 until do-mode emission
--- lands (flipped to expectNoCode in the do-mode task).
-def testEligibleStillTH1ForNow : IO Unit := expectCode
+-- Eligible function-local plain `=`: in subset since do-mode emission
+def testEligiblePlainAssignAllowed : IO Unit := expectNoCode
   "function f(): number { let n = 0; n = 1; return n; }" 1
+-- Compound/update forms flip in their own task; still TH0001 for now
+def testEligibleCompoundStillTH1 : IO Unit := expectCode
+  "function f(): number { let n = 0; n += 1; return n; }" 1
+def testEligibleUpdateStillTH1 : IO Unit := expectCode
+  "function f(): number { let n = 0; n++; return n; }" 1
+-- Arrow bodies don't lower through emitFuncDecl: their own-local mutation
+-- stays TH0001 in v1 even though the eligibility analysis would allow it
+def testArrowOwnLocalStillTH1 : IO Unit := expectCode
+  "const g = (): number => { let n = 0; n = 1; return n; };" 1
 
 -- Still-rejected forms keep TH0001
 def testUninitializedLet : IO Unit := expectCode
@@ -86,6 +94,9 @@ def testLogicalAssignStaysTH1 : IO Unit := expectCode
 #eval testExprPositionUpdate
 #eval testMutationInTry
 #eval testMutationInThrowsFn
-#eval testEligibleStillTH1ForNow
+#eval testEligiblePlainAssignAllowed
+#eval testEligibleCompoundStillTH1
+#eval testEligibleUpdateStillTH1
+#eval testArrowOwnLocalStillTH1
 #eval testUninitializedLet
 #eval testLogicalAssignStaysTH1

--- a/Test/Emit/MutationCheckTest.lean
+++ b/Test/Emit/MutationCheckTest.lean
@@ -61,14 +61,18 @@ def testMutationInTry : IO Unit := expectCode
 def testMutationInThrowsFn : IO Unit := expectCode
   "/** @throws RangeError */\nfunction f(x: number): number { let n = 0; n = x; if (x === 0) { throw new RangeError(\"z\"); } return n; }" 7
 
--- Eligible function-local plain `=`: in subset since do-mode emission
+-- Eligible function-local mutation: in subset since do-mode emission
 def testEligiblePlainAssignAllowed : IO Unit := expectNoCode
   "function f(): number { let n = 0; n = 1; return n; }" 1
--- Compound/update forms flip in their own task; still TH0001 for now
-def testEligibleCompoundStillTH1 : IO Unit := expectCode
+def testEligibleCompoundAllowed : IO Unit := expectNoCode
   "function f(): number { let n = 0; n += 1; return n; }" 1
-def testEligibleUpdateStillTH1 : IO Unit := expectCode
+def testEligibleUpdateAllowed : IO Unit := expectNoCode
   "function f(): number { let n = 0; n++; return n; }" 1
+-- `%=` and bitwise compounds stay TH0001 until their runtime lowering lands
+def testModAssignStillTH1 : IO Unit := expectCode
+  "function f(): number { let n = 7; n %= 3; return n; }" 1
+def testBitAndAssignStillTH1 : IO Unit := expectCode
+  "function f(): number { let n = 7; n &= 3; return n; }" 1
 -- Arrow bodies don't lower through emitFuncDecl: their own-local mutation
 -- stays TH0001 in v1 even though the eligibility analysis would allow it
 def testArrowOwnLocalStillTH1 : IO Unit := expectCode
@@ -95,8 +99,10 @@ def testLogicalAssignStaysTH1 : IO Unit := expectCode
 #eval testMutationInTry
 #eval testMutationInThrowsFn
 #eval testEligiblePlainAssignAllowed
-#eval testEligibleCompoundStillTH1
-#eval testEligibleUpdateStillTH1
+#eval testEligibleCompoundAllowed
+#eval testEligibleUpdateAllowed
+#eval testModAssignStillTH1
+#eval testBitAndAssignStillTH1
 #eval testArrowOwnLocalStillTH1
 #eval testUninitializedLet
 #eval testLogicalAssignStaysTH1

--- a/Test/Emit/MutationCheckTest.lean
+++ b/Test/Emit/MutationCheckTest.lean
@@ -68,10 +68,10 @@ def testEligibleCompoundAllowed : IO Unit := expectNoCode
   "function f(): number { let n = 0; n += 1; return n; }" 1
 def testEligibleUpdateAllowed : IO Unit := expectNoCode
   "function f(): number { let n = 0; n++; return n; }" 1
--- `%=` and bitwise compounds stay TH0001 until their runtime lowering lands
-def testModAssignStillTH1 : IO Unit := expectCode
+-- `%=` and the bitwise compounds lower through the JS-semantics helpers
+def testModAssignAllowed : IO Unit := expectNoCode
   "function f(): number { let n = 7; n %= 3; return n; }" 1
-def testBitAndAssignStillTH1 : IO Unit := expectCode
+def testBitAndAssignAllowed : IO Unit := expectNoCode
   "function f(): number { let n = 7; n &= 3; return n; }" 1
 -- Arrow bodies don't lower through emitFuncDecl: their own-local mutation
 -- stays TH0001 in v1 even though the eligibility analysis would allow it
@@ -101,8 +101,8 @@ def testLogicalAssignStaysTH1 : IO Unit := expectCode
 #eval testEligiblePlainAssignAllowed
 #eval testEligibleCompoundAllowed
 #eval testEligibleUpdateAllowed
-#eval testModAssignStillTH1
-#eval testBitAndAssignStillTH1
+#eval testModAssignAllowed
+#eval testBitAndAssignAllowed
 #eval testArrowOwnLocalStillTH1
 #eval testUninitializedLet
 #eval testLogicalAssignStaysTH1

--- a/Test/Emit/MutationCheckTest.lean
+++ b/Test/Emit/MutationCheckTest.lean
@@ -1,6 +1,8 @@
 /-
   Test/Emit/MutationCheckTest.lean
-  Verifies TH0001-TH0005 are emitted for mutation patterns.
+  Verifies the #24 mutation routing: TH0001 (still-rejected forms),
+  TH0002-TH0004 (member/method mutation), TH0005 (captured), TH0006
+  (expression position), TH0007 (throws/try context).
 -/
 import Thales.Emit.SubsetCheck
 import Thales.Parser.Native
@@ -19,27 +21,56 @@ def expectCode (src : String) (code : Nat) : IO Unit := do
       let formatted := (diags.map (·.format "test.ts")).toList
       throw (IO.userError s!"expected TH{code}, got: {formatted}")
 
+/-- Helper: assert that NO diagnostic with the given TH code fires. -/
+def expectNoCode (src : String) (code : Nat) : IO Unit := do
+  match parseTSSourceNative src with
+  | .error e => throw (IO.userError s!"parse error: {e}")
+  | .ok prog =>
+    let diags := subsetCheck prog
+    if diags.any (·.thalesCode? = some code) then
+      let formatted := (diags.map (·.format "test.ts")).toList
+      throw (IO.userError s!"expected no TH{code}, got: {formatted}")
+
+-- Module-level mutation: always TH0001
 def testReassignment : IO Unit := expectCode "let x = 0; x = 1;" 1
 def testCompoundAssignment : IO Unit := expectCode "let x = 0; x += 1;" 1
 def testIncrement : IO Unit := expectCode "let x = 0; x++;" 1
 def testDecrement : IO Unit := expectCode "let x = 0; --x;" 1
+
+-- Member/method mutation: unchanged
 def testArrayIndexWrite : IO Unit := expectCode "const arr = [1]; arr[0] = 2;" 2
 def testPropertyWrite : IO Unit := expectCode "const o = {x: 1}; o.x = 2;" 3
 def testPushMethodCall : IO Unit := expectCode "const arr = [1]; arr.push(2);" 4
 def testSortMethodCall : IO Unit := expectCode "const arr = [1]; arr.sort();" 4
 
-/-- Closure capture: outer let, inner arrow reassigns it.
-    For v1, treat this as TH0001 (reassignment detection fires inside the closure body);
-    if the implementation specifically detects capture, TH0005 is also acceptable. -/
-def testCapturedWrite : IO Unit := do
-  let src := "let counter = 0; const bump = () => { counter = counter + 1; };"
-  match parseTSSourceNative src with
-  | .error e => throw (IO.userError s!"parse error: {e}")
-  | .ok prog =>
-    let diags := subsetCheck prog
-    -- Accept either TH0001 or TH0005; the spirit is "mutation inside a closure is caught".
-    unless diags.any (fun d => d.thalesCode? = some 1 || d.thalesCode? = some 5) do
-      throw (IO.userError s!"expected TH0001 or TH0005; got {(diags.map (·.format "")).toList}")
+-- Captured mutation: strictly TH0005 now
+def testCapturedWrite : IO Unit := expectCode
+  "let counter = 0; const bump = () => { counter = counter + 1; };" 5
+def testCapturedReadBlocksFn : IO Unit := expectCode
+  "function f(): number { let n = 0; const g = () => n; n = 1; return g(); }" 5
+
+-- Expression-position assignment/update: TH0006
+def testExprPositionAssign : IO Unit := expectCode
+  "function f(): number { let n = 0; const y = (n = 1); return y; }" 6
+def testExprPositionUpdate : IO Unit := expectCode
+  "function f(): number { let n = 0; return n++; }" 6
+
+-- Mutation under try/catch or @throws: TH0007
+def testMutationInTry : IO Unit := expectCode
+  "function f(x: number): number { let n = 0; try { n = 1; } catch (e) { return 0; } return n; }" 7
+def testMutationInThrowsFn : IO Unit := expectCode
+  "/** @throws RangeError */\nfunction f(x: number): number { let n = 0; n = x; if (x === 0) { throw new RangeError(\"z\"); } return n; }" 7
+
+-- Eligible function-local mutation: still TH0001 until do-mode emission
+-- lands (flipped to expectNoCode in the do-mode task).
+def testEligibleStillTH1ForNow : IO Unit := expectCode
+  "function f(): number { let n = 0; n = 1; return n; }" 1
+
+-- Still-rejected forms keep TH0001
+def testUninitializedLet : IO Unit := expectCode
+  "function f(): number { let n: number; n = 1; return n; }" 1
+def testLogicalAssignStaysTH1 : IO Unit := expectCode
+  "function f(x: boolean): boolean { let b = x; b &&= x; return b; }" 1
 
 #eval testReassignment
 #eval testCompoundAssignment
@@ -50,3 +81,11 @@ def testCapturedWrite : IO Unit := do
 #eval testPushMethodCall
 #eval testSortMethodCall
 #eval testCapturedWrite
+#eval testCapturedReadBlocksFn
+#eval testExprPositionAssign
+#eval testExprPositionUpdate
+#eval testMutationInTry
+#eval testMutationInThrowsFn
+#eval testEligibleStillTH1ForNow
+#eval testUninitializedLet
+#eval testLogicalAssignStaysTH1

--- a/Test/Runtime/JsNumericOpsTest.lean
+++ b/Test/Runtime/JsNumericOpsTest.lean
@@ -1,0 +1,62 @@
+/-
+  Test/Runtime/JsNumericOpsTest.lean
+  Pins the JS-semantics numeric helpers (#32, needed by #24's compound
+  assignment): ES ToInt32/ToUint32, the bitwise/shift family, and `%`.
+  Every expected value below is Node's output for the same expression.
+-/
+import Thales.TS.Runtime
+
+open Thales.TS
+
+private def expectFloat (label : String) (got expected : Float) : IO Unit := do
+  -- compare via bit-faithful display to catch -0 vs 0 and NaN
+  unless toString got == toString expected do
+    throw (IO.userError s!"{label}: got {got}, expected {expected}")
+
+private def expectNat (label : String) (got expected : Nat) : IO Unit := do
+  unless got == expected do
+    throw (IO.userError s!"{label}: got {got}, expected {expected}")
+
+private def expectInt (label : String) (got expected : Int) : IO Unit := do
+  unless got == expected do
+    throw (IO.userError s!"{label}: got {got}, expected {expected}")
+
+-- ToInt32 / ToUint32 edges
+def tConv : IO Unit := do
+  expectInt "toInt32 NaN" (toInt32 (0.0 / 0.0)) 0
+  expectInt "toInt32 Inf" (toInt32 (1.0 / 0.0)) 0
+  expectInt "toInt32 5.7" (toInt32 5.7) 5
+  expectInt "toInt32 -5.7" (toInt32 (-5.7)) (-5)
+  expectInt "toInt32 2^32+1" (toInt32 4294967297.0) 1
+  expectInt "toInt32 2^31" (toInt32 2147483648.0) (-2147483648)
+  expectNat "toUint32 -1" (toUint32 (-1.0)) 4294967295
+  expectNat "toUint32 -16" (toUint32 (-16.0)) 4294967280
+  expectNat "toUint32 2^85" (toUint32 38685626227668133590597632.0) 0
+
+-- Node: 1 7 6 16 -4 15 1
+def tBitwise : IO Unit := do
+  expectFloat "5&3" (jsBitAnd 5.0 3.0) 1.0
+  expectFloat "5|3" (jsBitOr 5.0 3.0) 7.0
+  expectFloat "5^3" (jsBitXor 5.0 3.0) 6.0
+  expectFloat "1<<4" (jsShl 1.0 4.0) 16.0
+  expectFloat "-16>>2" (jsShr (-16.0) 2.0) (-4.0)
+  expectFloat "-16>>>28" (jsUShr (-16.0) 28.0) 15.0
+  expectFloat "5.7&3" (jsBitAnd 5.7 3.0) 1.0
+  -- shift count masks to 5 bits: 1 << 33 === 2
+  expectFloat "1<<33" (jsShl 1.0 33.0) 2.0
+  -- -1 >>> 0 === 4294967295
+  expectFloat "-1>>>0" (jsUShr (-1.0) 0.0) 4294967295.0
+
+-- Node: 1 -1 1.5 NaN-cases
+def tMod : IO Unit := do
+  expectFloat "7%3" (jsMod 7.0 3.0) 1.0
+  expectFloat "-7%3" (jsMod (-7.0) 3.0) (-1.0)
+  expectFloat "5.5%2" (jsMod 5.5 2.0) 1.5
+  expectFloat "7%-3" (jsMod 7.0 (-3.0)) 1.0
+  unless (jsMod 7.0 0.0).isNaN do throw (IO.userError "7%0 not NaN")
+  unless (jsMod (1.0 / 0.0) 3.0).isNaN do throw (IO.userError "Inf%3 not NaN")
+  expectFloat "7%Inf" (jsMod 7.0 (1.0 / 0.0)) 7.0
+
+#eval tConv
+#eval tBitwise
+#eval tMod

--- a/Test/TypeCheck/AssignmentFlowTest.lean
+++ b/Test/TypeCheck/AssignmentFlowTest.lean
@@ -1,0 +1,72 @@
+/-
+  Test/TypeCheck/AssignmentFlowTest.lean
+  Pins #24's tsc-style assignment typing and flow updates. Every
+  expectation here was cross-checked against tsc 6.0 (--strict):
+    * assignment RHS checks against the DECLARED type (annotation or
+      widened initializer) → TS2322;
+    * compound `x OP= y` types as `x = x OP y` (so `s += 1` on string is
+      clean — string concatenation — and never a raw-RHS TS2322);
+    * after `x = e`, the flow type is the widened RHS narrowed against
+      the declared type (so a nullable that was just assigned a string
+      is not "possibly null").
+-/
+import Thales.TypeCheck.Check
+import Thales.Parser.Native
+
+open Thales.TypeCheck
+open Thales.Parser
+
+private def diagsOf (src : String) : IO (Array Diagnostic) := do
+  match parseTSSourceNative src with
+  | .error e => throw (IO.userError s!"parse error: {e}")
+  | .ok prog => return typeCheck prog
+
+private def hasTS (d : Diagnostic) (code : Nat) : Bool :=
+  ((d.format "t.ts").splitOn s!"error TS{code}:").length > 1
+
+def expectTS (src : String) (code : Nat) : IO Unit := do
+  let diags ← diagsOf src
+  unless diags.any (hasTS · code) do
+    let formatted := (diags.map (·.format "t.ts")).toList
+    throw (IO.userError s!"expected TS{code}, got: {formatted}")
+
+def expectNoTS (src : String) (code : Nat) : IO Unit := do
+  let diags ← diagsOf src
+  if diags.any (hasTS · code) then
+    let formatted := (diags.map (·.format "t.ts")).toList
+    throw (IO.userError s!"expected no TS{code}, got: {formatted}")
+
+-- pin: annotated declared type already checks assignments (pre-#24 behavior)
+def t0 : IO Unit := expectTS
+  "function f(): number { let n: number = 0; n = \"x\"; return n; }" 2322
+-- widened-initializer declared type: `let n = 0` declares number
+def t1 : IO Unit := expectTS
+  "function f(): number { let n = 0; n = \"x\"; return n; }" 2322
+-- compound op types as `s = s + 1` (string concat) — tsc is clean here;
+-- a raw-RHS check would wrongly emit TS2322
+def t2 : IO Unit := expectNoTS
+  "function f(): string { let s = \"a\"; s += 1; return s; }" 2322
+-- `n *= \"x\"`: tsc emits TS2363 (arithmetic operand) which thales does not
+-- implement (pre-existing gap, see follow-ups); the desugar must at least
+-- not mis-report it as TS2322
+def t3 : IO Unit := expectNoTS
+  "function f(): number { let n = 2; n *= \"x\"; return n; }" 2322
+-- flow update: after `x = \"a\"`, x is string — tsc is clean; thales's
+-- possibly-null surrogate TS2339 must not fire
+def t4 : IO Unit := expectNoTS
+  "function f(x: string | null): number { x = \"a\"; return x.length; }" 2339
+-- ordinary numeric reassignment stays clean
+def t5 : IO Unit := expectNoTS
+  "function f(): number { let n = 0; n = n + 1; return n; }" 2322
+-- the widened declared type is the BASE type, not the literal: `n = 5`
+-- after `let n = 0` is fine
+def t6 : IO Unit := expectNoTS
+  "function f(): number { let n = 0; n = 5; return n; }" 2322
+
+#eval t0
+#eval t1
+#eval t2
+#eval t3
+#eval t4
+#eval t5
+#eval t6

--- a/Test/TypeCheck/AssignmentFlowTest.lean
+++ b/Test/TypeCheck/AssignmentFlowTest.lean
@@ -63,6 +63,29 @@ def t5 : IO Unit := expectNoTS
 def t6 : IO Unit := expectNoTS
   "function f(): number { let n = 0; n = 5; return n; }" 2322
 
+-- ── if/else joins (cross-checked against tsc --strict) ──
+
+-- both branches assign a string: join is string — tsc clean, no
+-- possibly-null surrogate TS2339
+def j1 : IO Unit := expectNoTS
+  "function f(c: boolean, x: string | null): number { if (c) { x = \"a\"; } else { x = \"b\"; } return x.length; }" 2339
+-- early-return branch contributes nothing: continuation gets the negated
+-- guard (x non-null) — tsc clean
+def j2 : IO Unit := expectNoTS
+  "function f(x: string | null): number { if (x === null) { return 0; } return x.length; }" 2339
+-- assignment in a nested branch invalidates narrowing: after the inner
+-- if, x is string|null again — tsc flags x.length (TS18047); thales's
+-- surrogate is TS2339, which must now fire
+def j3 : IO Unit := expectTS
+  "function f(c: boolean, x: string | null): number { if (x !== null) { if (c) { x = null; } return x.length; } return 0; }" 2339
+-- no-else assignment joins with the fall-through path: x stays possibly
+-- null after `if (c) { x = \"a\"; }` — tsc flags x.length
+def j4 : IO Unit := expectTS
+  "function f(c: boolean, x: string | null): number { if (c) { x = \"a\"; } return x.length; }" 2339
+-- assignment before the if, then both paths keep it: still clean
+def j5 : IO Unit := expectNoTS
+  "function f(c: boolean, x: string | null): number { x = \"a\"; if (c) { x = \"b\"; } return x.length; }" 2339
+
 #eval t0
 #eval t1
 #eval t2
@@ -70,3 +93,8 @@ def t6 : IO Unit := expectNoTS
 #eval t4
 #eval t5
 #eval t6
+#eval j1
+#eval j2
+#eval j3
+#eval j4
+#eval j5

--- a/Thales/AST.lean
+++ b/Thales/AST.lean
@@ -136,6 +136,29 @@ inductive AssignmentOperator where
   | nullishAssign     -- ??=
   deriving Repr, Inhabited
 
+/-- Map a compound assignment operator to its underlying binary operator
+    (`x OP= y` desugars to `x = x OP y`). `none` for plain `=` and the
+    (deferred) logical assignment family. -/
+def AssignmentOperator.compoundToBinary : AssignmentOperator → Option BinaryOperator
+  | .addAssign  => some .add
+  | .subAssign  => some .sub
+  | .mulAssign  => some .mul
+  | .divAssign  => some .div
+  | .modAssign  => some .mod
+  | .expAssign  => some .exp
+  | .shlAssign  => some .shl
+  | .shrAssign  => some .shr
+  | .ushrAssign => some .ushr
+  | .orAssign   => some .bitor
+  | .xorAssign  => some .bitxor
+  | .andAssign  => some .bitand
+  | _ => none
+
+/-- The short-circuit logical assignment operators (`&&=`, `||=`, `??=`). -/
+def AssignmentOperator.isLogical : AssignmentOperator → Bool
+  | .orLogicalAssign | .andLogicalAssign | .nullishAssign => true
+  | _ => false
+
 /-- Template literal element (string part between interpolations) -/
 structure TemplateElement where
   value : String  -- cooked value (escape sequences resolved)

--- a/Thales/Emit/EscapeAnalysis.lean
+++ b/Thales/Emit/EscapeAnalysis.lean
@@ -35,6 +35,11 @@ structure MutationInfo where
   params : Std.HashSet String := {}
   /-- Vars null-tested or refinement-predicate-tested in a condition. -/
   narrowTested : Std.HashSet String := {}
+  /-- The own body contains a `switch` that do-mode cannot lower: an arm
+      that does not return on every path (`break`-style fall-through would
+      need post-switch join emission) or a `default` arm. Mutation in such
+      a function stays rejected. -/
+  hasUnloweredSwitchShape : Bool := false
 
 def MutationInfo.eligible (info : MutationInfo) (name : String) : Bool :=
   (info.params.contains name || info.initializedLets.contains name)
@@ -112,6 +117,18 @@ partial def identsStmt : Statement → List String
   | .functionDecl _ _ _ b _ _ => identsStmt b
   | _ => []
 end
+
+/-- Whether a statement list returns or throws on every control path.
+    Conservative (false when unsure); the do-mode twin of the checker's
+    `alwaysReturns`. -/
+partial def stmtsReturn (stmts : List Statement) : Bool :=
+  stmts.any fun s =>
+    match s with
+    | .returnStmt _ _ => true
+    | .throwStmt _ _ => true
+    | .blockStmt _ ss => stmtsReturn ss
+    | .ifStmt _ _ c (some a) => stmtsReturn [c] && stmtsReturn [a]
+    | _ => false
 
 /-- Vars that a condition expression null-tests or predicate-tests. -/
 private partial def narrowTestVars : Expression → List String
@@ -202,6 +219,8 @@ partial def walkStmt (acc : MutationInfo) : Statement → MutationInfo
         | .inr vd => walkStmt acc (.variableDecl vd)
       walkStmt (walkExpr acc r) b
   | .switchStmt _ d cases =>
+      let unlowered := cases.any fun (.mk _ t ss) => t.isNone || !stmtsReturn ss
+      let acc := if unlowered then { acc with hasUnloweredSwitchShape := true } else acc
       cases.foldl (fun a (.mk _ t ss) =>
         let a := match t with | some e => walkExpr a e | none => a
         ss.foldl walkStmt a) (walkExpr acc d)

--- a/Thales/Emit/EscapeAnalysis.lean
+++ b/Thales/Emit/EscapeAnalysis.lean
@@ -1,0 +1,224 @@
+/-
+  Thales/Emit/EscapeAnalysis.lean
+  Per-function mutation-eligibility analysis (issue #24).
+  A binding is mutable-eligible iff every reference to it (read or write)
+  occurs in the declaring function's own body — no reference from any
+  nested function/arrow. Conservative on two axes, both safe (they only
+  reject, never accept):
+    * any identifier occurrence inside a nested function counts as a
+      capture, even if the inner function shadows the name;
+    * a mutated variable that is null-tested (`x === null`) or appears as
+      the sole argument of a call in an `if`/ternary condition (the
+      refinement-predicate shape) is ineligible — assignment would
+      invalidate narrowing evidence the emitter bakes into `dite`/`match`.
+-/
+import Thales.AST
+import Std.Data.HashSet
+
+namespace Thales.Emit.EscapeAnalysis
+
+open Thales.AST
+
+structure MutationInfo where
+  /-- Identifier targets of assignment/update anywhere in the own body. -/
+  mutated : Std.HashSet String := {}
+  /-- Identifiers occurring anywhere inside a nested function/arrow. -/
+  capturedRefs : Std.HashSet String := {}
+  /-- `let`/`var` names declared WITH an initializer in the own body. -/
+  initializedLets : Std.HashSet String := {}
+  /-- `let`/`var` names declared WITHOUT an initializer. -/
+  uninitializedLets : Std.HashSet String := {}
+  /-- `const` names declared in the own body (mutation of these is tsc's
+      TS2588 territory — no TH code on top). -/
+  consts : Std.HashSet String := {}
+  /-- Parameter names. -/
+  params : Std.HashSet String := {}
+  /-- Vars null-tested or refinement-predicate-tested in a condition. -/
+  narrowTested : Std.HashSet String := {}
+
+def MutationInfo.eligible (info : MutationInfo) (name : String) : Bool :=
+  (info.params.contains name || info.initializedLets.contains name)
+    && !info.capturedRefs.contains name
+    && !info.narrowTested.contains name
+
+private def insertAll (s : Std.HashSet String) (xs : List String) : Std.HashSet String :=
+  xs.foldl (·.insert ·) s
+
+/- All identifiers in an expression/statement, including inside nested
+   function bodies. Used to account a nested function's references
+   wholesale to `capturedRefs`. -/
+mutual
+partial def identsExpr : Expression → List String
+  | .identifier _ n => [n]
+  | .literal _ _ _ | .thisExpr _ | .super_ _ | .metaProperty _ _ _
+  | .patternExpr _ _ => []
+  | .arrayExpr _ els =>
+      els.flatMap fun | some e => identsExpr e | none => []
+  | .objectExpr _ props => props.flatMap fun
+      | .regular _ k v _ _ _ => identsExpr k ++ identsExpr v
+      | .spread _ a => identsExpr a
+  | .functionExpr _ _ _ body _ _ => identsStmt body
+  | .arrowFunctionExpr _ _ body _ _ _ =>
+      match body with | .inl e => identsExpr e | .inr s => identsStmt s
+  | .unaryExpr _ _ _ a | .updateExpr _ _ a _ | .spreadElement _ a
+  | .awaitExpr _ a | .chainExpr _ a => identsExpr a
+  | .binaryExpr _ _ l r | .assignmentExpr _ _ l r | .logicalExpr _ _ l r =>
+      identsExpr l ++ identsExpr r
+  | .memberExpr _ o p _ _ => identsExpr o ++ identsExpr p
+  | .privateMemberExpr _ o _ => identsExpr o
+  | .conditionalExpr _ t c a => identsExpr t ++ identsExpr c ++ identsExpr a
+  | .callExpr _ f args _ | .newExpr _ f args =>
+      identsExpr f ++ args.flatMap identsExpr
+  | .sequenceExpr _ es => es.flatMap identsExpr
+  | .templateLiteral _ _ es => es.flatMap identsExpr
+  | .taggedTemplate _ t q => identsExpr t ++ identsExpr q
+  | .classExpr _ _ _ _ => []   -- classes are TH0030-rejected; don't dig
+  | .yieldExpr _ a _ => match a with | some e => identsExpr e | none => []
+
+partial def identsStmt : Statement → List String
+  | .exprStmt _ e | .throwStmt _ e => identsExpr e
+  | .blockStmt _ b => b.flatMap identsStmt
+  | .ifStmt _ t c a =>
+      identsExpr t ++ identsStmt c
+        ++ (match a with | some s => identsStmt s | none => [])
+  | .returnStmt _ a => match a with | some e => identsExpr e | none => []
+  | .variableDecl (.mk _ decls _) =>
+      decls.flatMap fun (.mk _ _ init _) =>
+        match init with | some e => identsExpr e | none => []
+  | .whileStmt _ t b => identsExpr t ++ identsStmt b
+  | .doWhileStmt _ b t => identsStmt b ++ identsExpr t
+  | .forStmt _ init t u b =>
+      (match init with
+        | some (.inl e) => identsExpr e
+        | some (.inr (.mk _ decls _)) =>
+            decls.flatMap fun (.mk _ _ i _) =>
+              match i with | some e => identsExpr e | none => []
+        | none => [])
+        ++ (match t with | some e => identsExpr e | none => [])
+        ++ (match u with | some e => identsExpr e | none => [])
+        ++ identsStmt b
+  | .forInStmt _ left r b | .forOfStmt _ left r b _ =>
+      (match left with | .inl e => identsExpr e | .inr _ => [])
+        ++ identsExpr r ++ identsStmt b
+  | .switchStmt _ d cases =>
+      identsExpr d ++ cases.flatMap (fun (.mk _ t ss) =>
+        (match t with | some e => identsExpr e | none => [])
+          ++ ss.flatMap identsStmt)
+  | .tryStmt _ b h f =>
+      identsStmt b
+        ++ (match h with | some (.mk _ _ hb _) => identsStmt hb | none => [])
+        ++ (match f with | some s => identsStmt s | none => [])
+  | .labeledStmt _ _ b | .withStmt _ _ b => identsStmt b
+  | .functionDecl _ _ _ b _ _ => identsStmt b
+  | _ => []
+end
+
+/-- Vars that a condition expression null-tests or predicate-tests. -/
+private partial def narrowTestVars : Expression → List String
+  | .binaryExpr _ op l r =>
+      let isNullLit : Expression → Bool
+        | .literal _ .null _ => true
+        | _ => false
+      match op with
+      | .seq | .sneq | .eq | .neq =>
+        match l, r with
+        | .identifier _ n, e => if isNullLit e then [n] else []
+        | e, .identifier _ n => if isNullLit e then [n] else []
+        | _, _ => []
+      | _ => []
+  | .callExpr _ _ [.identifier _ n] _ => [n]
+  | .unaryExpr _ .not _ a => narrowTestVars a
+  | .logicalExpr _ _ l r => narrowTestVars l ++ narrowTestVars r
+  | _ => []
+
+/- Walk the function's OWN body: nested functions are not descended into —
+   every identifier they mention lands in `capturedRefs` wholesale. -/
+mutual
+partial def walkExpr (acc : MutationInfo) : Expression → MutationInfo
+  | .assignmentExpr _ _ (.identifier _ n) r =>
+      walkExpr { acc with mutated := acc.mutated.insert n } r
+  | .assignmentExpr _ _ l r => walkExpr (walkExpr acc l) r
+  | .updateExpr _ _ (.identifier _ n) _ =>
+      { acc with mutated := acc.mutated.insert n }
+  | .updateExpr _ _ a _ => walkExpr acc a
+  | .functionExpr _ _ _ body _ _ =>
+      { acc with capturedRefs := insertAll acc.capturedRefs (identsStmt body) }
+  | .arrowFunctionExpr _ _ body _ _ _ =>
+      let ids := match body with | .inl e => identsExpr e | .inr s => identsStmt s
+      { acc with capturedRefs := insertAll acc.capturedRefs ids }
+  | .conditionalExpr _ t c a =>
+      let acc := { acc with narrowTested := insertAll acc.narrowTested (narrowTestVars t) }
+      walkExpr (walkExpr (walkExpr acc t) c) a
+  | .unaryExpr _ _ _ a | .spreadElement _ a | .awaitExpr _ a | .chainExpr _ a =>
+      walkExpr acc a
+  | .binaryExpr _ _ l r | .logicalExpr _ _ l r =>
+      walkExpr (walkExpr acc l) r
+  | .memberExpr _ o p _ _ => walkExpr (walkExpr acc o) p
+  | .privateMemberExpr _ o _ => walkExpr acc o
+  | .callExpr _ f args _ | .newExpr _ f args =>
+      args.foldl walkExpr (walkExpr acc f)
+  | .arrayExpr _ els =>
+      els.foldl (fun a oe => match oe with | some e => walkExpr a e | none => a) acc
+  | .objectExpr _ props =>
+      props.foldl (fun a p => match p with
+        | .regular _ k v _ _ _ => walkExpr (walkExpr a k) v
+        | .spread _ s => walkExpr a s) acc
+  | .sequenceExpr _ es | .templateLiteral _ _ es => es.foldl walkExpr acc
+  | .taggedTemplate _ t q => walkExpr (walkExpr acc t) q
+  | .yieldExpr _ a _ => match a with | some e => walkExpr acc e | none => acc
+  | _ => acc
+
+partial def walkStmt (acc : MutationInfo) : Statement → MutationInfo
+  | .exprStmt _ e | .throwStmt _ e => walkExpr acc e
+  | .blockStmt _ b => b.foldl walkStmt acc
+  | .ifStmt _ t c a =>
+      let acc := { acc with narrowTested := insertAll acc.narrowTested (narrowTestVars t) }
+      let acc := walkStmt (walkExpr acc t) c
+      match a with | some s => walkStmt acc s | none => acc
+  | .returnStmt _ a => match a with | some e => walkExpr acc e | none => acc
+  | .variableDecl (.mk _ decls kind) =>
+      decls.foldl (fun a (.mk _ pat init _) =>
+        let a := match init with | some e => walkExpr a e | none => a
+        match pat with
+        | .identifier id =>
+          if kind == .const then { a with consts := a.consts.insert id.name }
+          else match init with
+            | some _ => { a with initializedLets := a.initializedLets.insert id.name }
+            | none => { a with uninitializedLets := a.uninitializedLets.insert id.name }
+        | _ => a) acc
+  | .whileStmt _ t b => walkStmt (walkExpr acc t) b
+  | .doWhileStmt _ b t => walkExpr (walkStmt acc b) t
+  | .forStmt _ init t u b =>
+      let acc := match init with
+        | some (.inl e) => walkExpr acc e
+        | some (.inr vd) => walkStmt acc (.variableDecl vd)
+        | none => acc
+      let acc := match t with | some e => walkExpr acc e | none => acc
+      let acc := match u with | some e => walkExpr acc e | none => acc
+      walkStmt acc b
+  | .forInStmt _ left r b | .forOfStmt _ left r b _ =>
+      let acc := match left with
+        | .inl e => walkExpr acc e
+        | .inr vd => walkStmt acc (.variableDecl vd)
+      walkStmt (walkExpr acc r) b
+  | .switchStmt _ d cases =>
+      cases.foldl (fun a (.mk _ t ss) =>
+        let a := match t with | some e => walkExpr a e | none => a
+        ss.foldl walkStmt a) (walkExpr acc d)
+  | .tryStmt _ b h f =>
+      let acc := walkStmt acc b
+      let acc := match h with | some (.mk _ _ hb _) => walkStmt acc hb | none => acc
+      match f with | some s => walkStmt acc s | none => acc
+  | .labeledStmt _ _ b | .withStmt _ _ b => walkStmt acc b
+  | .functionDecl _ _ _ body _ _ =>
+      -- nested function declaration: everything it references is a capture
+      { acc with capturedRefs := insertAll acc.capturedRefs (identsStmt body) }
+  | _ => acc
+end
+
+/-- Analyze one function: parameter names + body statement. -/
+def analyze (paramNames : List String) (body : Statement) : MutationInfo :=
+  let acc : MutationInfo := { params := insertAll {} paramNames }
+  walkStmt acc body
+
+end Thales.Emit.EscapeAnalysis

--- a/Thales/Emit/EscapeAnalysis.lean
+++ b/Thales/Emit/EscapeAnalysis.lean
@@ -3,14 +3,19 @@
   Per-function mutation-eligibility analysis (issue #24).
   A binding is mutable-eligible iff every reference to it (read or write)
   occurs in the declaring function's own body — no reference from any
-  nested function/arrow. Conservative on two axes, both safe (they only
+  nested function/arrow. Conservative on several axes, all safe (they only
   reject, never accept):
     * any identifier occurrence inside a nested function counts as a
       capture, even if the inner function shadows the name;
-    * a mutated variable that is null-tested (`x === null`) or appears as
-      the sole argument of a call in an `if`/ternary condition (the
+    * a mutated variable that is null/undefined-tested or appears as the
+      sole argument of a call in an `if`/ternary condition (the
       refinement-predicate shape) is ineligible — assignment would
       invalidate narrowing evidence the emitter bakes into `dite`/`match`.
+  Beyond per-variable eligibility, `doModeLowerable` is the function-level
+  gate (#40/#41): bodies containing a `try`/`catch`, a switch shape the
+  do-mode emitter cannot lower, or a read of a narrow-tested variable
+  outside its test positions stay on the pure emission path entirely, so
+  their mutation is rejected wholesale.
 -/
 import Thales.AST
 import Std.Data.HashSet
@@ -33,18 +38,46 @@ structure MutationInfo where
   consts : Std.HashSet String := {}
   /-- Parameter names. -/
   params : Std.HashSet String := {}
-  /-- Vars null-tested or refinement-predicate-tested in a condition. -/
+  /-- Vars null/undefined-tested or refinement-predicate-tested in a
+      condition. -/
   narrowTested : Std.HashSet String := {}
+  /-- Identifiers referenced in the own body outside narrow-test positions:
+      the subject occurrence of `x === null` / `pred(x)` does not count,
+      every other occurrence does. Mutation targets are not references. -/
+  nonTestRefs : Std.HashSet String := {}
   /-- The own body contains a `switch` that do-mode cannot lower: an arm
       that does not return on every path (`break`-style fall-through would
-      need post-switch join emission) or a `default` arm. Mutation in such
-      a function stays rejected. -/
+      need post-switch join emission), a `default` arm, or a scrutinee that
+      is not the `ident.field` shape of a discriminated-union dispatch.
+      Mutation in such a function stays rejected. -/
   hasUnloweredSwitchShape : Bool := false
+  /-- The own body contains a `try`/`catch` (#41): the exception path emits
+      pure Except match-chains, which do-mode cannot thread through, so
+      mutation in such a function stays rejected. -/
+  hasTryShape : Bool := false
 
 def MutationInfo.eligible (info : MutationInfo) (name : String) : Bool :=
   (info.params.contains name || info.initializedLets.contains name)
     && !info.capturedRefs.contains name
     && !info.narrowTested.contains name
+
+/-- A narrow-tested variable is referenced outside its test positions —
+    in the own body or from a nested function (#40). The pure path bakes
+    such narrowing into `dite`/`match` rebinding; do-mode's plain `if`
+    carries no evidence, so the read would elaborate at the unnarrowed
+    type. Such a function must stay on the pure emission path. -/
+def MutationInfo.narrowingDependentBody (info : MutationInfo) : Bool :=
+  info.narrowTested.toList.any fun n =>
+    info.nonTestRefs.contains n || info.capturedRefs.contains n
+
+/-- Function-level do-mode admissibility (#40/#41): the single predicate
+    that BOTH SubsetCheck's mutation routing and `emitFuncDecl`'s do-mode
+    entry consult — they must never disagree, or accepted programs get
+    miscompiled. False when the body contains a shape `emitBodyDo` cannot
+    lower. -/
+def MutationInfo.doModeLowerable (info : MutationInfo) : Bool :=
+  !info.hasUnloweredSwitchShape && !info.hasTryShape
+    && !info.narrowingDependentBody
 
 private def insertAll (s : Std.HashSet String) (xs : List String) : Std.HashSet String :=
   xs.foldl (·.insert ·) s
@@ -130,28 +163,19 @@ partial def stmtsReturn (stmts : List Statement) : Bool :=
     | .ifStmt _ _ c (some a) => stmtsReturn [c] && stmtsReturn [a]
     | _ => false
 
-/-- Vars that a condition expression null-tests or predicate-tests. -/
-private partial def narrowTestVars : Expression → List String
-  | .binaryExpr _ op l r =>
-      let isNullLit : Expression → Bool
-        | .literal _ .null _ => true
-        | _ => false
-      match op with
-      | .seq | .sneq | .eq | .neq =>
-        match l, r with
-        | .identifier _ n, e => if isNullLit e then [n] else []
-        | e, .identifier _ n => if isNullLit e then [n] else []
-        | _, _ => []
-      | _ => []
-  | .callExpr _ _ [.identifier _ n] _ => [n]
-  | .unaryExpr _ .not _ a => narrowTestVars a
-  | .logicalExpr _ _ l r => narrowTestVars l ++ narrowTestVars r
-  | _ => []
+/-- A nullish test operand: the `null` literal or the `undefined`
+    identifier (`undefined` is an identifier in the AST, not a literal). -/
+private def isNullishOperand : Expression → Bool
+  | .literal _ .null _ => true
+  | .identifier _ "undefined" => true
+  | _ => false
 
 /- Walk the function's OWN body: nested functions are not descended into —
    every identifier they mention lands in `capturedRefs` wholesale. -/
 mutual
 partial def walkExpr (acc : MutationInfo) : Expression → MutationInfo
+  | .identifier _ n =>
+      { acc with nonTestRefs := acc.nonTestRefs.insert n }
   | .assignmentExpr _ _ (.identifier _ n) r =>
       walkExpr { acc with mutated := acc.mutated.insert n } r
   | .assignmentExpr _ _ l r => walkExpr (walkExpr acc l) r
@@ -164,8 +188,7 @@ partial def walkExpr (acc : MutationInfo) : Expression → MutationInfo
       let ids := match body with | .inl e => identsExpr e | .inr s => identsStmt s
       { acc with capturedRefs := insertAll acc.capturedRefs ids }
   | .conditionalExpr _ t c a =>
-      let acc := { acc with narrowTested := insertAll acc.narrowTested (narrowTestVars t) }
-      walkExpr (walkExpr (walkExpr acc t) c) a
+      walkExpr (walkExpr (walkCond acc t) c) a
   | .unaryExpr _ _ _ a | .spreadElement _ a | .awaitExpr _ a | .chainExpr _ a =>
       walkExpr acc a
   | .binaryExpr _ _ l r | .logicalExpr _ _ l r =>
@@ -185,12 +208,40 @@ partial def walkExpr (acc : MutationInfo) : Expression → MutationInfo
   | .yieldExpr _ a _ => match a with | some e => walkExpr acc e | none => acc
   | _ => acc
 
+/-- Walk an `if`/ternary condition. The narrow-test shapes — nullish
+    equality (`===`/`!==`/`==`/`!=` against `null`/`undefined`, either
+    operand order) and the single-ident-argument predicate call — mark
+    their subject in `narrowTested` WITHOUT recording that occurrence in
+    `nonTestRefs`; every other subtree walks normally. Must stay a
+    superset of the shapes the emitter bakes narrowing for
+    (`nullCheckVar`, `detectRefinementPredicate`). -/
+partial def walkCond (acc : MutationInfo) : Expression → MutationInfo
+  | e@(.binaryExpr _ op l r) =>
+      let nullishEqOp := match op with
+        | .seq | .sneq | .eq | .neq => true
+        | _ => false
+      let subjectOf : Expression → Expression → Option String := fun a b =>
+        match a with
+        | .identifier _ n =>
+            if isNullishOperand b && n != "undefined" then some n else none
+        | _ => none
+      if nullishEqOp then
+        match subjectOf l r <|> subjectOf r l with
+        | some n => { acc with narrowTested := acc.narrowTested.insert n }
+        | none => walkExpr acc e
+      else
+        walkExpr acc e
+  | .callExpr _ f [.identifier _ n] _ =>
+      walkExpr { acc with narrowTested := acc.narrowTested.insert n } f
+  | .unaryExpr _ .not _ a => walkCond acc a
+  | .logicalExpr _ _ l r => walkCond (walkCond acc l) r
+  | e => walkExpr acc e
+
 partial def walkStmt (acc : MutationInfo) : Statement → MutationInfo
   | .exprStmt _ e | .throwStmt _ e => walkExpr acc e
   | .blockStmt _ b => b.foldl walkStmt acc
   | .ifStmt _ t c a =>
-      let acc := { acc with narrowTested := insertAll acc.narrowTested (narrowTestVars t) }
-      let acc := walkStmt (walkExpr acc t) c
+      let acc := walkStmt (walkCond acc t) c
       match a with | some s => walkStmt acc s | none => acc
   | .returnStmt _ a => match a with | some e => walkExpr acc e | none => acc
   | .variableDecl (.mk _ decls kind) =>
@@ -219,13 +270,22 @@ partial def walkStmt (acc : MutationInfo) : Statement → MutationInfo
         | .inr vd => walkStmt acc (.variableDecl vd)
       walkStmt (walkExpr acc r) b
   | .switchStmt _ d cases =>
-      let unlowered := cases.any fun (.mk _ t ss) => t.isNone || !stmtsReturn ss
+      -- Lowerable switch shape: a discriminated-union dispatch
+      -- (`switch (ident.field)`, non-computed) where every arm returns and
+      -- there is no `default`. Anything else — including a plain-identifier
+      -- scrutinee, which the emitter has no lowering for — keeps the
+      -- function out of do-mode.
+      let discriminatedShape := match d with
+        | .memberExpr _ (.identifier _ _) (.identifier _ _) false _ => true
+        | _ => false
+      let unlowered := !discriminatedShape
+        || cases.any fun (.mk _ t ss) => t.isNone || !stmtsReturn ss
       let acc := if unlowered then { acc with hasUnloweredSwitchShape := true } else acc
       cases.foldl (fun a (.mk _ t ss) =>
         let a := match t with | some e => walkExpr a e | none => a
         ss.foldl walkStmt a) (walkExpr acc d)
   | .tryStmt _ b h f =>
-      let acc := walkStmt acc b
+      let acc := walkStmt { acc with hasTryShape := true } b
       let acc := match h with | some (.mk _ _ hb _) => walkStmt acc hb | none => acc
       match f with | some s => walkStmt acc s | none => acc
   | .labeledStmt _ _ b | .withStmt _ _ b => walkStmt acc b

--- a/Thales/Emit/Lean.lean
+++ b/Thales/Emit/Lean.lean
@@ -557,6 +557,14 @@ private def refinementKindPredicate : RefinementKind → String
   | .byte => "isByte"
   | .bit => "isBit"
 
+/-- Loud do-mode failure marker: renders as invalid Lean (same pattern as
+    the pure path's `(unsupported: throw without @throws)`), so a statement
+    `emitBodyDo` cannot lower breaks the build instead of being silently
+    dropped. `SubsetCheck`'s `doModeLowerable` gate should make this
+    unreachable; reaching it means the two have drifted. -/
+private def unloweredDoStmt : List LDoStmt :=
+  [.ret (.var "(unsupported: statement not lowerable in do-mode)")]
+
 mutual
 
 /-- Translate a JS `Expression` to a Lean `LExpr`. Unsupported constructs
@@ -1006,9 +1014,13 @@ partial def emitBody : List Statement → LExpr :=
 /-- #24 do-mode lowering: the body of a function with an eligible
     statement-position mutation, as a list of `Id.run do` statements.
     Only shapes SubsetCheck admits into do-mode arrive here — straight-line
-    mutation, declarations, and `return`; anything else was rejected
-    upstream (TH0001/TH0005/TH0006/TH0007/TH0010 …) and the fall-through
-    arms simply skip. -/
+    mutation, declarations, `return`, `if`/`else`, and discriminated-union
+    switches; anything else was rejected upstream
+    (TH0001/TH0005/TH0006/TH0007/TH0010 …). A statement this function has
+    no lowering for renders the loud `(unsupported: …)` marker — invalid
+    Lean — rather than being dropped: silent divergence from the TS
+    behavior is the one failure mode the conformance harness can't catch
+    when the emitted file still compiles. -/
 partial def emitBodyDo (env : EmitEnv) (info : EscapeAnalysis.MutationInfo)
     : List Statement → List LDoStmt
   | .returnStmt _ (some e) :: _ =>
@@ -1058,7 +1070,11 @@ partial def emitBodyDo (env : EmitEnv) (info : EscapeAnalysis.MutationInfo)
   -- EscapeAnalysis guarantees every arm returns and there is no `default`
   -- (`hasUnloweredSwitchShape` keeps anything else out of do-mode), so
   -- `rest` after the switch is dead code and is dropped.
-  | .switchStmt _ discriminant cases :: rest =>
+  | .switchStmt _ discriminant cases :: _ =>
+      -- `hasUnloweredSwitchShape` guarantees the `ident.field` discriminant
+      -- shape with all-return arms and no `default`, so `rest` is dead code
+      -- and a fallback that DROPS the switch is never correct — the
+      -- non-discriminated cases render the loud marker instead.
       match discriminant with
       | .memberExpr _ (.identifier _ scrutName) (.identifier _ _fieldName) false _ =>
           (match env.bindingEnv.get? scrutName with
@@ -1081,15 +1097,19 @@ partial def emitBodyDo (env : EmitEnv) (info : EscapeAnalysis.MutationInfo)
                     if arms.length >= ctors.length then arms
                     else arms ++ [(.wildcard, [.ret (.var "unreachable!")])]
                   [.matchDo (.var scrutName) allArms]
-              | none => emitBodyDo env info rest)
-            | _ => emitBodyDo env info rest)
-          | none => emitBodyDo env info rest)
-      | _ => emitBodyDo env info rest
+              | none => unloweredDoStmt)
+            | _ => unloweredDoStmt)
+          | none => unloweredDoStmt)
+      | _ => unloweredDoStmt
   -- A list that ends without `return` is a branch falling through to the
   -- code after its `if` — emit nothing. The function-level trailing
   -- `return ()` (for void bodies) is appended by `emitFuncDecl`.
   | [] => []
-  | _ :: rest => emitBodyDo env info rest
+  -- Genuinely effect-free statements.
+  | .emptyStmt _ :: rest | .debuggerStmt _ :: rest => emitBodyDo env info rest
+  -- Anything else reaching here is a SubsetCheck/emitter disagreement
+  -- about do-mode lowerability — fail loudly (invalid Lean), never drop.
+  | _ :: _ => unloweredDoStmt
 
 /-- Declarator lowering inside do-mode: mutated names become `let mut`,
     everything else stays an immutable `let`. Mirrors `emitVarDecl`'s
@@ -1246,11 +1266,14 @@ def emitFuncDecl (aliasEnv : Std.HashMap String TSType) (name : String) (typePar
     | other           => [other]
   -- #24: a body with an eligible statement-position mutation lowers to
   -- `Id.run do` with `let mut`; everything else keeps the pure path
-  -- untouched. `@throws` functions never reach do-mode (TH0007 upstream).
+  -- untouched. `@throws` functions never reach do-mode (TH0007 upstream),
+  -- and `doModeLowerable` is the same function-level gate SubsetCheck's
+  -- mutation routing rejects on (#40/#41) — checked here too so a checker
+  -- regression degrades to the pure path instead of a miscompile.
   let info := EscapeAnalysis.analyze (params.map (·.1)) body
   let hasEligibleMutation := info.mutated.toList.any info.eligible
   let bodyExpr :=
-    if hasEligibleMutation && throws.isEmpty then
+    if hasEligibleMutation && info.doModeLowerable && throws.isEmpty then
       -- Mutated parameters self-shadow as `let mut x := x`: JS parameters
       -- are mutable locals whose mutation never affects the caller.
       let prologue : List LDoStmt := normalizedParams.filterMap fun (n, _) =>

--- a/Thales/Emit/Lean.lean
+++ b/Thales/Emit/Lean.lean
@@ -1198,7 +1198,13 @@ def emitFuncDecl (aliasEnv : Std.HashMap String TSType) (name : String) (typePar
   let hasEligibleMutation := info.mutated.toList.any info.eligible
   let bodyExpr :=
     if hasEligibleMutation && throws.isEmpty then
-      .idRunDo (emitBodyDo env info stmts)
+      -- Mutated parameters self-shadow as `let mut x := x`: JS parameters
+      -- are mutable locals whose mutation never affects the caller.
+      let prologue : List LDoStmt := normalizedParams.filterMap fun (n, _) =>
+        if info.mutated.contains n && info.eligible n
+        then some (.letMut n none (.var n))
+        else none
+      .idRunDo (prologue ++ emitBodyDo env info stmts)
     else
       emitBodyEnv env stmts
   let leanParams := normalizedParams.map fun (n, t) => (n, emitType t)

--- a/Thales/Emit/Lean.lean
+++ b/Thales/Emit/Lean.lean
@@ -27,6 +27,19 @@ structure EmitEnv where
   -- a fresh `h_i` is introduced (e.g. for `is<T>`-narrowing shadow-lets).
   diteBinderCounter : Nat := 0
 
+/-- Binary ops lowered through JS-semantics runtime helpers (#32) instead
+    of bare Lean operators: no Float instances exist for these, and the JS
+    semantics (ToInt32 wrap, dividend-sign `%`) differ anyway. -/
+private def jsBinopHelper : BinaryOperator → Option String
+  | .mod    => some "jsMod"
+  | .bitand => some "jsBitAnd"
+  | .bitor  => some "jsBitOr"
+  | .bitxor => some "jsBitXor"
+  | .shl    => some "jsShl"
+  | .shr    => some "jsShr"
+  | .ushr   => some "jsUShr"
+  | _ => none
+
 /-- Resolve a TSType through one level of type-alias references. -/
 private def resolveTypeAlias (env : EmitEnv) : TSType → TSType
   | .ref name _ =>
@@ -579,14 +592,20 @@ partial def emitExprEnv (env : EmitEnv) : Expression → LExpr
       .proj (.var varName) "isSome"
   -- General binary expressions: when the op is arithmetic, relational, or
   -- equality, project `.val` off any refinement-typed identifier operands
-  -- so the operation elaborates on plain `Float`.
+  -- so the operation elaborates on plain `Float`. `%`, bitwise, and shift
+  -- ops route through JS-semantics runtime helpers (#32) — bare Lean
+  -- operators have no Float instances (and the wrong semantics anyway).
   | .binaryExpr _ op left right =>
       let lExpr := emitExprEnv env left
       let rExpr := emitExprEnv env right
-      if arithBinaryOp op || eqBinaryOp op then
-        .binOp (binaryOpStr op) (coerceToFloat env left lExpr) (coerceToFloat env right rExpr)
-      else
-        .binOp (binaryOpStr op) lExpr rExpr
+      match jsBinopHelper op with
+      | some helper =>
+          .app (.var helper) [coerceToFloat env left lExpr, coerceToFloat env right rExpr]
+      | none =>
+        if arithBinaryOp op || eqBinaryOp op then
+          .binOp (binaryOpStr op) (coerceToFloat env left lExpr) (coerceToFloat env right rExpr)
+        else
+          .binOp (binaryOpStr op) lExpr rExpr
   -- Logical expressions
   | .logicalExpr _ .«and» left right =>
       .binOp "&&" (emitExprEnv env left) (emitExprEnv env right)

--- a/Thales/Emit/Lean.lean
+++ b/Thales/Emit/Lean.lean
@@ -997,8 +997,23 @@ partial def emitBodyDo (env : EmitEnv) (info : EscapeAnalysis.MutationInfo)
   | .returnStmt _ none :: _ => [.ret (.var "()")]
   | .variableDecl (.mk _ decls _) :: rest =>
       emitVarDeclDo env info decls rest
-  | .exprStmt _ (.assignmentExpr _ .assign (.identifier _ name) rhs) :: rest =>
-      .assign name (emitExprEnv env rhs) :: emitBodyDo env info rest
+  -- `x = e` / `x OP= e`: compound forms desugar to `x := x OP e` so emission
+  -- reuses the binary-op lowering (refinement projection, string concat, …).
+  | .exprStmt _ (.assignmentExpr b op (.identifier _ name) rhs) :: rest =>
+      let value : LExpr :=
+        match op.compoundToBinary with
+        | some binOp =>
+            emitExprEnv env (.binaryExpr b binOp (.identifier b name) rhs)
+        | none => emitExprEnv env rhs   -- plain `=` (logical never reaches do-mode)
+      .assign name value :: emitBodyDo env info rest
+  -- `x++` / `x--` desugar to `x := x ± 1`.
+  | .exprStmt _ (.updateExpr b op (.identifier _ name) _) :: rest =>
+      let one : Expression := .literal b (.number 1) "1"
+      let binOp : BinaryOperator := match op with
+        | .inc => .add
+        | .dec => .sub
+      .assign name (emitExprEnv env (.binaryExpr b binOp (.identifier b name) one))
+        :: emitBodyDo env info rest
   | .blockStmt _ inner :: rest => emitBodyDo env info (inner ++ rest)
   | .exprStmt _ _ :: rest => emitBodyDo env info rest  -- dropped, as in pure mode
   | [] => [.ret (.var "()")]

--- a/Thales/Emit/Lean.lean
+++ b/Thales/Emit/Lean.lean
@@ -304,6 +304,10 @@ private partial def substMemberAccessExpr (scrutName : String) : Expression → 
                   (args.map (substMemberAccessExpr scrutName)) opt
   | .arrayExpr b elems =>
       .arrayExpr b (elems.map (Option.map (substMemberAccessExpr scrutName)))
+  -- #24: switch arms may contain mutation; substitute inside the RHS
+  -- (the target identifier is a local, never `scrutName.field`).
+  | .assignmentExpr b op target rhs =>
+      .assignmentExpr b op target (substMemberAccessExpr scrutName rhs)
   | other => other
 
 /-- Rewrite `scrutName.field` in all expressions within a statement. -/
@@ -1050,6 +1054,37 @@ partial def emitBodyDo (env : EmitEnv) (info : EscapeAnalysis.MutationInfo)
         | none => []
       .ifDo (emitExprEnv env cond) thnDo elsDo :: emitBodyDo env info rest
   | .exprStmt _ _ :: rest => emitBodyDo env info rest  -- dropped, as in pure mode
+  -- Discriminated-union switch, do-mode twin of `emitBodyEnv`'s arm.
+  -- EscapeAnalysis guarantees every arm returns and there is no `default`
+  -- (`hasUnloweredSwitchShape` keeps anything else out of do-mode), so
+  -- `rest` after the switch is dead code and is dropped.
+  | .switchStmt _ discriminant cases :: rest =>
+      match discriminant with
+      | .memberExpr _ (.identifier _ scrutName) (.identifier _ _fieldName) false _ =>
+          (match env.bindingEnv.get? scrutName with
+          | some rawTy =>
+            (match resolveTypeAlias env rawTy with
+            | .union branches =>
+              (match asDiscriminated branches with
+              | some ctors =>
+                  let arms : List (LPattern × List LDoStmt) := cases.filterMap fun
+                    | .mk _ (some (.literal _ (.string caseLit) _)) caseBody =>
+                        (match ctors.find? (fun (ctorName, _) => ctorName == caseLit) with
+                        | some (_ctorName, fields) =>
+                            let fieldNames := fields.map (·.1)
+                            let pat : LPattern := .ctor caseLit (fieldNames.map .var)
+                            let substBody := caseBody.map (substMemberAccessStmt scrutName)
+                            some (pat, emitBodyDo env info substBody)
+                        | none => none)
+                    | _ => none
+                  let allArms :=
+                    if arms.length >= ctors.length then arms
+                    else arms ++ [(.wildcard, [.ret (.var "unreachable!")])]
+                  [.matchDo (.var scrutName) allArms]
+              | none => emitBodyDo env info rest)
+            | _ => emitBodyDo env info rest)
+          | none => emitBodyDo env info rest)
+      | _ => emitBodyDo env info rest
   -- A list that ends without `return` is a branch falling through to the
   -- code after its `if` — emit nothing. The function-level trailing
   -- `return ()` (for void bodies) is appended by `emitFuncDecl`.

--- a/Thales/Emit/Lean.lean
+++ b/Thales/Emit/Lean.lean
@@ -1034,8 +1034,26 @@ partial def emitBodyDo (env : EmitEnv) (info : EscapeAnalysis.MutationInfo)
       .assign name (emitExprEnv env (.binaryExpr b binOp (.identifier b name) one))
         :: emitBodyDo env info rest
   | .blockStmt _ inner :: rest => emitBodyDo env info (inner ++ rest)
+  -- `if`/`else` in statement position: branches lower WITHOUT the
+  -- continuation appended (do-notation gives statement semantics — the
+  -- pure path's continuation-into-branches trick at `emitBodyEnv` does
+  -- not apply), so mutation inside a branch stays visible after it and
+  -- `return` inside a branch is do-notation's native early return.
+  | .ifStmt _ cond thn elsOpt :: rest =>
+      let stmtsOf : Statement → List Statement := fun s =>
+        match s with
+        | .blockStmt _ ss => ss
+        | other => [other]
+      let thnDo := emitBodyDo env info (stmtsOf thn)
+      let elsDo := match elsOpt with
+        | some els => emitBodyDo env info (stmtsOf els)
+        | none => []
+      .ifDo (emitExprEnv env cond) thnDo elsDo :: emitBodyDo env info rest
   | .exprStmt _ _ :: rest => emitBodyDo env info rest  -- dropped, as in pure mode
-  | [] => [.ret (.var "()")]
+  -- A list that ends without `return` is a branch falling through to the
+  -- code after its `if` — emit nothing. The function-level trailing
+  -- `return ()` (for void bodies) is appended by `emitFuncDecl`.
+  | [] => []
   | _ :: rest => emitBodyDo env info rest
 
 /-- Declarator lowering inside do-mode: mutated names become `let mut`,
@@ -1204,7 +1222,12 @@ def emitFuncDecl (aliasEnv : Std.HashMap String TSType) (name : String) (typePar
         if info.mutated.contains n && info.eligible n
         then some (.letMut n none (.var n))
         else none
-      .idRunDo (prologue ++ emitBodyDo env info stmts)
+      let core := prologue ++ emitBodyDo env info stmts
+      -- A body that can fall off the end (void function) needs an explicit
+      -- unit return; appending one after an always-returning body would be
+      -- dead code at the wrong type.
+      let core := if doStmtsTerminate core then core else core ++ [.ret (.var "()")]
+      .idRunDo core
     else
       emitBodyEnv env stmts
   let leanParams := normalizedParams.map fun (n, t) => (n, emitType t)

--- a/Thales/Emit/Lean.lean
+++ b/Thales/Emit/Lean.lean
@@ -2,6 +2,7 @@ import Thales.TypeCheck.TSAST
 import Thales.TypeCheck.Context
 import Thales.TypeCheck.Generic
 import Thales.Emit.LeanSyntax
+import Thales.Emit.EscapeAnalysis
 import Std.Data.HashMap
 
 namespace Thales.Emit
@@ -979,6 +980,58 @@ partial def emitBodyEnv (env : EmitEnv) : List Statement → LExpr
 partial def emitBody : List Statement → LExpr :=
   emitBodyEnv {}
 
+/-- #24 do-mode lowering: the body of a function with an eligible
+    statement-position mutation, as a list of `Id.run do` statements.
+    Only shapes SubsetCheck admits into do-mode arrive here — straight-line
+    mutation, declarations, and `return`; anything else was rejected
+    upstream (TH0001/TH0005/TH0006/TH0007/TH0010 …) and the fall-through
+    arms simply skip. -/
+partial def emitBodyDo (env : EmitEnv) (info : EscapeAnalysis.MutationInfo)
+    : List Statement → List LDoStmt
+  | .returnStmt _ (some e) :: _ =>
+      let emitted :=
+        ((emitRefinementLiteral env.aliasEnv env.retTy e)
+          <|> (emitLiteralAsCtor env.aliasEnv env.retTy e))
+          |>.getD (emitExprEnv env e)
+      [.ret (wrapReturn env.retTy emitted)]
+  | .returnStmt _ none :: _ => [.ret (.var "()")]
+  | .variableDecl (.mk _ decls _) :: rest =>
+      emitVarDeclDo env info decls rest
+  | .exprStmt _ (.assignmentExpr _ .assign (.identifier _ name) rhs) :: rest =>
+      .assign name (emitExprEnv env rhs) :: emitBodyDo env info rest
+  | .blockStmt _ inner :: rest => emitBodyDo env info (inner ++ rest)
+  | .exprStmt _ _ :: rest => emitBodyDo env info rest  -- dropped, as in pure mode
+  | [] => [.ret (.var "()")]
+  | _ :: rest => emitBodyDo env info rest
+
+/-- Declarator lowering inside do-mode: mutated names become `let mut`,
+    everything else stays an immutable `let`. Mirrors `emitVarDecl`'s
+    refinement-literal wrapping and bindingEnv threading. -/
+partial def emitVarDeclDo (env : EmitEnv) (info : EscapeAnalysis.MutationInfo)
+    (decls : List VariableDeclarator) (rest : List Statement) : List LDoStmt :=
+  match decls with
+  | [] => emitBodyDo env info rest
+  | d :: moreDecls =>
+      match d with
+      | .mk _ (.identifier id) init typeAnnotation =>
+          let ty := typeAnnotation.map emitType
+          let targetTy : Option TSType := typeAnnotation
+          let initExpr := match init with
+            | some e =>
+                ((emitRefinementLiteral env.aliasEnv targetTy e)
+                  <|> (emitLiteralAsCtor env.aliasEnv targetTy e))
+                  |>.getD (emitExprEnv env e)
+            | none   => .var "()"
+          let env' :=
+            match typeAnnotation with
+            | some t => { env with bindingEnv := env.bindingEnv.insert id.name t }
+            | none   => env
+          let bind := if info.mutated.contains id.name
+            then LDoStmt.letMut id.name ty initExpr
+            else LDoStmt.letPure id.name ty initExpr
+          bind :: emitVarDeclDo env' info moreDecls rest
+      | _ => emitVarDeclDo env info moreDecls rest
+
 end
 
 /-- Lower a top-level `console.log(...)` call to its IO action, or `none`
@@ -1101,9 +1154,19 @@ def emitFuncDecl (aliasEnv : Std.HashMap String TSType) (name : String) (typePar
     normalizedParams.foldl (fun m (n, t) => m.insert n t) {}
   let env : EmitEnv := { aliasEnv, bindingEnv, retTy := some normalizedRetTy,
                          throwTypes := throws, funcThrowsEnv, funcParamTypes }
-  let bodyExpr := match body with
-    | .blockStmt _ stmts => emitBodyEnv env stmts
-    | other              => emitBodyEnv env [other]
+  let stmts := match body with
+    | .blockStmt _ ss => ss
+    | other           => [other]
+  -- #24: a body with an eligible statement-position mutation lowers to
+  -- `Id.run do` with `let mut`; everything else keeps the pure path
+  -- untouched. `@throws` functions never reach do-mode (TH0007 upstream).
+  let info := EscapeAnalysis.analyze (params.map (·.1)) body
+  let hasEligibleMutation := info.mutated.toList.any info.eligible
+  let bodyExpr :=
+    if hasEligibleMutation && throws.isEmpty then
+      .idRunDo (emitBodyDo env info stmts)
+    else
+      emitBodyEnv env stmts
   let leanParams := normalizedParams.map fun (n, t) => (n, emitType t)
   let leanRetTy :=
     if throws.isEmpty then emitType normalizedRetTy

--- a/Thales/Emit/LeanSyntax.lean
+++ b/Thales/Emit/LeanSyntax.lean
@@ -26,6 +26,8 @@ inductive LPattern where
   | ctor (name : String) (args : List LPattern) -- .circle r
   deriving Inhabited
 
+mutual
+
 /-- Lean term. Only the subset the emitter uses. -/
 inductive LExpr where
   | var (name : String)
@@ -62,7 +64,28 @@ inductive LExpr where
   -- a singleton is degenerate. All current call sites are guarded by
   -- `stmtsHaveIO`, which ensures the tail is non-empty before wrapping.
   | doSeq (stmts : List LExpr)
-  deriving Inhabited
+  -- An `Id.run do` block with mutable locals (#24). MUST be constructed
+  -- with ≥ 1 statement, and every control path through the statements must
+  -- end in a `ret` (the emitter guarantees this; a fall-through path would
+  -- render a do-block with no value).
+  | idRunDo (stmts : List LDoStmt)
+
+/-- A statement inside an `Id.run do` block (#24). Only what do-mode
+    emission needs: mutable/immutable lets, reassignment, early return,
+    statement-position `if`, and `match` with statement-list arms. -/
+inductive LDoStmt where
+  | letMut (name : String) (ty : Option LType) (value : LExpr)   -- let mut n := e
+  | letPure (name : String) (ty : Option LType) (value : LExpr)  -- let n := e
+  | assign (name : String) (value : LExpr)                       -- n := e
+  | ret (value : LExpr)                                          -- return e
+  -- `if c then …` / `if c then … else …`; an empty branch renders `pure ()`
+  | ifDo (cond : LExpr) (thn : List LDoStmt) (els : List LDoStmt)
+  | matchDo (scrutinee : LExpr) (arms : List (LPattern × List LDoStmt))
+
+end
+
+instance : Inhabited LExpr := ⟨.var ""⟩
+instance : Inhabited LDoStmt := ⟨.ret (.var "")⟩
 
 /-- Top-level declaration. -/
 inductive LDecl where
@@ -218,6 +241,35 @@ mutual
         -- `app`s like `consoleLog x` are wrapped harmlessly as `(consoleLog x)`.
         let body := lines (stmts.map renderExprAtom)
         s!"(do\n{indent body})"
+    | .idRunDo stmts =>
+        s!"Id.run do\n{indent (renderDoStmts stmts)}"
+
+  /-- Render a do-statement list; an empty list renders `pure ()` so empty
+      `if` branches stay valid Lean. -/
+  partial def renderDoStmts (stmts : List LDoStmt) : String :=
+    if stmts.isEmpty then "pure ()" else lines (stmts.map renderDoStmt)
+
+  partial def renderDoStmt : LDoStmt → String
+    | .letMut n tyOpt v =>
+        let annot := match tyOpt with
+          | some t => s!" : {renderType t}"
+          | none   => ""
+        s!"let mut {n}{annot} := {renderExpr v}"
+    | .letPure n tyOpt v =>
+        let annot := match tyOpt with
+          | some t => s!" : {renderType t}"
+          | none   => ""
+        s!"let {n}{annot} := {renderExpr v}"
+    | .assign n v => s!"{n} := {renderExpr v}"
+    | .ret v => s!"return {renderExpr v}"
+    | .ifDo c thn [] =>
+        s!"if {renderExpr c} then\n{indent (renderDoStmts thn)}"
+    | .ifDo c thn els =>
+        s!"if {renderExpr c} then\n{indent (renderDoStmts thn)}\nelse\n{indent (renderDoStmts els)}"
+    | .matchDo scrut arms =>
+        let armsS := arms.map fun (p, stmts) =>
+          s!"| {renderPattern p} =>\n{indent (renderDoStmts stmts)}"
+        s!"match {renderExpr scrut} with\n{lines armsS}"
 
   partial def renderExprAtom : LExpr → String
     | .var n      => n

--- a/Thales/Emit/LeanSyntax.lean
+++ b/Thales/Emit/LeanSyntax.lean
@@ -87,6 +87,19 @@ end
 instance : Inhabited LExpr := ⟨.var ""⟩
 instance : Inhabited LDoStmt := ⟨.ret (.var "")⟩
 
+/-- Whether a do-statement list `return`s on every control path — i.e. an
+    `idRunDo` built from it never falls off the end. Conservative (false
+    when unsure). -/
+partial def doStmtsTerminate (stmts : List LDoStmt) : Bool :=
+  match stmts.getLast? with
+  | none => false
+  | some (.ret _) => true
+  | some (.ifDo _ thn els) =>
+      !els.isEmpty && doStmtsTerminate thn && doStmtsTerminate els
+  | some (.matchDo _ arms) =>
+      !arms.isEmpty && arms.all fun (_, ss) => doStmtsTerminate ss
+  | some _ => false
+
 /-- Top-level declaration. -/
 inductive LDecl where
   | def_ (name : String)

--- a/Thales/Emit/SubsetCheck.lean
+++ b/Thales/Emit/SubsetCheck.lean
@@ -59,12 +59,20 @@ private def nestedInfo (params : List FunctionParam) (body : Statement)
     : EscapeAnalysis.MutationInfo :=
   EscapeAnalysis.analyze (funcParamNames params) body
 
+/-- Compound operators whose desugared binary op has a working Float
+    lowering today. `%=`, bitwise and shift compounds stay rejected until
+    their JS-semantics runtime helpers land — their underlying binops
+    (`%`, `&&&`, …) have no Float instances, so accepting them would emit
+    Lean that does not compile. -/
+private def emittableMutationOp : AssignmentOperator → Bool
+  | .assign | .addAssign | .subAssign | .mulAssign | .divAssign | .expAssign => true
+  | _ => false
+
 /-- Route a statement-position mutation of identifier `name`.
     Returns the rejection diagnostics; `#[]` means the mutation is allowed.
-    `plainAssign` is true only for bare `=` — compound/update forms flip in
-    their own task. -/
+    `emittable` is false for operators whose lowering isn't implemented. -/
 private def routeIdentMutation (ctx : MutCtx) (loc : Option SourceLocation)
-    (name : String) (logicalOp : Bool) (plainAssign : Bool) : Array Diagnostic :=
+    (name : String) (logicalOp : Bool) (emittable : Bool) : Array Diagnostic :=
   match ctx.info with
   | none =>
     -- Module-level mutation stays out of the subset.
@@ -89,9 +97,9 @@ private def routeIdentMutation (ctx : MutCtx) (loc : Option SourceLocation)
       -- Still-rejected forms: `let` without initializer, and variables
       -- whose narrowing the emitter relies on.
       #[mkThalesDiag (.cannotReassignVariable name) loc]
-    else if ctx.allowEligible && plainAssign then
-      -- Eligible plain `=` in a declared function body: in subset, lowered
-      -- to `Id.run do` by the emitter. (Compound/update flip in Task 8.)
+    else if ctx.allowEligible && emittable then
+      -- Eligible mutation (`=`, arithmetic `OP=`, `++`/`--`) in a declared
+      -- function body: in subset, lowered to `Id.run do` by the emitter.
       #[]
     else
       #[mkThalesDiag (.cannotReassignVariable name) loc]
@@ -219,11 +227,10 @@ partial def checkStmt (ctx : MutCtx) (stmt : Statement) : Array Diagnostic :=
   | .exprStmt _ expr =>
     match expr with
     | .assignmentExpr b op (.identifier _ name) right =>
-      let plainAssign := op.compoundToBinary.isNone && !op.isLogical
-      routeIdentMutation ctx b.loc name op.isLogical plainAssign
+      routeIdentMutation ctx b.loc name op.isLogical (emittableMutationOp op)
         ++ checkExpr ctx right
     | .updateExpr b _ (.identifier _ name) _ =>
-      routeIdentMutation ctx b.loc name false false
+      routeIdentMutation ctx b.loc name false true
     | _ => checkExpr ctx expr
   | .blockStmt _ body =>
     body.foldl (fun acc s => acc ++ checkStmt ctx s) #[]

--- a/Thales/Emit/SubsetCheck.lean
+++ b/Thales/Emit/SubsetCheck.lean
@@ -60,13 +60,12 @@ private def nestedInfo (params : List FunctionParam) (body : Statement)
   EscapeAnalysis.analyze (funcParamNames params) body
 
 /-- Compound operators whose desugared binary op has a working Float
-    lowering today. `%=`, bitwise and shift compounds stay rejected until
-    their JS-semantics runtime helpers land — their underlying binops
-    (`%`, `&&&`, …) have no Float instances, so accepting them would emit
-    Lean that does not compile. -/
+    lowering. Everything except the (deferred, short-circuit) logical
+    family: the arithmetic ops lower to Lean operators, and `%`/bitwise/
+    shifts route through the JS-semantics runtime helpers (#32). -/
 private def emittableMutationOp : AssignmentOperator → Bool
-  | .assign | .addAssign | .subAssign | .mulAssign | .divAssign | .expAssign => true
-  | _ => false
+  | .orLogicalAssign | .andLogicalAssign | .nullishAssign => false
+  | _ => true
 
 /-- Route a statement-position mutation of identifier `name`.
     Returns the rejection diagnostics; `#[]` means the mutation is allowed.

--- a/Thales/Emit/SubsetCheck.lean
+++ b/Thales/Emit/SubsetCheck.lean
@@ -92,9 +92,11 @@ private def routeIdentMutation (ctx : MutCtx) (loc : Option SourceLocation)
     else if info.capturedRefs.contains name then
       #[mkThalesDiag (.cannotMutateCapturedVariable name) loc]
     else if info.uninitializedLets.contains name
-            || info.narrowTested.contains name then
-      -- Still-rejected forms: `let` without initializer, and variables
-      -- whose narrowing the emitter relies on.
+            || info.narrowTested.contains name
+            || info.hasUnloweredSwitchShape then
+      -- Still-rejected forms: `let` without initializer, variables whose
+      -- narrowing the emitter relies on, and functions containing a
+      -- switch shape do-mode can't lower (non-returning arm / default).
       #[mkThalesDiag (.cannotReassignVariable name) loc]
     else if ctx.allowEligible && emittable then
       -- Eligible mutation (`=`, arithmetic `OP=`, `++`/`--`) in a declared

--- a/Thales/Emit/SubsetCheck.lean
+++ b/Thales/Emit/SubsetCheck.lean
@@ -7,6 +7,7 @@
 import Thales.TypeCheck.TSAST
 import Thales.TypeCheck.Diagnostic
 import Thales.Emit.DirectiveApply
+import Thales.Emit.EscapeAnalysis
 import Std.Data.HashMap
 
 namespace Thales.Emit
@@ -30,32 +31,89 @@ private def mutatingMethodNames : List String :=
 private def mkThalesDiag (kind : ThalesKind) (loc : Option SourceLocation) : Diagnostic :=
   { kind := .thales kind, location := loc }
 
+/-- Mutation-routing context (#24). -/
+structure MutCtx where
+  /-- Eligibility info for the innermost enclosing function; `none` at
+      module level. -/
+  info : Option EscapeAnalysis.MutationInfo := none
+  /-- Inside a `@throws` function body or under `try`/`catch`. -/
+  noMutZone : Bool := false
+
+/-- Parameter names of a JS-level function/arrow (typed params live on
+    `annotatedFuncDecl` and are handled separately). -/
+private def funcParamNames (params : List FunctionParam) : List String :=
+  params.filterMap fun
+    | .simple id        => some id.name
+    | .withDefault id _ => some id.name
+    | .rest id          => some id.name
+    | .pattern _        => none
+
+/-- Eligibility info for a nested function/arrow body. -/
+private def nestedInfo (params : List FunctionParam) (body : Statement)
+    : EscapeAnalysis.MutationInfo :=
+  EscapeAnalysis.analyze (funcParamNames params) body
+
+/-- Route a statement-position mutation of identifier `name`.
+    Returns the rejection diagnostics; `#[]` means the mutation is allowed. -/
+private def routeIdentMutation (ctx : MutCtx) (loc : Option SourceLocation)
+    (name : String) (logicalOp : Bool) : Array Diagnostic :=
+  match ctx.info with
+  | none =>
+    -- Module-level mutation stays out of the subset.
+    #[mkThalesDiag (.cannotReassignVariable name) loc]
+  | some info =>
+    if info.consts.contains name then
+      -- Reassigning a `const` is tsc's TS2588; no TH code on top.
+      #[]
+    else if ctx.noMutZone then
+      #[mkThalesDiag (.mutationInThrowsContext name) loc]
+    else if logicalOp then
+      -- `&&=` / `||=` / `??=` are deferred (short-circuit semantics).
+      #[mkThalesDiag (.cannotReassignVariable name) loc]
+    else if !(info.params.contains name || info.initializedLets.contains name
+              || info.uninitializedLets.contains name) then
+      -- Not declared in this function: mutation of an outer-scope binding.
+      #[mkThalesDiag (.cannotMutateCapturedVariable name) loc]
+    else if info.capturedRefs.contains name then
+      #[mkThalesDiag (.cannotMutateCapturedVariable name) loc]
+    else if info.uninitializedLets.contains name
+            || info.narrowTested.contains name then
+      -- Still-rejected forms: `let` without initializer, and variables
+      -- whose narrowing the emitter relies on.
+      #[mkThalesDiag (.cannotReassignVariable name) loc]
+    else
+      -- ELIGIBLE. Kept rejected until do-mode emission lands; the do-mode
+      -- task changes this arm to `#[]`.
+      #[mkThalesDiag (.cannotReassignVariable name) loc]
+
 mutual
 
-/-- Check an expression for mutation violations. -/
-partial def checkExpr (expr : Expression) : Array Diagnostic :=
+/-- Check an expression for mutation violations. Assignment/update
+    expressions reaching this function are in EXPRESSION position
+    (statement-position ones are routed by `checkStmt`). -/
+partial def checkExpr (ctx : MutCtx) (expr : Expression) : Array Diagnostic :=
   match expr with
   | .assignmentExpr b _ left right =>
     let loc := b.loc
     let targetDiags : Array Diagnostic :=
       match left with
-      | .identifier _ name =>
-        #[mkThalesDiag (.cannotReassignVariable name) loc]
+      | .identifier _ _ =>
+        #[mkThalesDiag .assignmentInExpressionPosition loc]
       | .memberExpr _ _ _ computed _ =>
         if computed then
           #[mkThalesDiag .cannotAssignArrayElement loc]
         else
           #[mkThalesDiag .cannotAssignObjectProperty loc]
       | _ => #[]
-    targetDiags ++ checkExpr right
+    targetDiags ++ checkExpr ctx right
   | .updateExpr b _ argument _ =>
     let loc := b.loc
     let targetDiags : Array Diagnostic :=
       match argument with
-      | .identifier _ name =>
-        #[mkThalesDiag (.cannotReassignVariable name) loc]
+      | .identifier _ _ =>
+        #[mkThalesDiag .assignmentInExpressionPosition loc]
       | _ => #[]
-    targetDiags ++ checkExpr argument
+    targetDiags ++ checkExpr ctx argument
   | .callExpr b callee arguments _ =>
     let loc := b.loc
     let calleeDiags : Array Diagnostic :=
@@ -63,64 +121,70 @@ partial def checkExpr (expr : Expression) : Array Diagnostic :=
       | .memberExpr _ obj (.identifier _ propName) false _ =>
         if mutatingMethodNames.elem propName then
           #[mkThalesDiag (.cannotCallMutatingMethod propName) loc]
-            ++ checkExpr obj
+            ++ checkExpr ctx obj
         else
-          checkExpr callee
-      | _ => checkExpr callee
-    calleeDiags ++ (arguments.foldl (fun acc arg => acc ++ checkExpr arg) #[])
+          checkExpr ctx callee
+      | _ => checkExpr ctx callee
+    calleeDiags ++ (arguments.foldl (fun acc arg => acc ++ checkExpr ctx arg) #[])
   | .unaryExpr _ _ _ argument =>
-    checkExpr argument
+    checkExpr ctx argument
   | .binaryExpr _ _ left right =>
-    checkExpr left ++ checkExpr right
+    checkExpr ctx left ++ checkExpr ctx right
   | .logicalExpr _ _ left right =>
-    checkExpr left ++ checkExpr right
+    checkExpr ctx left ++ checkExpr ctx right
   | .memberExpr _ obj prop _ _ =>
-    checkExpr obj ++ checkExpr prop
+    checkExpr ctx obj ++ checkExpr ctx prop
   | .privateMemberExpr _ obj _ =>
-    checkExpr obj
+    checkExpr ctx obj
   | .conditionalExpr _ test consequent alternate =>
-    checkExpr test ++ checkExpr consequent ++ checkExpr alternate
+    checkExpr ctx test ++ checkExpr ctx consequent ++ checkExpr ctx alternate
   | .newExpr _ callee arguments =>
-    checkExpr callee ++ (arguments.foldl (fun acc arg => acc ++ checkExpr arg) #[])
+    checkExpr ctx callee ++ (arguments.foldl (fun acc arg => acc ++ checkExpr ctx arg) #[])
   | .chainExpr _ inner =>
-    checkExpr inner
+    checkExpr ctx inner
   | .sequenceExpr _ exprs =>
-    exprs.foldl (fun acc e => acc ++ checkExpr e) #[]
+    exprs.foldl (fun acc e => acc ++ checkExpr ctx e) #[]
   | .templateLiteral _ _ exprs =>
-    exprs.foldl (fun acc e => acc ++ checkExpr e) #[]
+    exprs.foldl (fun acc e => acc ++ checkExpr ctx e) #[]
   | .taggedTemplate _ tag quasi =>
-    checkExpr tag ++ checkExpr quasi
+    checkExpr ctx tag ++ checkExpr ctx quasi
   | .arrayExpr _ elements =>
     elements.foldl (fun acc optE =>
       match optE with
-      | some e => acc ++ checkExpr e
+      | some e => acc ++ checkExpr ctx e
       | none => acc) #[]
   | .objectExpr _ props =>
     props.foldl (fun acc p =>
       match p with
-      | .regular _ _ v _ _ _ => acc ++ checkExpr v
-      | .spread _ arg => acc ++ checkExpr arg) #[]
+      | .regular _ _ v _ _ _ => acc ++ checkExpr ctx v
+      | .spread _ arg => acc ++ checkExpr ctx arg) #[]
   -- TH0012: async function expressions — emit diagnostic, still recurse body
-  | .functionExpr b _ _ body _ async =>
+  | .functionExpr b _ params body _ async =>
+    let ctx' := { ctx with info := some (nestedInfo params body) }
     (if async then #[mkThalesDiag .asyncNotSupported b.loc] else #[])
-      ++ checkStmt body
+      ++ checkStmt ctx' body
   -- TH0012: async arrow functions — emit diagnostic, still recurse body
-  | .arrowFunctionExpr b _ body _ async _ =>
+  | .arrowFunctionExpr b params body _ async _ =>
     let bodyDiags : Array Diagnostic :=
       match body with
-      | .inl e => checkExpr e
-      | .inr s => checkStmt s
+      | .inl e =>
+        -- Expression-bodied arrow: wrap so escape analysis sees one body.
+        let ctx' := { ctx with info := some (nestedInfo params (.exprStmt b e)) }
+        checkExpr ctx' e
+      | .inr s =>
+        let ctx' := { ctx with info := some (nestedInfo params s) }
+        checkStmt ctx' s
     (if async then #[mkThalesDiag .asyncNotSupported b.loc] else #[])
       ++ bodyDiags
   | .spreadElement _ arg =>
-    checkExpr arg
+    checkExpr ctx arg
   | .yieldExpr _ arg _ =>
     match arg with
-    | some e => checkExpr e
+    | some e => checkExpr ctx e
     | none => #[]
   -- TH0012: await expression — emit diagnostic, still recurse argument
   | .awaitExpr b arg =>
-    #[mkThalesDiag .asyncNotSupported b.loc] ++ checkExpr arg
+    #[mkThalesDiag .asyncNotSupported b.loc] ++ checkExpr ctx arg
   -- TH0030: class expressions — emit diagnostic, optionally TH0031 for extends, do NOT recurse
   | .classExpr b _ superClass _ =>
     let baseDiag := #[mkThalesDiag .classNotSupported b.loc]
@@ -135,19 +199,26 @@ partial def checkExpr (expr : Expression) : Array Diagnostic :=
   | .metaProperty _ _ _ => #[]
   | .patternExpr _ _ => #[]
 
-/-- Check a statement for subset violations (mutation + control-flow). -/
-partial def checkStmt (stmt : Statement) : Array Diagnostic :=
+/-- Check a statement for subset violations (mutation + control-flow).
+    Statement-position assignment/update to an identifier is routed through
+    `routeIdentMutation` (#24); everything else delegates to `checkExpr`. -/
+partial def checkStmt (ctx : MutCtx) (stmt : Statement) : Array Diagnostic :=
   match stmt with
   | .emptyStmt _ => #[]
   | .debuggerStmt _ => #[]
   | .exprStmt _ expr =>
-    checkExpr expr
+    match expr with
+    | .assignmentExpr b op (.identifier _ name) right =>
+      routeIdentMutation ctx b.loc name op.isLogical ++ checkExpr ctx right
+    | .updateExpr b _ (.identifier _ name) _ =>
+      routeIdentMutation ctx b.loc name false
+    | _ => checkExpr ctx expr
   | .blockStmt _ body =>
-    body.foldl (fun acc s => acc ++ checkStmt s) #[]
+    body.foldl (fun acc s => acc ++ checkStmt ctx s) #[]
   | .ifStmt _ test consequent alternate =>
-    checkExpr test
-      ++ checkStmt consequent
-      ++ (match alternate with | some s => checkStmt s | none => #[])
+    checkExpr ctx test
+      ++ checkStmt ctx consequent
+      ++ (match alternate with | some s => checkStmt ctx s | none => #[])
   -- TH0010: loop statements — emit once, do NOT recurse into body
   | .whileStmt b _ _ =>
     #[mkThalesDiag .loopNotSupported b.loc]
@@ -163,7 +234,7 @@ partial def checkStmt (stmt : Statement) : Array Diagnostic :=
   | .continueStmt _ _ => #[]
   | .returnStmt _ arg =>
     match arg with
-    | some e => checkExpr e
+    | some e => checkExpr ctx e
     | none => #[]
   -- TH0063 (non-record throw) is checked syntactically: primitive literals
   -- are rejected. TH0060 (unannotated throw) is no longer emitted here —
@@ -177,32 +248,36 @@ partial def checkStmt (stmt : Statement) : Array Diagnostic :=
       | .literal _ (.bigint _) _ =>
           #[mkThalesDiag .nonRecordThrow b.loc]
       | _ => #[]
-    nonRecord ++ checkExpr arg
+    nonRecord ++ checkExpr ctx arg
   -- Untyped `catch (e)` is the standard TS form (tsc rejects `catch (e: E)`
   -- with TS1196); thales infers the catch type from the try-body's Except.
+  -- Mutation anywhere under try/catch is TH0007 (#24): the exception path
+  -- emits pure Except match-chains, which do-mode cannot thread through.
   | .tryStmt _ block handler _ =>
-    let blockDiags := checkStmt block
+    let ctx' := { ctx with noMutZone := true }
+    let blockDiags := checkStmt ctx' block
     let handlerDiags := match handler with
-      | some (CatchClause.mk _ _ handlerBody _) => checkStmt handlerBody
+      | some (CatchClause.mk _ _ handlerBody _) => checkStmt ctx' handlerBody
       | none => #[]
     blockDiags ++ handlerDiags
   | .switchStmt _ discriminant cases =>
-    checkExpr discriminant
+    checkExpr ctx discriminant
       ++ cases.foldl (fun acc (SwitchCase.mk _ _ stmts) =>
-           stmts.foldl (fun acc2 s => acc2 ++ checkStmt s) acc) #[]
+           stmts.foldl (fun acc2 s => acc2 ++ checkStmt ctx s) acc) #[]
   | .labeledStmt _ _ body =>
-    checkStmt body
+    checkStmt ctx body
   | .withStmt _ obj body =>
-    checkExpr obj ++ checkStmt body
+    checkExpr ctx obj ++ checkStmt ctx body
   | .variableDecl (VariableDeclaration.mk _ decls _) =>
     decls.foldl (fun acc (VariableDeclarator.mk _ _ initOpt _) =>
       match initOpt with
-      | some e => acc ++ checkExpr e
+      | some e => acc ++ checkExpr ctx e
       | none => acc) #[]
   -- TH0012: async function declarations — emit diagnostic, still recurse body
-  | .functionDecl b _ _ body _ async =>
+  | .functionDecl b _ params body _ async =>
+    let ctx' := { ctx with info := some (nestedInfo params body) }
     (if async then #[mkThalesDiag .asyncNotSupported b.loc] else #[])
-      ++ checkStmt body
+      ++ checkStmt ctx' body
   -- TH0030: class declarations — emit diagnostic, optionally TH0031 for extends, do NOT recurse
   | .classDecl b _ superClass _ =>
     let baseDiag := #[mkThalesDiag .classNotSupported b.loc]
@@ -211,15 +286,15 @@ partial def checkStmt (stmt : Statement) : Array Diagnostic :=
     | none => baseDiag
 
 /-- Check class elements for mutation violations. -/
-partial def checkClassElements (elements : List ClassElement) : Array Diagnostic :=
+partial def checkClassElements (ctx : MutCtx) (elements : List ClassElement) : Array Diagnostic :=
   elements.foldl (fun acc elem =>
     match elem with
     | .method (MethodDefinition.mk _ key value _ _ _ ..) =>
-      acc ++ checkExpr key ++ checkExpr value
+      acc ++ checkExpr ctx key ++ checkExpr ctx value
     | .field (FieldDefinition.mk _ key valueOpt _ _ ..) =>
-      acc ++ checkExpr key ++ (match valueOpt with | some v => checkExpr v | none => #[])
+      acc ++ checkExpr ctx key ++ (match valueOpt with | some v => checkExpr ctx v | none => #[])
     | .staticBlock _ body =>
-      body.foldl (fun acc2 s => acc2 ++ checkStmt s) acc) #[]
+      body.foldl (fun acc2 s => acc2 ++ checkStmt ctx s) acc) #[]
 
 end
 
@@ -454,18 +529,21 @@ private def buildParamEnv
 /-- Check a TS-level statement for mutation violations. -/
 def checkTSStmt (ts : TSStatement) : Array Diagnostic :=
   match ts with
-  | .js s => checkStmt s
+  | .js s => checkStmt {} s
   | .annotatedVarDecl b _ _ typeAnn initOpt =>
     checkAnn b.loc typeAnn
       ++ (match initOpt with
-          | some e => checkExpr e
+          | some e => checkExpr {} e
           | none => #[])
   -- TH0012: async annotated function declarations — emit diagnostic, still recurse body.
   -- TH0060 is no longer SubsetCheck's responsibility, so no suppression filter is needed.
-  | .annotatedFuncDecl b _ _ params returnType body _ async _throwsAnn _ =>
+  | .annotatedFuncDecl b _ _ params returnType body _ async throwsAnn _ =>
+    let ctx : MutCtx :=
+      { info := some (EscapeAnalysis.analyze (params.map (·.1)) body),
+        noMutZone := throwsAnn != .absent }
     let paramTypeDiags := params.foldl (fun acc (_, ann, _, _) =>
       acc ++ checkAnn b.loc ann) #[]
-    let bodyDiags := checkStmt body
+    let bodyDiags := checkStmt ctx body
     (if async then #[mkThalesDiag .asyncNotSupported b.loc] else #[])
       ++ paramTypeDiags
       ++ checkAnn b.loc returnType

--- a/Thales/Emit/SubsetCheck.lean
+++ b/Thales/Emit/SubsetCheck.lean
@@ -38,6 +38,12 @@ structure MutCtx where
   info : Option EscapeAnalysis.MutationInfo := none
   /-- Inside a `@throws` function body or under `try`/`catch`. -/
   noMutZone : Bool := false
+  /-- Whether eligible mutation is actually emittable here: true only for
+      `annotatedFuncDecl` bodies (the do-mode path). Arrow and function
+      EXPRESSIONS don't lower through `emitFuncDecl`, so their mutation
+      stays rejected in v1 even when the eligibility analysis would allow
+      it. -/
+  allowEligible : Bool := false
 
 /-- Parameter names of a JS-level function/arrow (typed params live on
     `annotatedFuncDecl` and are handled separately). -/
@@ -54,9 +60,11 @@ private def nestedInfo (params : List FunctionParam) (body : Statement)
   EscapeAnalysis.analyze (funcParamNames params) body
 
 /-- Route a statement-position mutation of identifier `name`.
-    Returns the rejection diagnostics; `#[]` means the mutation is allowed. -/
+    Returns the rejection diagnostics; `#[]` means the mutation is allowed.
+    `plainAssign` is true only for bare `=` — compound/update forms flip in
+    their own task. -/
 private def routeIdentMutation (ctx : MutCtx) (loc : Option SourceLocation)
-    (name : String) (logicalOp : Bool) : Array Diagnostic :=
+    (name : String) (logicalOp : Bool) (plainAssign : Bool) : Array Diagnostic :=
   match ctx.info with
   | none =>
     -- Module-level mutation stays out of the subset.
@@ -81,9 +89,11 @@ private def routeIdentMutation (ctx : MutCtx) (loc : Option SourceLocation)
       -- Still-rejected forms: `let` without initializer, and variables
       -- whose narrowing the emitter relies on.
       #[mkThalesDiag (.cannotReassignVariable name) loc]
+    else if ctx.allowEligible && plainAssign then
+      -- Eligible plain `=` in a declared function body: in subset, lowered
+      -- to `Id.run do` by the emitter. (Compound/update flip in Task 8.)
+      #[]
     else
-      -- ELIGIBLE. Kept rejected until do-mode emission lands; the do-mode
-      -- task changes this arm to `#[]`.
       #[mkThalesDiag (.cannotReassignVariable name) loc]
 
 mutual
@@ -160,7 +170,7 @@ partial def checkExpr (ctx : MutCtx) (expr : Expression) : Array Diagnostic :=
       | .spread _ arg => acc ++ checkExpr ctx arg) #[]
   -- TH0012: async function expressions — emit diagnostic, still recurse body
   | .functionExpr b _ params body _ async =>
-    let ctx' := { ctx with info := some (nestedInfo params body) }
+    let ctx' := { ctx with info := some (nestedInfo params body), allowEligible := false }
     (if async then #[mkThalesDiag .asyncNotSupported b.loc] else #[])
       ++ checkStmt ctx' body
   -- TH0012: async arrow functions — emit diagnostic, still recurse body
@@ -169,10 +179,10 @@ partial def checkExpr (ctx : MutCtx) (expr : Expression) : Array Diagnostic :=
       match body with
       | .inl e =>
         -- Expression-bodied arrow: wrap so escape analysis sees one body.
-        let ctx' := { ctx with info := some (nestedInfo params (.exprStmt b e)) }
+        let ctx' := { ctx with info := some (nestedInfo params (.exprStmt b e)), allowEligible := false }
         checkExpr ctx' e
       | .inr s =>
-        let ctx' := { ctx with info := some (nestedInfo params s) }
+        let ctx' := { ctx with info := some (nestedInfo params s), allowEligible := false }
         checkStmt ctx' s
     (if async then #[mkThalesDiag .asyncNotSupported b.loc] else #[])
       ++ bodyDiags
@@ -209,9 +219,11 @@ partial def checkStmt (ctx : MutCtx) (stmt : Statement) : Array Diagnostic :=
   | .exprStmt _ expr =>
     match expr with
     | .assignmentExpr b op (.identifier _ name) right =>
-      routeIdentMutation ctx b.loc name op.isLogical ++ checkExpr ctx right
+      let plainAssign := op.compoundToBinary.isNone && !op.isLogical
+      routeIdentMutation ctx b.loc name op.isLogical plainAssign
+        ++ checkExpr ctx right
     | .updateExpr b _ (.identifier _ name) _ =>
-      routeIdentMutation ctx b.loc name false
+      routeIdentMutation ctx b.loc name false false
     | _ => checkExpr ctx expr
   | .blockStmt _ body =>
     body.foldl (fun acc s => acc ++ checkStmt ctx s) #[]
@@ -275,7 +287,7 @@ partial def checkStmt (ctx : MutCtx) (stmt : Statement) : Array Diagnostic :=
       | none => acc) #[]
   -- TH0012: async function declarations — emit diagnostic, still recurse body
   | .functionDecl b _ params body _ async =>
-    let ctx' := { ctx with info := some (nestedInfo params body) }
+    let ctx' := { ctx with info := some (nestedInfo params body), allowEligible := false }
     (if async then #[mkThalesDiag .asyncNotSupported b.loc] else #[])
       ++ checkStmt ctx' body
   -- TH0030: class declarations — emit diagnostic, optionally TH0031 for extends, do NOT recurse
@@ -540,7 +552,8 @@ def checkTSStmt (ts : TSStatement) : Array Diagnostic :=
   | .annotatedFuncDecl b _ _ params returnType body _ async throwsAnn _ =>
     let ctx : MutCtx :=
       { info := some (EscapeAnalysis.analyze (params.map (·.1)) body),
-        noMutZone := throwsAnn != .absent }
+        noMutZone := throwsAnn != .absent,
+        allowEligible := true }
     let paramTypeDiags := params.foldl (fun acc (_, ann, _, _) =>
       acc ++ checkAnn b.loc ann) #[]
     let bodyDiags := checkStmt ctx body

--- a/Thales/Emit/SubsetCheck.lean
+++ b/Thales/Emit/SubsetCheck.lean
@@ -93,10 +93,13 @@ private def routeIdentMutation (ctx : MutCtx) (loc : Option SourceLocation)
       #[mkThalesDiag (.cannotMutateCapturedVariable name) loc]
     else if info.uninitializedLets.contains name
             || info.narrowTested.contains name
-            || info.hasUnloweredSwitchShape then
+            || !info.doModeLowerable then
       -- Still-rejected forms: `let` without initializer, variables whose
-      -- narrowing the emitter relies on, and functions containing a
-      -- switch shape do-mode can't lower (non-returning arm / default).
+      -- narrowing the emitter relies on, and functions whose body contains
+      -- a shape do-mode can't lower — an unlowerable switch, a
+      -- `try`/`catch` (#41), or a read of a narrow-tested variable outside
+      -- its test (#40). `doModeLowerable` is the same predicate
+      -- `emitFuncDecl` gates on; the two must never disagree.
       #[mkThalesDiag (.cannotReassignVariable name) loc]
     else if ctx.allowEligible && emittable then
       -- Eligible mutation (`=`, arithmetic `OP=`, `++`/`--`) in a declared

--- a/Thales/TS/Runtime.lean
+++ b/Thales/TS/Runtime.lean
@@ -305,6 +305,74 @@ private def stripTrailingZerosAfterDot (s : String) : String :=
       if fracChars.isEmpty then whole else s!"{whole}.{String.ofList fracChars}"
   | _ => s
 
+/-! ### JS numeric-conversion helpers (#32, used by #24's operators)
+
+ES2023 7.1.6 ToInt32 / 7.1.7 ToUint32, and the `%`, bitwise, and shift
+operators built on them. JS bitwise operates on the 32-bit integer
+truncation of the double; shift counts mask to 5 bits; `%` keeps the
+dividend's sign. -/
+
+/-- ES ToUint32: truncate toward zero, wrap modulo 2^32. NaN/±∞ → 0.
+    `|x| < 2^64` truncates exactly via `toUInt64`; larger magnitudes
+    decompose as m·2^k through `frExp` (53-bit mantissa), so the wrap is
+    exact for every double. -/
+def toUint32 (x : Float) : Nat :=
+  if x.isNaN || x.isInf then 0
+  else
+    let neg := x < 0.0
+    let a := x.abs
+    let n : Nat :=
+      if a < 18446744073709551616.0 then -- 2^64
+        a.toUInt64.toNat
+      else
+        let (frac, exp) := a.frExp
+        -- a = frac·2^exp with frac ∈ [0.5, 1), so frac·2^53 is integral
+        let m : Nat := (frac * 9007199254740992.0).toUInt64.toNat
+        let k : Int := exp - 53
+        if k ≥ 32 then 0
+        else m <<< k.toNat
+    let r := n % 4294967296
+    if neg && r != 0 then 4294967296 - r else r
+
+/-- ES ToInt32: ToUint32 reinterpreted as signed 32-bit. -/
+def toInt32 (x : Float) : Int :=
+  let u := toUint32 x
+  if u ≥ 2147483648 then (u : Int) - 4294967296 else (u : Int)
+
+/-- Reinterpret a Uint32 value as a signed 32-bit quantity, as Float. -/
+private def int32ToFloat (u : Nat) : Float :=
+  if u ≥ 2147483648 then Float.ofInt ((u : Int) - 4294967296) else Float.ofNat u
+
+/-- JS `a & b`. -/
+def jsBitAnd (a b : Float) : Float := int32ToFloat (toUint32 a &&& toUint32 b)
+/-- JS `a | b`. -/
+def jsBitOr (a b : Float) : Float := int32ToFloat (toUint32 a ||| toUint32 b)
+/-- JS `a ^ b`. -/
+def jsBitXor (a b : Float) : Float := int32ToFloat (toUint32 a ^^^ toUint32 b)
+/-- JS `a << b` (count masked to 5 bits, result wraps to Int32). -/
+def jsShl (a b : Float) : Float :=
+  int32ToFloat ((toUint32 a <<< (toUint32 b % 32)) % 4294967296)
+/-- JS `a >> b` (sign-propagating shift on the Int32 value). -/
+def jsShr (a b : Float) : Float :=
+  Float.ofInt (toInt32 a >>> (toUint32 b % 32))
+/-- JS `a >>> b` (zero-fill shift on the Uint32 value; result is Uint32). -/
+def jsUShr (a b : Float) : Float :=
+  Float.ofNat (toUint32 a >>> (toUint32 b % 32))
+
+/-- JS `%` (fmod): result has the dividend's sign. NaN when the divisor is
+    ±0, the dividend is ±∞, or either operand is NaN; `a % ±∞ = a`.
+    Computed as `|a| - |b|·⌊|a|/|b|⌋` with the dividend's sign re-applied;
+    exact for the magnitudes v1 exercises (extreme-ratio rounding is
+    tracked in the test262 baseline). -/
+def jsMod (a b : Float) : Float :=
+  if a.isNaN || b.isNaN || a.isInf || b == 0.0 then (0.0 / 0.0)
+  else if b.isInf then a
+  else if a == 0.0 then a
+  else
+    let q := (a / b).abs.floor
+    let r := a.abs - b.abs * q
+    if a < 0.0 then -r else r
+
 /-- JS `Number.prototype.toString()` for the common cases Thales-TS v1 cares
     about. Whole-valued Floats print without a decimal; fractional Floats
     strip trailing zeros. Does not implement the full ECMA-262 ToString

--- a/Thales/TypeCheck/Check.lean
+++ b/Thales/TypeCheck/Check.lean
@@ -614,10 +614,110 @@ partial def assignmentFlowType (name : String) (rhsTy : TSType) : TypeCheckM (Op
     else
       return some declared
 
+/-- A statement after which control can never reach the next statement in
+    sequence: it returns or throws on every path. Conservative (false when
+    unsure). -/
+partial def alwaysReturns : Statement → Bool
+  | .returnStmt _ _ => true
+  | .throwStmt _ _ => true
+  | .blockStmt _ ss => ss.any alwaysReturns
+  | .ifStmt _ _ c (some a) => alwaysReturns c && alwaysReturns a
+  | _ => false
+
+/-- Syntactic flow type of an assignment RHS: literals only (#24 v1).
+    Non-literal RHS degrades to the declared type at a branch join. -/
+partial def literalFlowType : Expression → Option TSType
+  | .literal _ (.number _) _ => some .number
+  | .literal _ (.string _) _ => some .string
+  | .literal _ (.boolean _) _ => some .boolean
+  | .literal _ .null _ => some .null_
+  | _ => none
+
+/-- Union a list of flow contributions, flattening nested unions and
+    dropping duplicates. -/
+partial def joinTypes (ts : List TSType) : TSType :=
+  let flat := ts.flatMap fun | .union ms => ms | t => [t]
+  match flat.eraseDups with
+  | [] => .any
+  | [single] => single
+  | ms => .union ms
+
+/-- The flow type `name` carries when `branch` falls through to the join:
+    its entry flow updated by the branch's top-level assignments (last one
+    wins; a literal RHS gives a precise widened type, anything else — and
+    any assignment buried in nested constructs — degrades to the declared
+    type, the #24 soundness floor). -/
+partial def branchExitFlow (declared : Std.HashMap String TSType)
+    (entry : Std.HashMap String TSType) (branch : Statement) (name : String)
+    : Option TSType :=
+  let stmts := match branch with
+    | .blockStmt _ ss => ss
+    | s => [s]
+  let declaredTy := declared[name]?
+  stmts.foldl (init := entry[name]?) fun acc s =>
+    match s with
+    | .exprStmt _ (.assignmentExpr _ op (.identifier _ n) rhs) =>
+      if n == name then
+        match op.compoundToBinary, literalFlowType rhs with
+        | none, some t => some (widenLiteralType t)
+        | _, _ => declaredTy <|> acc
+      else acc
+    | .exprStmt _ (.updateExpr _ _ (.identifier _ n) _) =>
+      if n == name then declaredTy <|> acc else acc
+    | _ =>
+      if (collectAssignedVars s).contains name then declaredTy <|> acc else acc
+
+/-- Continuation scope updates after an `if` (#24): joins the flow types of
+    every path that can reach the statement after the `if` — non-returning
+    branches (with their assignments applied) and, when there is no `else`,
+    the (negated-guard) fall-through path. Early-returning branches are
+    excluded, which is what makes `if (x === null) return 0;` narrow the
+    rest of the function. -/
+partial def ifJoinUpdates (test : Expression) (consequent : Statement)
+    (alternate : Option Statement) : TypeCheckM (List (String × TSType)) := do
+  let ctx ← read
+  let (thenEntry, elseEntry) ← (do
+    match Narrowing.extractGuard test with
+    | some guard => do
+      let resolved ← resolveBindingsForNarrowing guard ctx.bindings
+      pure (Narrowing.applyGuard guard resolved, Narrowing.applyNegatedGuard guard resolved)
+    | none => pure (ctx.bindings, ctx.bindings))
+  let mut paths : List (Std.HashMap String TSType × Option Statement) := []
+  if !alwaysReturns consequent then
+    paths := paths ++ [(thenEntry, some consequent)]
+  match alternate with
+  | some alt =>
+    if !alwaysReturns alt then
+      paths := paths ++ [(elseEntry, some alt)]
+  | none =>
+    paths := paths ++ [(elseEntry, none)]
+  if paths.isEmpty then
+    return []  -- continuation unreachable; leave the scope as-is
+  -- Vars whose flow can differ at the join: assigned in a branch, or
+  -- guard-narrowed on a surviving path.
+  let assigned := (collectAssignedVars consequent
+    ++ (match alternate with | some a => collectAssignedVars a | none => [])).eraseDups
+  let narrowed := (Narrowing.bindingsDiff thenEntry ctx.bindings
+    ++ Narrowing.bindingsDiff elseEntry ctx.bindings).map (·.1)
+  let mut updates : List (String × TSType) := []
+  for v in (assigned ++ narrowed).eraseDups do
+    let contributions := paths.filterMap fun (entry, branchOpt) =>
+      match branchOpt with
+      | some branch => branchExitFlow ctx.declaredTypes entry branch v
+      | none => entry[v]?
+    match contributions with
+    | [] => pure ()
+    | cs =>
+      let joined := joinTypes cs
+      if ctx.bindings[v]? != some joined then
+        updates := updates ++ [(v, joined)]
+  return updates
+
 /-- Statement-list walker with sequential scope threading (#24), mirroring
     the continuation style of the top-level `checkStatements`: unannotated
-    `let` initializers install their widened type, and assignment/update
-    statements refine the variable's flow type for the rest of the list. -/
+    `let` initializers install their widened type, assignment/update
+    statements refine the variable's flow type, and `if` statements join
+    their surviving paths' flows for the rest of the list. -/
 partial def checkJSStatementsSeq : List Statement → TypeCheckM Unit
   | [] => pure ()
   | stmt :: rest =>
@@ -636,6 +736,10 @@ partial def checkJSStatementsSeq : List Statement → TypeCheckM Unit
       match ← lookupDeclaredType name with
       | some d => withScope [(name, d)] (checkJSStatementsSeq rest)
       | none => checkJSStatementsSeq rest
+    | .ifStmt _ test consequent alternate => do
+      checkJSStatementRaw stmt
+      let updates ← ifJoinUpdates test consequent alternate
+      withScope updates (checkJSStatementsSeq rest)
     | _ => do
       checkJSStatementRaw stmt
       checkJSStatementsSeq rest

--- a/Thales/TypeCheck/Check.lean
+++ b/Thales/TypeCheck/Check.lean
@@ -24,6 +24,20 @@ private def collectDeclaredBindings : Statement → List (String × TSType)
   | .blockStmt _ stmts => stmts.flatMap collectDeclaredBindings
   | _ => []
 
+/-- tsc-style literal widening for mutable positions (#24): a fresh literal
+    type widens to its base primitive when it seeds a mutable binding's
+    declared type or a variable's post-assignment flow type. -/
+partial def widenLiteralType : TSType → TSType
+  | .numberLit _ => .number
+  | .stringLit _ => .string
+  | .booleanLit _ => .boolean
+  | .paren inner => widenLiteralType inner
+  | .union members =>
+    match (members.map widenLiteralType).eraseDups with
+    | [single] => single
+    | ms => .union ms
+  | t => t
+
 /-- Collect all `var`-declared names from a JS statement, recursing into
     blocks/if/for/while/try but stopping at function boundaries. -/
 private partial def collectHoistedVarsJS : Statement → List String
@@ -548,11 +562,83 @@ partial def checkStatements (stmts : List TSStatement) : TypeCheckM Unit := do
 
 /-- Process a list of JS statements, pre-seeding scope with declared variable names -/
 partial def checkJSStatements (stmts : List Statement) : TypeCheckM Unit := do
-  -- Pre-seed scope with all variable declarations using annotation types where available
+  -- Pre-seed scope with all variable declarations using annotation types
+  -- where available (hoisting/forward refs); the sequential walker then
+  -- refines unannotated declarations and assignments as it goes (#24).
   let extraBindings := stmts.flatMap collectDeclaredBindings
-  withScopeAndDeclaredTypes extraBindings (do
-    for stmt in stmts do
-      checkJSStatementRaw stmt)
+  withScopeAndDeclaredTypes extraBindings (checkJSStatementsSeq stmts)
+
+/-- Check a declarator list, returning scope updates for unannotated
+    initialized declarations: the declared type is the widened initializer
+    type for mutable kinds (`let`/`var`), the exact synthesized type for
+    `const` (tsc keeps literal types on consts). Mirrors the checking that
+    `checkJSStatementRaw`'s `variableDecl` arm performs — callers must use
+    one or the other, never both, or initializers get double-synthesized. -/
+partial def checkDeclaratorsSeq (declarators : List VariableDeclarator)
+    (kind : VariableKind) : TypeCheckM (List (String × TSType)) := do
+  let mut updates : List (String × TSType) := []
+  for decl in declarators do
+    let (.mk _ pat init typeAnn) := decl
+    match pat with
+    | .identifier id =>
+      match typeAnn, init with
+      | some annTy, some expr =>
+        let initTyped ← synthJSExpr expr (some annTy)
+        checkAssignable initTyped.type annTy (exprLoc expr) (exprSourceName expr)
+        markAssigned id.name
+      | _, none =>
+        match kind with
+        | .let_ | .const => requireAssignmentCheck id.name
+        | .var => markAssigned id.name
+      | none, some expr =>
+        let initTyped ← synthJSExpr expr
+        markAssigned id.name
+        match kind with
+        | .let_ | .var => updates := updates ++ [(id.name, widenLiteralType initTyped.type)]
+        | .const => updates := updates ++ [(id.name, initTyped.type)]
+    | _ => pure ()
+  return updates
+
+/-- The flow type of `name` after an assignment whose RHS synthesized to
+    `rhsTy` (#24): the widened RHS if it is assignable to the declared type,
+    else the declared type (the assignment is ill-typed — TS2322 was already
+    emitted — and flow degrades to declared). `none` when nothing is known. -/
+partial def assignmentFlowType (name : String) (rhsTy : TSType) : TypeCheckM (Option TSType) := do
+  match ← lookupDeclaredType name with
+  | none => return none
+  | some declared =>
+    if declared == .any then return none
+    let widened := widenLiteralType rhsTy
+    if ← isSubtype widened declared then
+      return some widened
+    else
+      return some declared
+
+/-- Statement-list walker with sequential scope threading (#24), mirroring
+    the continuation style of the top-level `checkStatements`: unannotated
+    `let` initializers install their widened type, and assignment/update
+    statements refine the variable's flow type for the rest of the list. -/
+partial def checkJSStatementsSeq : List Statement → TypeCheckM Unit
+  | [] => pure ()
+  | stmt :: rest =>
+    match stmt with
+    | .variableDecl (.mk _ declarators kind) => do
+      let updates ← checkDeclaratorsSeq declarators kind
+      withScopeAndDeclaredTypes updates (checkJSStatementsSeq rest)
+    | .exprStmt _ expr@(.assignmentExpr _ _ (.identifier _ name) _) => do
+      let typed ← synthJSExpr expr
+      match ← assignmentFlowType name typed.type with
+      | some ty => withScope [(name, ty)] (checkJSStatementsSeq rest)
+      | none => checkJSStatementsSeq rest
+    | .exprStmt _ expr@(.updateExpr _ _ (.identifier _ name) _) => do
+      let _ ← synthJSExpr expr
+      -- `x++` preserves the declared (numeric) type; flow resets to declared.
+      match ← lookupDeclaredType name with
+      | some d => withScope [(name, d)] (checkJSStatementsSeq rest)
+      | none => checkJSStatementsSeq rest
+    | _ => do
+      checkJSStatementRaw stmt
+      checkJSStatementsSeq rest
 
 end
 

--- a/Thales/TypeCheck/Context.lean
+++ b/Thales/TypeCheck/Context.lean
@@ -163,13 +163,17 @@ def withScopeAndDeclaredTypes {α : Type} (extraBindings : List (String × TSTyp
 def lookupDeclaredType (name : String) : TypeCheckM (Option TSType) := do
   return (← read).declaredTypes[name]?
 
-/-- Run a computation in a function scope (with params and return type) -/
+/-- Run a computation in a function scope (with params and return type).
+    Parameters seed both the flow type and the declared type — assignment
+    checking and post-assignment flow updates (#24) treat parameters
+    exactly like initialized `let` bindings. -/
 def withFunctionScope {α : Type} (params : List (String × TSType)) (retTy : Option TSType)
     (m : TypeCheckM α) : TypeCheckM α :=
   StateT.mk fun s =>
     ReaderT.mk fun ctx =>
       let newBindings := params.foldl (fun map (k, v) => map.insert k v) ctx.bindings
-      (m.run s).run { ctx with bindings := newBindings, returnType := retTy }
+      let newDeclared := params.foldl (fun map (k, v) => map.insert k v) ctx.declaredTypes
+      (m.run s).run { ctx with bindings := newBindings, declaredTypes := newDeclared, returnType := retTy }
 
 /-- Run a computation with a registered type alias -/
 def withTypeAlias {α : Type} (name : String) (def_ : TypeAliasDef) (m : TypeCheckM α) : TypeCheckM α :=

--- a/Thales/TypeCheck/Diagnostic.lean
+++ b/Thales/TypeCheck/Diagnostic.lean
@@ -67,6 +67,8 @@ inductive ThalesKind where
   | cannotAssignObjectProperty
   | cannotCallMutatingMethod (name : String)
   | cannotMutateCapturedVariable (name : String)
+  | assignmentInExpressionPosition
+  | mutationInThrowsContext (name : String)
   | loopNotSupported
   | asyncNotSupported
   | anyNotPermitted
@@ -110,6 +112,8 @@ def ThalesKind.thCode : ThalesKind → Nat
   | .cannotAssignObjectProperty => 3
   | .cannotCallMutatingMethod _ => 4
   | .cannotMutateCapturedVariable _ => 5
+  | .assignmentInExpressionPosition => 6
+  | .mutationInThrowsContext _ => 7
   | .loopNotSupported => 10
   | .asyncNotSupported => 12
   | .anyNotPermitted => 20
@@ -148,6 +152,10 @@ def ThalesKind.message : ThalesKind → String
   | .cannotAssignObjectProperty => "Cannot assign to object property; construct a new object"
   | .cannotCallMutatingMethod name => s!"Cannot call mutating method '{name}'"
   | .cannotMutateCapturedVariable name => s!"Cannot mutate variable '{name}' captured by enclosing scope"
+  | .assignmentInExpressionPosition =>
+    "Assignment and update expressions are only supported as statements; assign in a separate statement"
+  | .mutationInThrowsContext name =>
+    s!"Cannot mutate variable '{name}' inside a `@throws` function or `try`/`catch`"
   | .loopNotSupported => "Loop not supported; use recursion or array methods"
   | .asyncNotSupported => "async/await not supported"
   | .anyNotPermitted => "'any' is not permitted"

--- a/Thales/TypeCheck/Synth.lean
+++ b/Thales/TypeCheck/Synth.lean
@@ -412,9 +412,16 @@ partial def synthJSExpr (expr : Expression) (expected : Option TSType := none) :
       let rightTyped ← synthJSExpr right
       return { expr := .js expr, type := leftTyped.type, children := #[leftTyped, rightTyped] }
 
-  -- Assignment expressions
-  | .assignmentExpr _ _ left right =>
-    let rightTyped ← synthJSExpr right
+  -- Assignment expressions. Compound `x OP= y` types as `x = x OP y`
+  -- (#24): the synthesized RHS is the desugared binary expression, so
+  -- checking reuses the binary-op paths (e.g. `s += 1` on a string is
+  -- string concatenation, not a raw-RHS-vs-declared mismatch).
+  | .assignmentExpr b op left right =>
+    let effectiveRHS : Expression :=
+      match op.compoundToBinary with
+      | some binOp => .binaryExpr b binOp left right
+      | none => right
+    let rightTyped ← synthJSExpr effectiveRHS
     -- LHS legality (TS2540 / TS2588 / TS2364) — emit before RHS-vs-declared check.
     match ← classifyAssignTarget synthJSExpr left with
     | some kind => emitDiagnostic kind (exprLoc left)

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -100,7 +100,11 @@ forms:
 - reassignment of a `let` declared without an initializer
   (`let x: number; x = 1;` — give it an initializer instead);
 - reassignment of a variable whose narrowing the emitter relies on
-  (null-tested or refinement-predicate-tested in a condition).
+  (null-tested or refinement-predicate-tested in a condition);
+- mutation inside arrow/function-expression bodies (only declared
+  functions lower through the do-mode path in v1);
+- mutation in a function containing a `switch` shape do-mode cannot lower
+  (an arm that falls through via `break`, or a `default` arm).
 
 [Details in subset.md#th0001--cannot-reassign-variable](./subset.md#th0001--cannot-reassign-variable)
 

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -100,11 +100,20 @@ forms:
 - reassignment of a `let` declared without an initializer
   (`let x: number; x = 1;` — give it an initializer instead);
 - reassignment of a variable whose narrowing the emitter relies on
-  (null-tested or refinement-predicate-tested in a condition);
+  (null- or undefined-tested, or refinement-predicate-tested, in a
+  condition);
 - mutation inside arrow/function-expression bodies (only declared
   functions lower through the do-mode path in v1);
 - mutation in a function containing a `switch` shape do-mode cannot lower
-  (an arm that falls through via `break`, or a `default` arm).
+  (an arm that falls through via `break`, a `default` arm, or a scrutinee
+  that is not a discriminated-union field access);
+- mutation in a function whose body contains `try`/`catch` — the exception
+  path emits pure `Except` match-chains do-mode cannot thread through
+  (mutation _inside_ the `try` is the separate TH0007);
+- mutation in a function that reads a null/undefined-tested or
+  predicate-tested variable outside its test: the pure path bakes that
+  narrowing into its `match`/`dite` lowering, and do-mode carries no such
+  evidence, so the whole function stays on the pure path.
 
 [Details in subset.md#th0001--cannot-reassign-variable](./subset.md#th0001--cannot-reassign-variable)
 
@@ -177,7 +186,7 @@ return n - 1; // instead of `return n++;`
 
 ### TH0007 — Cannot mutate inside `@throws` or `try`/`catch`
 
-**Message:** `Cannot mutate variable inside a \`@throws\` function or \`try\`/\`catch\``
+**Message:** ``Cannot mutate variable inside a `@throws` function or `try`/`catch` ``
 
 Rejected: mutation in the body of a `@throws`-annotated function, or
 anywhere under a `try`/`catch`.

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -49,6 +49,8 @@ soundness check).
 | TH0003 | Mutation     | Cannot assign to object property                    |
 | TH0004 | Mutation     | Cannot call mutating method                         |
 | TH0005 | Mutation     | Cannot mutate variable captured by enclosing scope  |
+| TH0006 | Mutation     | Assignment only supported in statement position     |
+| TH0007 | Mutation     | Cannot mutate inside `@throws` or `try`/`catch`     |
 | TH0010 | Control flow | Loop not supported                                  |
 | TH0012 | Control flow | async/await not supported                           |
 | TH0020 | Types        | `any` not permitted                                 |
@@ -89,7 +91,16 @@ will grow over time.
 
 **Message:** `Cannot reassign variable`
 
-Rejected: `let x = 0; x = 1;`
+Since #24, function-local non-escaping mutation is **in subset** (emitted
+as `Id.run do` with `let mut`). TH0001 now covers only the still-rejected
+forms:
+
+- module-level reassignment: `let x = 0; x = 1;` at the top level;
+- logical assignment operators (`&&=`, `||=`, `??=`);
+- reassignment of a `let` declared without an initializer
+  (`let x: number; x = 1;` — give it an initializer instead);
+- reassignment of a variable whose narrowing the emitter relies on
+  (null-tested or refinement-predicate-tested in a condition).
 
 [Details in subset.md#th0001--cannot-reassign-variable](./subset.md#th0001--cannot-reassign-variable)
 
@@ -131,7 +142,47 @@ Rejected: `arr.push(42);`
 
 Rejected: `let sum = 0; arr.forEach(x => { sum += x; });`
 
+A binding is mutable only when every reference to it (read _or_ write)
+occurs in the declaring function's own body. JS closures capture the live
+binding; Lean's `let mut` cannot be captured at all, and a read-only
+capture of a mutated variable would silently snapshot the value. Mutating
+a variable declared in an enclosing scope, or mutating a variable that any
+nested function/arrow mentions, is rejected. Workaround: restructure so
+the nested function takes the value as a parameter or returns the update.
+
 [Details in subset.md#th0005--cannot-mutate-variable-captured-by-enclosing-scope](./subset.md#th0005--cannot-mutate-variable-captured-by-enclosing-scope)
+
+---
+
+### TH0006 — Assignment only supported in statement position
+
+**Message:** `Assignment and update expressions are only supported as statements; assign in a separate statement`
+
+Rejected: `const y = (n = 1);`, `f(n += 1)`, `return n++;`
+
+Assignment and update expressions produce values in JavaScript, but the
+Thales subset treats mutation as a statement-level effect. Split the
+mutation into its own statement:
+
+```ts
+n++;
+return n - 1; // instead of `return n++;`
+```
+
+---
+
+### TH0007 — Cannot mutate inside `@throws` or `try`/`catch`
+
+**Message:** `Cannot mutate variable inside a \`@throws\` function or \`try\`/\`catch\``
+
+Rejected: mutation in the body of a `@throws`-annotated function, or
+anywhere under a `try`/`catch`.
+
+The `@throws` path emits pure `Except` match-chains; the mutation path
+emits `Id.run do` blocks. Unifying them is staged as a follow-up, mirroring
+how `@throws`/`@total` exclusivity was staged. Workaround: hoist the
+mutation into a helper function without `@throws`, or compute the value
+purely.
 
 ---
 

--- a/docs/subset.md
+++ b/docs/subset.md
@@ -6,7 +6,7 @@ Thales-TS 0.6 is a pure-functional subset of TypeScript with a mechanical shallo
 
 v0.6 adds four built-in bounded number types (`Integer`, `Natural`, `Byte`, `Bit`) shipped via `@thales/prelude`. See the dedicated section below for details.
 
-Thales-TS is **not** full TypeScript. It excludes mutation, exceptions, async I/O, classes, and several advanced type constructs in order to keep every accepted program mechanically translatable to terminating, pure Lean 4 code. If your program compiles under `thales`, it has a Lean 4 image — and the behavior of the two paths is verified by the example corpus.
+Thales-TS is **not** full TypeScript. It excludes escaping mutation (function-local non-escaping mutation is in subset, emitted as `Id.run do`), unannotated exceptions, async I/O, classes, and several advanced type constructs in order to keep every accepted program mechanically translatable to terminating Lean 4 code. If your program compiles under `thales`, it has a Lean 4 image — and the behavior of the two paths is verified by the example corpus.
 
 ## Conformance contract
 
@@ -68,7 +68,7 @@ under `tests/conformance/reject/` for one canonical demonstration per `TH####` c
 | Tuples       | `[A, B]`, `[A, B, C]`, ... → Lean `×` / fixed structures                                                                                         |
 | Unions       | Discriminated unions (shared `kind` field of string-literal type) → Lean inductive; nullable unions (`T \| null`, `T \| undefined`) → `Option T` |
 | Generics     | Parametric only (`<T>`, `<T, U>`)                                                                                                                |
-| Values       | `const`, `let`, `var` — all bound once, never reassigned in 0.5                                                                                  |
+| Values       | `const`, `let`, `var`; function-local non-escaping mutation (`x = e`, `x OP= e`, `x++`/`x--`) emitted as `Id.run do` with `let mut` (#24)        |
 | Functions    | `function` declarations and `const f = (...) => ...` arrows                                                                                      |
 | Recursion    | Structural or with `@decreasing` hint; all functions must terminate in 0.5                                                                       |
 | Control flow | `if`/`else`, ternary, `switch` (exhaustive on a discriminated union)                                                                             |
@@ -86,21 +86,38 @@ Each restriction below is identified by a `TH####` diagnostic code produced by `
 
 **Category:** Mutation
 
-Rejected:
+Function-local non-escaping mutation is **in subset** since #24: a binding
+whose every reference (read or write) stays in the declaring function's own
+body may be reassigned, and the function lowers to `Id.run do` with
+`let mut`. Parameters count as initialized locals (mutating them never
+affects the caller). TH0001 covers the still-rejected forms:
+
+Rejected (module level):
 
 ```typescript
 let count = 0;
-count = count + 1;
+count = count + 1; // TH0001: top-level bindings stay immutable
 ```
 
-Idiomatic replacement:
+Also still rejected under TH0001:
+
+- the logical assignment operators `&&=`, `||=`, `??=` (short-circuit
+  semantics; deferred);
+- reassigning a `let` declared without an initializer (`let mut` needs
+  one — give the declaration an initial value);
+- reassigning a variable whose narrowing the emitter relies on
+  (null-tested or refinement-predicate-tested in a condition);
+- mutation inside arrow/function-expression bodies (only declared
+  functions lower through the do-mode path in v1);
+- mutation in a function containing a `switch` shape do-mode cannot lower
+  (an arm that falls through via `break`, or a `default` arm).
+
+Idiomatic replacement where mutation stays rejected:
 
 ```typescript
 const count = 0;
 const nextCount = count + 1;
 ```
-
-Lean 4 bindings (`let` in `do`-notation and top-level `def`) are immutable. There is no direct shallow embedding for mutable locals; introducing one would require wrapping every function body in `Id.run do`, which is deferred to 1.5.
 
 ---
 

--- a/docs/subset.md
+++ b/docs/subset.md
@@ -106,11 +106,20 @@ Also still rejected under TH0001:
 - reassigning a `let` declared without an initializer (`let mut` needs
   one — give the declaration an initial value);
 - reassigning a variable whose narrowing the emitter relies on
-  (null-tested or refinement-predicate-tested in a condition);
+  (null- or undefined-tested, or refinement-predicate-tested, in a
+  condition);
 - mutation inside arrow/function-expression bodies (only declared
   functions lower through the do-mode path in v1);
 - mutation in a function containing a `switch` shape do-mode cannot lower
-  (an arm that falls through via `break`, or a `default` arm).
+  (an arm that falls through via `break`, a `default` arm, or a scrutinee
+  that is not a discriminated-union field access);
+- mutation in a function whose body contains `try`/`catch` (the exception
+  path emits pure `Except` match-chains do-mode cannot thread through;
+  mutation _inside_ the `try` is the separate TH0007);
+- mutation in a function that reads a null/undefined-tested or
+  predicate-tested variable outside its test (the pure path bakes that
+  narrowing into its `match`/`dite` lowering; do-mode carries no such
+  evidence).
 
 Idiomatic replacement where mutation stays rejected:
 

--- a/docs/test262.md
+++ b/docs/test262.md
@@ -50,7 +50,7 @@ on demand).
 
 ## Baseline
 
-thales `98610ec`, test262 `fc32f3e8`, 2026-06-10:
+thales `3f11f4a` (after #24 mutation widening), test262 `fc32f3e8`, 2026-06-10:
 
 ```
 Slice                                             Total  Skip   OoS  Pass  Fail  InSubset   Pass%
@@ -78,28 +78,44 @@ Skip reasons (all slices):
 Top blocking diagnostics (tests blocked, by attribution):
 Code              Shim   Body  Unknown
 TS2339            1179    895        0
-TH0001            1179    451        0
+TH0001            1179    213        0
 TS2304            1179     77        0
 TH0030            1179     48        0
+TH0007            1179     18        0
 TH0063            1179      2        0
 TH0021            1179      0        0
 TH0031            1179      0        0
 TH0060            1179      0        0
+TS2322            1179      0        0
 TS2349            1179      0        0
 TH0010               0    765        0
+TH0005               0    171        0
 TH0002               0    150        0
 parse-error          0      0      142
+TH0006               0     78        0
 TH0003               0     36        0
 TS2364               0     12        0
 TH0004               0      5        0
 ```
 
-Reading the baseline: every runnable test is blocked at minimum by the
-shim (1,179 tests; classes/namespaces — TH0030/TH0031 et al., plus the
-spurious TS2304s of #31). The dominant body blockers are loops (TH0010,
-765 tests) and mutation (TH0001, 451) — precisely the #24–#26 widening
-targets. `parse-error` counts tests where thales hard-fails without a
-structured diagnostic (e.g. multi-declarator `var x, y;`).
+Reading the baseline: every runnable test is still blocked at minimum by
+the shim (1,179 tests; classes/namespaces — TH0030/TH0031 et al., plus
+the spurious TS2304s of #31), which is why Pass% stays n/a — #24 alone
+cannot move it. The #24 movement is in the body attribution: **TH0001
+dropped 451 → 213**, with the remainder reclassified into the new precise
+codes — TH0005 (captured mutation, 171), TH0006 (expression-position
+assignment, 78), TH0007 (mutation under throws/try, 18) — and the truly
+in-subset mutations absorbed into tests still blocked by other constructs.
+Loops (TH0010, 765) remain the dominant body blocker, next up in #25/#26.
+`parse-error` counts tests where thales hard-fails without a structured
+diagnostic (e.g. multi-declarator `var x, y;`).
+
+New shim-attribution row vs the pre-#24 baseline: TS2322 — #24's
+declared-type precision (unannotated/const bindings are no longer `any`)
+exposes a pre-existing truthy-narrowing gap at `harness/assert.ts:34`
+(`if (basic) return basic;` on a nullable: tsc narrows, thales doesn't
+strip the null arm). Tracked with the flow-fidelity follow-ups (#38);
+shim-compilation blockers overall are #31.
 
 This table is updated manually when a feature lands; the per-directory
 numbers are the metric quoted in #24–#29.

--- a/tests/conformance/accept/bitwise-ops.ts
+++ b/tests/conformance/accept/bitwise-ops.ts
@@ -1,0 +1,13 @@
+// JS bitwise and % semantics (#32): operands truncate to 32-bit integers
+// (ToInt32/ToUint32), shift counts mask to 5 bits, % keeps the dividend's
+// sign. Expected values are Node's output.
+console.log(5 & 3);
+console.log(5 | 3);
+console.log(5 ^ 3);
+console.log(1 << 4);
+console.log(-16 >> 2);
+console.log(-16 >>> 28);
+console.log(5.7 & 3);
+console.log(7 % 3);
+console.log(-7 % 3);
+console.log(5.5 % 2);

--- a/tests/conformance/accept/counter-bitwise-compound.ts
+++ b/tests/conformance/accept/counter-bitwise-compound.ts
@@ -1,0 +1,12 @@
+// #24: bitwise and % compound assignment, desugared through the
+// JS-semantics runtime helpers (#32).
+function mask(): number {
+  let bits = 0;
+  bits |= 5;
+  bits &= 6;
+  bits ^= 3;
+  bits <<= 2;
+  bits %= 7;
+  return bits;
+}
+console.log(mask());

--- a/tests/conformance/accept/counter-branching.ts
+++ b/tests/conformance/accept/counter-branching.ts
@@ -1,0 +1,19 @@
+// #24: branching + early return with mutation. The no-else `if` keeps its
+// mutation visible after the branch; the early return is do-notation's
+// native `return`.
+function classify(score: number): number {
+  let bonus = 0;
+  if (score < 0) {
+    return -1;
+  }
+  if (score > 50) {
+    bonus += 10;
+  } else {
+    bonus += 1;
+  }
+  bonus += score;
+  return bonus;
+}
+console.log(classify(-5));
+console.log(classify(60));
+console.log(classify(10));

--- a/tests/conformance/accept/counter-compound.ts
+++ b/tests/conformance/accept/counter-compound.ts
@@ -1,0 +1,20 @@
+// #24's headline example: ++ and compound assignment desugar to
+// `x = x OP y` and lower through `Id.run do`.
+function count(): number {
+  let n = 0;
+  n++;
+  n += 2;
+  return n;
+}
+// The arithmetic compound family; values chosen to stay within the
+// runtime's number-formatting subset (no >6-decimal results).
+function scale(): number {
+  let m = 10;
+  m -= 1;
+  m *= 4;
+  m /= 8;
+  m **= 2;
+  return m;
+}
+console.log(count());
+console.log(scale());

--- a/tests/conformance/accept/counter-reassign.ts
+++ b/tests/conformance/accept/counter-reassign.ts
@@ -1,0 +1,8 @@
+// #24: straight-line local reassignment lowers to `Id.run do` / `let mut`.
+function inc(): number {
+  let n = 0;
+  n = n + 1;
+  n = n + 2;
+  return n;
+}
+console.log(inc());

--- a/tests/conformance/accept/param-mutation.ts
+++ b/tests/conformance/accept/param-mutation.ts
@@ -1,0 +1,10 @@
+// #24: parameter mutation. JS parameters are mutable locals whose
+// mutation never affects the caller; emitted via self-shadowing
+// (`let mut x := x`).
+function clampToTen(x: number): number {
+  x = x > 10 ? 10 : x;
+  x += 1;
+  return x;
+}
+console.log(clampToTen(20));
+console.log(clampToTen(3));

--- a/tests/conformance/accept/switch-mutation.ts
+++ b/tests/conformance/accept/switch-mutation.ts
@@ -1,0 +1,19 @@
+// #24: discriminated-union switch inside a do-mode body. Every arm
+// returns (do-mode's v1 switch shape), and the arms mutate a local.
+type Shape = { kind: 'circle'; r: number } | { kind: 'square'; s: number };
+
+function scaledArea(shape: Shape): number {
+  let area = 0;
+  switch (shape.kind) {
+    case 'circle':
+      area = 3 * shape.r * shape.r;
+      area += 1;
+      return area;
+    case 'square':
+      area = shape.s * shape.s;
+      return area;
+  }
+}
+
+console.log(scaledArea({ kind: 'circle', r: 2 }));
+console.log(scaledArea({ kind: 'square', s: 4 }));

--- a/tests/conformance/accept/total-mutation.ts
+++ b/tests/conformance/accept/total-mutation.ts
@@ -1,0 +1,10 @@
+// #24 + @total: `Id.run do` without loops is total, so the lake-backed
+// termination verification accepts a mutating body as a plain `def`.
+/** @total */
+function count(): number {
+  let n = 0;
+  n++;
+  n += 2;
+  return n;
+}
+console.log(count());

--- a/tests/conformance/mirror/assign-violates-declared-type.ts
+++ b/tests/conformance/mirror/assign-violates-declared-type.ts
@@ -1,0 +1,9 @@
+// Mirror-of-tsc example: assignment RHS must be assignable to the
+// variable's declared type (here the widened initializer type, number).
+// Both tsc and thales report TS2322 at the assignment line.
+function f(): number {
+  let n = 0;
+  n = 'not a number';
+  return n;
+}
+console.log(f());

--- a/tests/conformance/reject/0001-mutate-undefined-tested.ts
+++ b/tests/conformance/reject/0001-mutate-undefined-tested.ts
@@ -1,0 +1,12 @@
+// Subset-rejected example: mutating a variable whose narrowing the
+// emitter relies on (TH0001) — undefined tests count the same as null
+// tests (#42), since the emitter lowers `string | undefined` to Option
+// and bakes the test into its match/if lowering.
+function f(x: string | undefined): number {
+  if (x === undefined) {
+    // @thales-expect-error TH0001
+    x = 'fallback';
+  }
+  return x.length;
+}
+console.log(f('word'));

--- a/tests/conformance/reject/0001-mutation-beside-try.ts
+++ b/tests/conformance/reject/0001-mutation-beside-try.ts
@@ -1,0 +1,23 @@
+// Subset-rejected example: mutation in a function containing try/catch (TH0001).
+// tsc accepts; thales rejects: the exception path emits pure Except
+// match-chains, which do-mode mutation cannot thread through (#41) — a
+// try/catch anywhere in the body keeps the whole function out of do-mode.
+// (Mutation INSIDE the try is the separate TH0007.)
+/** @throws RangeError */
+function half(x: number): number {
+  if (x < 0) {
+    throw new RangeError('negative');
+  }
+  return x / 2;
+}
+function f(x: number): number {
+  let n = 0;
+  // @thales-expect-error TH0001
+  n = 5;
+  try {
+    return half(x);
+  } catch (e) {
+    return n;
+  }
+}
+console.log(f(4));

--- a/tests/conformance/reject/0001-mutation-narrowed-read.ts
+++ b/tests/conformance/reject/0001-mutation-narrowed-read.ts
@@ -1,0 +1,15 @@
+// Subset-rejected example: mutation in a function that reads a
+// null-tested variable outside its test (TH0001). The pure path bakes the
+// null test into an Option match; do-mode's plain `if` carries no
+// narrowing evidence (#40), so the whole function stays out of do-mode
+// and its mutation is rejected.
+function f(x: string | null): number {
+  let n = 0;
+  // @thales-expect-error TH0001
+  n += 1;
+  if (x === null) {
+    return n;
+  }
+  return x.length;
+}
+console.log(f('abc'));

--- a/tests/conformance/reject/0001-reassign-variable.ts
+++ b/tests/conformance/reject/0001-reassign-variable.ts
@@ -1,5 +1,6 @@
-// Subset-rejected example: variable reassignment (TH0001).
-// tsc accepts; thales rejects because locals are immutable in v1.
+// Subset-rejected example: module-level variable reassignment (TH0001).
+// tsc accepts; thales rejects because top-level bindings stay immutable —
+// only function-local non-escaping mutation is in the subset (#24).
 let counter = 0;
 // @thales-expect-error TH0001
 counter = counter + 1;

--- a/tests/conformance/reject/0005-mutate-captured.ts
+++ b/tests/conformance/reject/0005-mutate-captured.ts
@@ -1,0 +1,13 @@
+// Subset-rejected example: mutating a variable captured by a closure (TH0005).
+// tsc accepts; thales rejects because Lean's `let mut` cannot be captured —
+// a binding is mutable only if no nested function/arrow references it.
+function f(): number {
+  let n = 0;
+  const bump = () => {
+    // @thales-expect-error TH0005
+    n = n + 1;
+  };
+  bump();
+  return n;
+}
+console.log(f());

--- a/tests/conformance/reject/0006-assignment-expression.ts
+++ b/tests/conformance/reject/0006-assignment-expression.ts
@@ -1,0 +1,9 @@
+// Subset-rejected example: assignment in expression position (TH0006).
+// tsc accepts; thales treats mutation as a statement-level effect only.
+function f(): number {
+  let n = 0;
+  // @thales-expect-error TH0006
+  const y = (n = 1);
+  return y;
+}
+console.log(f());

--- a/tests/conformance/reject/0007-mutation-in-throws.ts
+++ b/tests/conformance/reject/0007-mutation-in-throws.ts
@@ -1,0 +1,14 @@
+// Subset-rejected example: mutation inside try/catch (TH0007).
+// tsc accepts; thales rejects because the exception path emits pure
+// Except match-chains, which do-mode mutation cannot thread through yet.
+function f(x: number): number {
+  let n = 0;
+  try {
+    // @thales-expect-error TH0007
+    n = x;
+  } catch (e) {
+    return 0;
+  }
+  return n;
+}
+console.log(f(2));


### PR DESCRIPTION
Closes #24. Also fixes #32 (bitwise/`%` binops emitted Lean with no Float instances), and fixes #40, #41, #42 (do-mode lowerability gating, found in review on this branch).

Function-local non-escaping mutation — reassignment, `++`/`--`, and the compound assignment family — is now in subset, emitted as `Id.run do` with `let mut`. Eligibility follows the escape-analysis rule from the issue; the still-rejected forms get precise codes (TH0005 captured, TH0006 expression position, TH0007 throws/try). The checker grew tsc-mirrored declared types, post-assignment flow updates, and branch joins, all pinned against live tsc output.

Beyond per-variable eligibility, `MutationInfo.doModeLowerable` is the function-level gate both SubsetCheck's mutation routing and `emitFuncDecl` consult (#40–#42): bodies containing a try/catch, an unlowerable switch shape, or a read of a narrow-tested variable outside its test stay on the pure path and their mutation is TH0001. `emitBodyDo` fails loudly on anything it can't lower instead of dropping statements.

Conformance corpus: 74 → 89, all passing. test262 TH0001 body-blockers: 451 → 213 (`docs/test262.md` updated). Deferred work is tracked in #33–#38.

The three pre-existing emitter miscompiles found in the same review are fixed in a PR stack on this branch — merge in order after this one: #46 (negated null-test narrowing, fixes #43) → #47 (TH0041 switch shapes, fixes #44) → #48 (TH0032 shadowing, fixes #45).

## Test plan
- [x] `lake build && lake build ThalesTest`
- [x] `node scripts/run-examples.js --self-test` (18/18) and full corpus (89/89 at this branch tip; 93/93 at the stack tip)
- [x] `node scripts/run-test262.js` re-measure vs baseline