### PR TITLE
Reject unlowerable switch shapes with TH0041; lower default arms as the wildcard

### DIFF
--- a/Test/Emit/LeanEmitSwitchTest.lean
+++ b/Test/Emit/LeanEmitSwitchTest.lean
@@ -48,5 +48,22 @@ function f(t: T): number {
     if (out.splitOn "unreachable!").length ≥ 2 then
       throw (IO.userError s!"unexpected '| _ => unreachable!' tail in:\n{out}")
 
+def testDefaultLowersAsWildcard : IO Unit := do
+  -- A `default` arm becomes the wildcard arm's body (#44), not
+  -- `unreachable!`.
+  let src := "
+type T = {kind: 'a', x: number} | {kind: 'b', y: number};
+function f(t: T): number {
+  switch (t.kind) { case 'a': return t.x; default: return 0; }
+}"
+  expectEmit src "M" ["| .a x =>", "| _ =>", "0.000000"]
+  match parseTSSourceNative src with
+  | .error e => throw (IO.userError s!"parse: {e}")
+  | .ok prog =>
+    let out := emit prog "M"
+    if (out.splitOn "unreachable!").length ≥ 2 then
+      throw (IO.userError s!"unexpected 'unreachable!' in:\n{out}")
+
 #eval testSwitchToMatch
 #eval testNoUnreachableTailWhenExhaustive
+#eval testDefaultLowersAsWildcard

--- a/Test/Emit/SwitchCheckTest.lean
+++ b/Test/Emit/SwitchCheckTest.lean
@@ -1,6 +1,9 @@
 /-
   Test/Emit/SwitchCheckTest.lean
-  Verifies TH0040 switch exhaustiveness on discriminated unions.
+  Verifies TH0040 switch exhaustiveness on discriminated unions, and the
+  #44 TH0041 classification: shapes the emitter has no lowering for
+  (plain-identifier scrutinee, unresolvable binding, wrong field,
+  non-returning arm) are rejected instead of silently dropped.
 -/
 import Thales.Emit.SubsetCheck
 import Thales.Parser.Native
@@ -53,17 +56,125 @@ function f(s: S): number {
   }
 }") 40
 
-/-- For v1, if the type is not declared as a union or we can't see it,
-    no TH0040 fires. This is a safe-default test. -/
-def testUnknownDiscriminantNoFire : IO Unit := expectNoCode "
+/-- A plain-identifier scrutinee is not TH0040's business (no TH0040), but
+    since #44 it IS rejected as unlowerable (TH0041) — it used to be
+    silently dropped from the emitted Lean. -/
+def testUnknownDiscriminantNoFire : IO Unit := do
+  let src := "
 function f(s: string): number {
   switch (s) {
     case 'a': return 1;
     case 'b': return 2;
   }
-}" 40
+}"
+  expectNoCode src 40
+  expectCode src 41
+
+-- ── TH0041 classification (#44) ──
+
+-- non-returning arm (break) on a proper discriminated dispatch
+def testBreakArm41 : IO Unit := expectCode (unionTypeDecl ++ "
+function f(s: S): number {
+  switch (s.kind) {
+    case 'a': break;
+    case 'b': return 2;
+    case 'c': return 3;
+  }
+  return 0;
+}") 41
+
+-- empty grouped case label: its body list does not return
+def testGroupedCase41 : IO Unit := expectCode (unionTypeDecl ++ "
+function f(s: S): number {
+  switch (s.kind) {
+    case 'a':
+    case 'b': return 2;
+    case 'c': return 3;
+  }
+}") 41
+
+-- switch on a non-discriminator field
+def testWrongField41 : IO Unit := expectCode ("type P = {kind: 'a', x: number} | {kind: 'b', x: number};
+function f(p: P): number {
+  switch (p.x) {
+    case 'a': return 1;
+    case 'b': return 2;
+  }
+}") 41
+
+-- well-shaped discriminated dispatch: no TH0041
+def testDiscriminatedOk41 : IO Unit := expectNoCode (unionTypeDecl ++ "
+function f(s: S): number {
+  switch (s.kind) {
+    case 'a': return 1;
+    case 'b': return 2;
+    case 'c': return 3;
+  }
+}") 41
+
+-- default arm whose body returns: accepted (lowers as the wildcard arm)
+def testDefaultOk41 : IO Unit := expectNoCode (unionTypeDecl ++ "
+function f(s: S): number {
+  switch (s.kind) {
+    case 'a': return 1;
+    default: return 0;
+  }
+}") 41
+
+-- missing arm with no default stays TH0040, not TH0041
+def testNonExhaustiveNot41 : IO Unit := expectNoCode (unionTypeDecl ++ "
+function f(s: S): number {
+  switch (s.kind) {
+    case 'a': return 1;
+    case 'b': return 2;
+  }
+}") 41
+
+-- switch on an ANNOTATED LOCAL: the binding threads through the
+-- statement list, so the dispatch resolves and is accepted
+def testAnnotatedLocalOk41 : IO Unit := expectNoCode (unionTypeDecl ++ "
+function f(): number {
+  const s: S = { kind: 'a' };
+  switch (s.kind) {
+    case 'a': return 1;
+    case 'b': return 2;
+    case 'c': return 3;
+  }
+}") 41
+
+-- switch on an unannotated local: unresolvable scrutinee type
+def testUnannotatedLocal41 : IO Unit := expectCode (unionTypeDecl ++ "
+function f(): number {
+  const s = { kind: 'a' };
+  switch (s.kind) {
+    case 'a': return 1;
+    default: return 2;
+  }
+}") 41
+
+-- VOID function: a fall-through (break) arm is fine — the unit arm the
+-- emitter produces is the correct value, so no TH0041
+def testVoidBreakArmOk41 : IO Unit := expectNoCode (unionTypeDecl ++ "
+function f(s: S) {
+  switch (s.kind) {
+    case 'a':
+      console.log('a');
+      break;
+    case 'b': return;
+    case 'c': return;
+  }
+}") 41
 
 #eval testNonExhaustive
 #eval testExhaustiveOk
 #eval testExhaustiveWithDefault
 #eval testUnknownDiscriminantNoFire
+#eval testBreakArm41
+#eval testGroupedCase41
+#eval testWrongField41
+#eval testDiscriminatedOk41
+#eval testDefaultOk41
+#eval testNonExhaustiveNot41
+#eval testAnnotatedLocalOk41
+#eval testUnannotatedLocal41
+#eval testVoidBreakArmOk41

--- a/Thales/Emit/Lean.lean
+++ b/Thales/Emit/Lean.lean
@@ -935,17 +935,22 @@ partial def emitBodyEnv (env : EmitEnv) : List Statement → LExpr
         | none => fallback
   | .blockStmt _ inner :: rest => emitBodyEnv env (inner ++ rest)
   | .exprStmt _ _ :: rest      => emitBodyEnv env rest
-  | .switchStmt _ discriminant cases :: rest =>
+  | .switchStmt _ discriminant cases :: _ =>
+      -- SubsetCheck (TH0041) guarantees the discriminated `ident.field`
+      -- shape with all-return arms, so the code after the switch is dead
+      -- and a fallback that DROPS the switch is never correct — the
+      -- unresolved cases render the loud marker instead (#44).
+      let unlowered : LExpr := .var "(unsupported: switch not lowerable)"
       match discriminant with
       | .memberExpr _ (.identifier _ scrutName) (.identifier _ _fieldName) false _ =>
           match env.bindingEnv.get? scrutName with
-          | none => emitBodyEnv env rest
+          | none => unlowered
           | some rawTy =>
               let resolvedTy := resolveTypeAlias env rawTy
               match resolvedTy with
               | .union branches =>
                   match asDiscriminated branches with
-                  | none => emitBodyEnv env rest
+                  | none => unlowered
                   | some ctors =>
                       let arms : List (LPattern × LExpr) := cases.filterMap fun
                         | .mk _ (some (.literal _ (.string caseLit) _)) caseBody =>
@@ -959,12 +964,24 @@ partial def emitBodyEnv (env : EmitEnv) : List Statement → LExpr
                                 let bodyExpr := emitBodyEnv env substBody
                                 some (pat, bodyExpr)
                         | _ => none
+                      -- A `default` arm lowers as the wildcard arm (#44; it
+                      -- used to render `unreachable!`, a runtime panic on
+                      -- any uncovered constructor). Its body gets no field
+                      -- substitution — there is no single-constructor
+                      -- context — so field references in it fail loudly.
+                      let defaultBody? := cases.findSome? fun
+                        | .mk _ none ss => some ss
+                        | _ => none
                       let allArms :=
                         if arms.length >= ctors.length then arms
-                        else arms ++ [(.wildcard, .var "unreachable!")]
+                        else
+                          let wild : LExpr := match defaultBody? with
+                            | some ss => emitBodyEnv env ss
+                            | none => .var "unreachable!"
+                          arms ++ [(.wildcard, wild)]
                       .match_ (.var scrutName) allArms
-              | _ => emitBodyEnv env rest
-      | _ => emitBodyEnv env rest
+              | _ => unlowered
+      | _ => unlowered
   | .throwStmt _ arg :: _ =>
       if env.throwTypes.isEmpty then
         -- SubsetCheck already flagged TH0060.

--- a/Thales/Emit/SubsetCheck.lean
+++ b/Thales/Emit/SubsetCheck.lean
@@ -17,10 +17,14 @@ open Thales.TypeCheck
 
 /-- Environment for switch exhaustiveness checking.
     aliasEnv maps type alias names to their resolved TSType.
-    bindingEnv maps identifier names to their declared TSType. -/
+    bindingEnv maps identifier names to their declared TSType.
+    voidReturn is true inside a function with no value to return — its
+    switch arms may legitimately fall through (`break`), since the unit
+    arm the emitter produces is the correct value. -/
 structure SwitchEnv where
   aliasEnv   : Std.HashMap String TSType := {}
   bindingEnv : Std.HashMap String TSType := {}
+  voidReturn : Bool := false
 
 /-- Method names that mutate their receiver. -/
 private def mutatingMethodNames : List String :=
@@ -404,30 +408,43 @@ private def discriminatorInfo (branches : List TSType) : Option (String × List 
       if allValues.length != branches.length then return none
       return some (discField, allValues)
 
-/-- Check a single switch statement for TH0040 exhaustiveness.
-    Returns a diagnostic if the switch on a discriminated union is non-exhaustive. -/
-private def checkSwitchExhaustive
+/-- Classify a switch statement (#44). Returns TH0041 when the emitter has
+    no lowering for its shape: the scrutinee must be a non-computed
+    `ident.field` access whose binding resolves to a discriminated union
+    keyed on that field, and every arm (including `default`) must return
+    on every control path — the lowering turns arms into match-arm
+    expressions with no continuation, so anything else used to be silently
+    dropped or miscompiled. Returns TH0040 for a well-shaped but
+    non-exhaustive switch; `none` means the switch is lowerable. -/
+private def classifySwitch
     (env : SwitchEnv) (loc : Option SourceLocation)
     (discriminant : Expression) (cases : List SwitchCase) : Option Diagnostic :=
-  -- Pattern: switch (ident.field) where computed=false
+  let notLowerable := some (mkThalesDiag .switchNotLowerable loc)
+  -- In a value-returning function every arm must return (the lowering
+  -- turns arms into match-arm expressions with no continuation); in a
+  -- void function a fall-through arm's unit value is already correct.
+  if !env.voidReturn
+      && cases.any (fun (SwitchCase.mk _ _ ss) => !EscapeAnalysis.stmtsReturn ss) then
+    notLowerable
+  else
   match discriminant with
   | .memberExpr _ (.identifier _ scrutName) (.identifier _ fieldName) false _ =>
     -- Look up the type of scrutName in the binding environment
     match env.bindingEnv.get? scrutName with
-    | none => none
+    | none => notLowerable
     | some rawTy =>
       -- Resolve through aliases
-      let resolvedTy := resolveType env.aliasEnv rawTy
-      match resolvedTy with
+      match resolveType env.aliasEnv rawTy with
       | .union branches =>
         -- Get discriminator info
         match discriminatorInfo branches with
-        | none => none
+        | none => notLowerable
         | some (discField, expectedLiterals) =>
           -- The switch must be on the discriminator field
-          if discField != fieldName then none
+          if discField != fieldName then notLowerable
           else
-            -- Check for a default arm (exhaustive by definition)
+            -- A `default` arm makes the switch exhaustive by definition
+            -- (the emitter lowers its body as the wildcard arm).
             let hasDefault := cases.any fun (SwitchCase.mk _ test _) => test.isNone
             if hasDefault then none
             else
@@ -440,21 +457,37 @@ private def checkSwitchExhaustive
               let missing := expectedLiterals.filter fun s => !coveredLiterals.contains s
               if missing.isEmpty then none
               else some (mkThalesDiag (.switchNotExhaustive missing) loc)
-      | _ => none
-  | _ => none
+      | _ => notLowerable
+  | _ => notLowerable
+
+/-- Thread annotated `let`/`const`/`var` declarations into the switch
+    checker's binding environment so a switch on an annotated local
+    resolves (the emitter threads the same annotations). -/
+private def bindSwitchDecls (env : SwitchEnv) : Statement → SwitchEnv
+  | .variableDecl (.mk _ decls _) =>
+      decls.foldl (fun e d =>
+        match d with
+        | .mk _ (.identifier id) _ (some ty) =>
+            { e with bindingEnv := e.bindingEnv.insert id.name ty }
+        | _ => e) env
+  | _ => env
 
 /-- Walk a statement body checking for switch exhaustiveness violations.
     Uses the provided SwitchEnv for identifier lookups. -/
 partial def checkSwitchStmt (env : SwitchEnv) (stmt : Statement) : Array Diagnostic :=
   match stmt with
   | .blockStmt _ body =>
-    body.foldl (fun acc s => acc ++ checkSwitchStmt env s) #[]
+    -- Thread annotated declarations through the statement list so later
+    -- switches on annotated locals resolve.
+    (body.foldl (fun (st : Array Diagnostic × SwitchEnv) s =>
+      let (acc, env) := st
+      (acc ++ checkSwitchStmt env s, bindSwitchDecls env s)) (#[], env)).1
   | .ifStmt _ _ consequent alternate =>
     checkSwitchStmt env consequent
       ++ (match alternate with | some s => checkSwitchStmt env s | none => #[])
   | .switchStmt b discriminant cases =>
     let switchDiag : Array Diagnostic :=
-      match checkSwitchExhaustive env b.loc discriminant cases with
+      match classifySwitch env b.loc discriminant cases with
       | some d => #[d]
       | none => #[]
     -- Also recurse into case bodies for nested switches
@@ -584,14 +617,18 @@ def checkTSStmt (ts : TSStatement) : Array Diagnostic :=
   | .declareStmt _ inner => checkTSStmt inner
   | .importDecl _ _ _ => #[]
 
-/-- Check a TS-level statement for switch exhaustiveness (TH0040).
-    Requires a SwitchEnv with type alias and binding information. -/
+/-- Check a TS-level statement for switch lowerability and exhaustiveness
+    (TH0041/TH0040). Requires a SwitchEnv with type alias and binding
+    information. -/
 def checkTSStmtSwitch (aliasEnv : Std.HashMap String TSType) (ts : TSStatement)
     : Array Diagnostic :=
   match ts with
-  | .annotatedFuncDecl _ _ _ params _ body _ _ _ _ =>
+  | .annotatedFuncDecl _ _ _ params returnType body _ _ _ _ =>
     let bindingEnv := buildParamEnv params
-    let env : SwitchEnv := { aliasEnv, bindingEnv }
+    let voidReturn := match returnType with
+      | none => true
+      | some ann => ann.type == .void_
+    let env : SwitchEnv := { aliasEnv, bindingEnv, voidReturn }
     checkSwitchStmt env body
   | .js s => checkSwitchStmt { aliasEnv, bindingEnv := {} } s
   | _ => #[]

--- a/Thales/TypeCheck/Diagnostic.lean
+++ b/Thales/TypeCheck/Diagnostic.lean
@@ -80,6 +80,7 @@ inductive ThalesKind where
   | classNotSupported
   | inheritanceNotSupported
   | switchNotExhaustive (missingKinds : List String)
+  | switchNotLowerable
   | cannotVerifyTermination (funcName : String)
   -- @throws / @total diagnostics (TH0060–TH0070)
   -- TH0061 (unusedThrowsAnnotation), TH0062 (untypedCatch), TH0064
@@ -125,6 +126,7 @@ def ThalesKind.thCode : ThalesKind → Nat
   | .classNotSupported => 30
   | .inheritanceNotSupported => 31
   | .switchNotExhaustive _ => 40
+  | .switchNotLowerable => 41
   | .cannotVerifyTermination _ => 50
   | .unannotatedThrow _ => 60
   | .nonRecordThrow => 63
@@ -168,6 +170,8 @@ def ThalesKind.message : ThalesKind → String
   | .inheritanceNotSupported => "Inheritance ('extends') is not supported"
   | .switchNotExhaustive missingKinds =>
     s!"Non-exhaustive switch on discriminated union (missing: {String.intercalate ", " missingKinds})"
+  | .switchNotLowerable =>
+    "Switch not supported here: dispatch on a discriminated-union field (e.g. `switch (shape.kind)`) with every arm ending in `return`"
   | .cannotVerifyTermination funcName =>
     s!"Cannot verify termination of '{funcName}'; add @decreasing hint or restructure"
   | .unannotatedThrow .fromThrow =>

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -62,6 +62,7 @@ soundness check).
 | TH0030 | Declarations | `class` not supported                               |
 | TH0031 | Declarations | Inheritance (`extends`) not supported               |
 | TH0040 | Matching     | Non-exhaustive switch on discriminated union        |
+| TH0041 | Matching     | Switch shape not lowerable                          |
 | TH0050 | Recursion    | Cannot verify termination                           |
 | TH0066 | Totality     | `@total` and `@throws` declared together            |
 | TH0067 | Totality     | `@total` function has uncaught throw                |
@@ -349,6 +350,26 @@ Rejected: `switch (u.kind) { case "a": ...; /* missing "b" */ }`
 [Details in subset.md#th0040--non-exhaustive-switch-on-discriminated-union](./subset.md#th0040--non-exhaustive-switch-on-discriminated-union)
 
 Permanent — all variants must be covered.
+
+---
+
+### TH0041 — Switch shape not lowerable
+
+**Message:** ``Switch not supported here: dispatch on a discriminated-union field (e.g. `switch (shape.kind)`) with every arm ending in `return` ``
+
+The emitter lowers exactly one switch shape: a non-computed
+`ident.field` scrutinee whose binding resolves to a discriminated union
+keyed on that field, with every arm (including `default`) returning on
+every control path. Anything else — a plain-identifier scrutinee
+(`switch (x)` on a `string`), an unannotated or unresolvable scrutinee
+binding, a non-union scrutinee type, a switch on a non-discriminator
+field, or an arm that falls through (`break`, empty grouped `case`
+labels) — is rejected. Previously these switches were silently dropped
+from the emitted Lean, producing wrong output. A `default` arm whose
+body returns is fine: it lowers as the wildcard match arm.
+
+Rejected: `switch (x) { case "a": return 1; case "b": return 2; }` on
+`x: string`.
 
 ---
 

--- a/tests/conformance/accept/switch-default-arm.ts
+++ b/tests/conformance/accept/switch-default-arm.ts
@@ -1,0 +1,16 @@
+// #44: a `default` arm on a discriminated-union switch lowers as the
+// wildcard match arm (it used to render `unreachable!` — a runtime panic
+// on any constructor not covered by a `case`).
+type Shape = { kind: 'circle'; r: number } | { kind: 'square'; s: number };
+
+function area(shape: Shape): number {
+  switch (shape.kind) {
+    case 'circle':
+      return 3 * shape.r * shape.r;
+    default:
+      return 0;
+  }
+}
+
+console.log(area({ kind: 'circle', r: 2 }));
+console.log(area({ kind: 'square', s: 4 }));

--- a/tests/conformance/reject/0041-switch-not-lowerable.ts
+++ b/tests/conformance/reject/0041-switch-not-lowerable.ts
@@ -1,0 +1,16 @@
+// Subset-rejected example: switch shape with no Lean lowering (TH0041).
+// tsc accepts; thales rejects because the emitter lowers exactly one
+// switch shape — a discriminated-union field dispatch with all-return
+// arms. A plain-identifier scrutinee used to be silently dropped from
+// the emitted Lean (#44).
+function f(x: string): number {
+  // @thales-expect-error TH0041
+  switch (x) {
+    case 'a':
+      return 1;
+    case 'b':
+      return 2;
+  }
+  return 0;
+}
+console.log(f('a'));

--- a/tests/conformance/reject/throws-in-switch-case.ts
+++ b/tests/conformance/reject/throws-in-switch-case.ts
@@ -4,6 +4,8 @@
 // that silently skipped `switchStmt`.
 
 function classify(x: number): string {
+  // Plain-identifier scrutinee: unlowerable switch shape (#44).
+  // @thales-expect-error TH0041
   switch (x) {
     case 0:
       return 'zero';


### PR DESCRIPTION
Fixes #44.

The emitter has exactly one switch lowering — a discriminated-union field dispatch — yet every other shape was silently dropped from the emitted Lean (accepted program, wrong output). `classifySwitch` now rejects them with the new TH0041: plain-identifier scrutinees, unresolvable or non-union scrutinee bindings, dispatch on a non-discriminator field, and (in value-returning functions) arms that do not return on every path. Void functions keep fall-through arms — their unit arm value is already correct. Annotated local declarations thread through the switch checker's binding environment, so `const s: Shape = …; switch (s.kind)` resolves the same way the emitter resolves it.

Two adjacent holes closed in the same family: a `default` arm now lowers as the wildcard match arm (it used to render `unreachable!` — a runtime panic on any constructor not covered by a `case`), and the pure path's switch fallbacks render the loud `(unsupported: …)` marker instead of dropping the statement.

New: 9 classification pins in `SwitchCheckTest`, a default-arm emission pin in `LeanEmitSwitchTest`, the `switch-default-arm` accept fixture (byte-match verified), and the `0041-switch-not-lowerable` reject fixture. The `throws-in-switch-case` fixture (plain-identifier scrutinee) now also declares TH0041.

**Stacked on #46** (second of three) to keep diffs disjoint; semantically independent of #43, but like it depends on #39's `EscapeAnalysis.stmtsReturn`.