### PR TITLE
Lower negated null/undefined tests to swapped Option match arms

### DIFF
--- a/Test/Emit/NarrowingEmitTest.lean
+++ b/Test/Emit/NarrowingEmitTest.lean
@@ -1,0 +1,74 @@
+/-
+  Test/Emit/NarrowingEmitTest.lean
+  Pins the null/undefined-test `if` lowering on the pure path (#43): a
+  positive test (`x === null`) lowers to an Option match with the THEN
+  branch in the none arm; a negated test (`x !== null`) swaps the arms so
+  the THEN branch gets the some-rebinding. Both forms require the THEN
+  branch to return on every path; otherwise the plain-ite fallback is kept.
+-/
+import Thales.Emit.Lean
+import Thales.Parser.Native
+
+open Thales.Emit
+open Thales.Parser
+
+private def containsSubstr (hay needle : String) : Bool :=
+  (hay.splitOn needle).length ≥ 2
+
+def expectEmitN (src : String) (needles : List String) (forbidden : List String := []) : IO Unit := do
+  match parseTSSourceNative src with
+  | .error e => throw (IO.userError s!"parse: {e}")
+  | .ok prog =>
+    let out := emit prog "M"
+    for n in needles do
+      unless containsSubstr out n do
+        throw (IO.userError s!"missing '{n}' in:\n{out}")
+    for n in forbidden do
+      if containsSubstr out n then
+        throw (IO.userError s!"unexpected '{n}' in:\n{out}")
+
+-- positive test: none arm is the THEN branch, continuation rebinds via some
+def testPositiveNullMatch : IO Unit :=
+  expectEmitN
+    "function a(x: string | null): number { if (x === null) { return 0; } return x.length; }
+console.log(a(\"hi\"));"
+    ["match x with", "| .none =>", "| .some x =>", "x.length.toFloat"]
+
+-- negated test (#43): arms swap — THEN gets the some-rebinding, so the
+-- narrowed read compiles
+def testNegatedNullMatch : IO Unit :=
+  expectEmitN
+    "function b(x: string | null): number { if (x !== null) { return x.length; } return 0; }
+console.log(b(\"hi\"));"
+    ["match x with", "| .some x =>", "x.length.toFloat", "| .none =>", "0.000000"]
+    (forbidden := ["if x.isSome"])
+
+-- negated undefined test lowers the same way
+def testNegatedUndefinedMatch : IO Unit :=
+  expectEmitN
+    "function c(x: string | undefined): number { if (x !== undefined) { return x.length; } return 0; }
+console.log(c(\"hi\"));"
+    ["match x with", "| .some x =>", "x.length.toFloat"]
+    (forbidden := ["if x.isSome"])
+
+-- reversed operand order
+def testNegatedReversedOperands : IO Unit :=
+  expectEmitN
+    "function d(x: string | null): number { if (null !== x) { return x.length; } return 0; }
+console.log(d(\"hi\"));"
+    ["match x with", "| .some x =>"]
+
+-- a THEN branch that does not return keeps the ite fallback (the match
+-- arms carry no continuation, so fall-through would skip it)
+def testNonReturningThnFallsBack : IO Unit :=
+  expectEmitN
+    "function e(x: string | null): number { if (x !== null) { const y = 1; } return 0; }
+console.log(e(\"hi\"));"
+    ["if x.isSome"]
+    (forbidden := ["match x with"])
+
+#eval testPositiveNullMatch
+#eval testNegatedNullMatch
+#eval testNegatedUndefinedMatch
+#eval testNegatedReversedOperands
+#eval testNonReturningThnFallsBack

--- a/Thales/Emit/Lean.lean
+++ b/Thales/Emit/Lean.lean
@@ -327,19 +327,29 @@ private partial def substMemberAccessStmt (scrutName : String) : Statement → S
         | d => d) k)
   | other => other
 
-/-- Extract the null-checked variable name from an `x === null` or `x === undefined` condition.
-    Returns `some varName` for `x === null`, `x === undefined`, `null === x`, `undefined === x`.
-    Returns `none` for other conditions. -/
-private def nullCheckVar : Expression → Option String
-  | .binaryExpr _ .seq (.identifier _ varName) (.literal _ .null _)
-  | .binaryExpr _ .eq  (.identifier _ varName) (.literal _ .null _)
-  | .binaryExpr _ .seq (.literal _ .null _)    (.identifier _ varName)
-  | .binaryExpr _ .eq  (.literal _ .null _)    (.identifier _ varName) => some varName
-  | .binaryExpr _ .seq (.identifier _ varName) (.identifier _ "undefined")
-  | .binaryExpr _ .eq  (.identifier _ varName) (.identifier _ "undefined")
-  | .binaryExpr _ .seq (.identifier _ "undefined") (.identifier _ varName)
-  | .binaryExpr _ .eq  (.identifier _ "undefined") (.identifier _ varName) =>
-    if varName != "undefined" then some varName else none
+/-- Extract the null/undefined-checked variable from an equality test
+    against `null` or `undefined` (either operand order). Returns the
+    variable name and the test's polarity: `true` for `===`/`==` (the THEN
+    branch is the nullish side), `false` for `!==`/`!=` (#43 — the THEN
+    branch is the narrowed, non-nullish side). Returns `none` for other
+    conditions. -/
+private def nullCheckVar : Expression → Option (String × Bool)
+  | .binaryExpr _ op l r =>
+    let polarity : Option Bool := match op with
+      | .seq | .eq => some true
+      | .sneq | .neq => some false
+      | _ => none
+    let isNullish : Expression → Bool
+      | .literal _ .null _ => true
+      | .identifier _ "undefined" => true
+      | _ => false
+    let subjectOf : Expression → Expression → Option String := fun a b =>
+      match a with
+      | .identifier _ n => if isNullish b && n != "undefined" then some n else none
+      | _ => none
+    match polarity with
+    | some pos => (subjectOf l r <|> subjectOf r l).map (·, pos)
+    | none => none
   | _ => none
 
 /-- If `targetTy` resolves through `aliasEnv` to a same-primitive literal
@@ -897,12 +907,30 @@ partial def emitBodyEnv (env : EmitEnv) : List Statement → LExpr
           .dite_ hName condExpr shadowed elseBody
       | none =>
         match nullCheckVar cond with
-        | some varName =>
+        | some (varName, positive) =>
             match env.bindingEnv.get? varName with
             | some (.option _) =>
-                let noneArm := (LPattern.ctor "none" [], emitBodyEnv env [thn])
-                let someArm := (LPattern.ctor "some" [.var varName], elseBody)
-                .match_ (.var varName) [noneArm, someArm]
+                -- The THEN branch becomes its own match arm WITHOUT the
+                -- continuation, so it must return on every path (the
+                -- early-return idiom); otherwise control would fall out of
+                -- the arm and the continuation — emitted only into the
+                -- other arm — would be skipped. Non-returning branches keep
+                -- the plain-ite fallback.
+                if EscapeAnalysis.stmtsReturn [thn] then
+                  let thnArm := emitBodyEnv env [thn]
+                  -- Positive test (`x === null`): THEN is the none arm and
+                  -- the continuation flows at the narrowed type via the
+                  -- some-arm rebinding. Negated (`x !== null`, #43): the
+                  -- arms swap — THEN gets the rebinding.
+                  let arms :=
+                    if positive then
+                      [(LPattern.ctor "none" [], thnArm),
+                       (LPattern.ctor "some" [.var varName], elseBody)]
+                    else
+                      [(LPattern.ctor "some" [.var varName], thnArm),
+                       (LPattern.ctor "none" [], elseBody)]
+                  .match_ (.var varName) arms
+                else fallback
             | _ => fallback
         | none => fallback
   | .blockStmt _ inner :: rest => emitBodyEnv env (inner ++ rest)

--- a/tests/conformance/accept/nullable-negated-test.ts
+++ b/tests/conformance/accept/nullable-negated-test.ts
@@ -1,0 +1,10 @@
+// #43: a negated null test lowers to an Option match with swapped arms,
+// so the branch reads the variable at its narrowed (unwrapped) type.
+function len(x: string | null): number {
+  if (x !== null) {
+    return x.length;
+  }
+  return -1;
+}
+console.log(len('abc'));
+console.log(len(null));


### PR DESCRIPTION
Fixes #43.

`nullCheckVar` now returns the test's polarity and covers `!==`/`!=` against `null` or `undefined` in either operand order. The pure path's `if` lowering swaps the Option match arms for negated tests, so the THEN branch gets the some-rebinding and narrowed reads elaborate at the unwrapped type. Both polarities are guarded on the THEN branch returning on every path — the match arms carry no continuation, so a fall-through branch keeps the plain-ite fallback instead of silently dropping the continuation (a latent variant of the same bug in the positive form).

New: `Test/Emit/NarrowingEmitTest.lean` (5 emission pins) and the `nullable-negated-test` accept fixture (byte-match verified).

**Stacked on #39** (first of three): the always-returns guard uses `EscapeAnalysis.stmtsReturn`, which #24 introduced. Merge after #39; #44/#45 PRs stack on this one purely to keep the diffs disjoint — there is no semantic dependency among the three fixes.