### PR TITLE
Reject shadowing declarations with TH0032

### DIFF
--- a/Test/Emit/DeclarationCheckTest.lean
+++ b/Test/Emit/DeclarationCheckTest.lean
@@ -34,6 +34,45 @@ def testExtends : IO Unit := do
     unless diags.any (·.thalesCode? = some 31) do
       throw (IO.userError "expected TH0031 (extends not supported)")
 
+-- ── TH0032 shadowing (#45) ──
+
+def expectNoDeclCode (src : String) (code : Nat) : IO Unit := do
+  match parseTSSourceNative src with
+  | .error e => throw (IO.userError s!"parse: {e}")
+  | .ok prog =>
+    let diags := subsetCheck prog
+    if diags.any (·.thalesCode? = some code) then
+      let fmt := (diags.map (·.format "")).toList
+      throw (IO.userError s!"did not expect TH{code}, got: {fmt}")
+
+-- bare-block shadow of a function-level const
+def testBareBlockShadow : IO Unit := expectDeclCode
+  "function f(): number { const n = 0; { const n = 1; } return n; }" 32
+-- if-branch shadow (the pure path appends the continuation into branches)
+def testIfBranchShadow : IO Unit := expectDeclCode
+  "function f(c: boolean): number { const n = 0; if (c) { const n = 1; } return n; }" 32
+-- let shadowing a parameter from a nested block
+def testParamShadow : IO Unit := expectDeclCode
+  "function f(x: number): number { { let x = 1; return x; } }" 32
+-- arrow parameters and bodies are fresh scopes: no TH0032
+def testArrowParamNoShadow : IO Unit := expectNoDeclCode
+  "function f(): number { const y = 1; const g = (y: number): number => y + 1; return g(y); }" 32
+def testArrowBodyNoShadow : IO Unit := expectNoDeclCode
+  "function f(): number { const y = 1; const g = (): number => { const y = 2; return y; }; return g() + y; }" 32
+-- `var` re-declaration is the same function-scoped binding: no TH0032
+def testVarRedeclNoShadow : IO Unit := expectNoDeclCode
+  "function f(): number { var n = 0; { var n = 1; } return n; }" 32
+-- sibling scopes don't shadow each other
+def testSiblingBlocksNoShadow : IO Unit := expectNoDeclCode
+  "function f(c: boolean): number { if (c) { const k = 1; return k; } const k = 2; return k; }" 32
+
 #eval testClassDecl
 #eval testClassExpr
 #eval testExtends
+#eval testBareBlockShadow
+#eval testIfBranchShadow
+#eval testParamShadow
+#eval testArrowParamNoShadow
+#eval testArrowBodyNoShadow
+#eval testVarRedeclNoShadow
+#eval testSiblingBlocksNoShadow

--- a/Thales/Emit/SubsetCheck.lean
+++ b/Thales/Emit/SubsetCheck.lean
@@ -472,6 +472,141 @@ private def bindSwitchDecls (env : SwitchEnv) : Statement → SwitchEnv
         | _ => e) env
   | _ => env
 
+/- ── Shadowing check (#45, TH0032) ──
+   The emitter flattens bare blocks into their enclosing statement list
+   and appends if-continuations into branches, so a block-scoped
+   declaration that shadows a name from an enclosing scope of the same
+   function captures references meant for the outer binding (accepted
+   program, wrong output). tsc allows shadowing; Thales rejects it
+   (subset-on-rejection). `var` declarations are exempt — they are
+   function-scoped, so re-declaration is the same binding and any
+   `var`-vs-`let` conflict is already tsc's TS2451. Nested functions and
+   arrows start fresh scope stacks: Lean lambdas shadow correctly, and a
+   catch parameter lowers to a real match binder, so neither is flagged. -/
+
+private def setUnion (a b : Std.HashSet String) : Std.HashSet String :=
+  b.fold (·.insert ·) a
+
+mutual
+
+/-- Walk one lexical scope's statement list. `outer` holds every name
+    bound in enclosing scopes of the same function (params included); the
+    fold threads the names declared so far in THIS scope. -/
+partial def shadowStmts (outer : Std.HashSet String) (stmts : List Statement)
+    : Array Diagnostic :=
+  (stmts.foldl (fun (st : Array Diagnostic × Std.HashSet String) s =>
+      let (diags, current) := st
+      let (d, current') := shadowStmt outer current s
+      (diags ++ d, current')) (#[], ({} : Std.HashSet String))).1
+
+/-- Check one statement; returns its diagnostics and the current scope's
+    binding set extended with any names this statement declares. -/
+partial def shadowStmt (outer current : Std.HashSet String) (stmt : Statement)
+    : Array Diagnostic × Std.HashSet String :=
+  let enter := setUnion outer current
+  match stmt with
+  | .variableDecl (.mk _ decls kind) =>
+      decls.foldl (fun (st : Array Diagnostic × Std.HashSet String) d =>
+        let (diags, cur) := st
+        let (.mk db pat init _) := d
+        let initDiags := match init with
+          | some e => shadowExpr e
+          | none => #[]
+        match pat with
+        | .identifier id =>
+            let shadowDiag :=
+              if kind != .var && outer.contains id.name then
+                #[mkThalesDiag (.shadowingNotSupported id.name) db.loc]
+              else #[]
+            (diags ++ initDiags ++ shadowDiag, cur.insert id.name)
+        | _ => (diags ++ initDiags, cur)) (#[], current)
+  | .blockStmt _ body => (shadowStmts enter body, current)
+  | .ifStmt _ t c a =>
+      (shadowExpr t
+        ++ shadowStmts enter [c]
+        ++ (match a with | some s => shadowStmts enter [s] | none => #[]), current)
+  | .switchStmt _ d cases =>
+      -- the entire switch body is ONE block scope shared by all arms
+      let testDiags := cases.foldl (fun acc c =>
+        let (SwitchCase.mk _ t _) := c
+        acc ++ (match t with | some e => shadowExpr e | none => #[])) (shadowExpr d)
+      let armStmts := cases.flatMap fun (SwitchCase.mk _ _ ss) => ss
+      (testDiags ++ shadowStmts enter armStmts, current)
+  | .tryStmt _ b h f =>
+      let hDiags := match h with
+        | some (CatchClause.mk _ paramOpt hb _) =>
+            -- the catch param binds (as a real match binder) in the
+            -- handler's enclosing set
+            let enter' := match paramOpt with
+              | some (.identifier id) => enter.insert id.name
+              | _ => enter
+            shadowStmts enter' [hb]
+        | none => #[]
+      (shadowStmts enter [b]
+        ++ hDiags
+        ++ (match f with | some s => shadowStmts enter [s] | none => #[]), current)
+  | .forStmt _ init t u b =>
+      let initDiags := match init with
+        | some (.inl e) => shadowExpr e
+        | some (.inr vd) => (shadowStmt enter {} (.variableDecl vd)).1
+        | none => #[]
+      (initDiags
+        ++ (match t with | some e => shadowExpr e | none => #[])
+        ++ (match u with | some e => shadowExpr e | none => #[])
+        ++ shadowStmts enter [b], current)
+  | .forInStmt _ left r b | .forOfStmt _ left r b _ =>
+      let leftDiags := match left with
+        | .inl e => shadowExpr e
+        | .inr vd => (shadowStmt enter {} (.variableDecl vd)).1
+      (leftDiags ++ shadowExpr r ++ shadowStmts enter [b], current)
+  | .whileStmt _ t b => (shadowExpr t ++ shadowStmts enter [b], current)
+  | .doWhileStmt _ b t => (shadowStmts enter [b] ++ shadowExpr t, current)
+  | .exprStmt _ e | .throwStmt _ e => (shadowExpr e, current)
+  | .returnStmt _ a =>
+      ((match a with | some e => shadowExpr e | none => #[]), current)
+  | .functionDecl _ _ params body _ _ =>
+      -- nested function: fresh scope stack seeded with its params
+      (shadowFunc (funcParamNames params) body, current)
+  | .labeledStmt _ _ b | .withStmt _ _ b => (shadowStmts enter [b], current)
+  | _ => (#[], current)
+
+/-- Find nested function/arrow bodies inside an expression and shadow-check
+    each with a fresh scope stack. -/
+partial def shadowExpr : Expression → Array Diagnostic
+  | .functionExpr _ _ params body _ _ => shadowFunc (funcParamNames params) body
+  | .arrowFunctionExpr _ params body _ _ _ =>
+      (match body with
+        | .inl e => shadowExpr e
+        | .inr s => shadowFunc (funcParamNames params) s)
+  | .unaryExpr _ _ _ a | .updateExpr _ _ a _ | .spreadElement _ a
+  | .awaitExpr _ a | .chainExpr _ a | .privateMemberExpr _ a _ => shadowExpr a
+  | .binaryExpr _ _ l r | .assignmentExpr _ _ l r | .logicalExpr _ _ l r
+  | .taggedTemplate _ l r => shadowExpr l ++ shadowExpr r
+  | .memberExpr _ o p _ _ => shadowExpr o ++ shadowExpr p
+  | .conditionalExpr _ t c a => shadowExpr t ++ shadowExpr c ++ shadowExpr a
+  | .callExpr _ f args _ | .newExpr _ f args =>
+      args.foldl (fun acc a => acc ++ shadowExpr a) (shadowExpr f)
+  | .arrayExpr _ els =>
+      els.foldl (fun acc oe => match oe with
+        | some e => acc ++ shadowExpr e
+        | none => acc) #[]
+  | .objectExpr _ props =>
+      props.foldl (fun acc p => match p with
+        | .regular _ k v _ _ _ => acc ++ shadowExpr k ++ shadowExpr v
+        | .spread _ a => acc ++ shadowExpr a) #[]
+  | .sequenceExpr _ es | .templateLiteral _ _ es =>
+      es.foldl (fun acc e => acc ++ shadowExpr e) #[]
+  | .yieldExpr _ a _ =>
+      (match a with | some e => shadowExpr e | none => #[])
+  | _ => #[]
+
+/-- Shadow-check a function: its parameters form the outermost scope. -/
+partial def shadowFunc (paramNames : List String) (body : Statement)
+    : Array Diagnostic :=
+  shadowStmts (paramNames.foldl (·.insert ·) ({} : Std.HashSet String)) [body]
+
+end
+
 /-- Walk a statement body checking for switch exhaustiveness violations.
     Uses the provided SwitchEnv for identifier lookups. -/
 partial def checkSwitchStmt (env : SwitchEnv) (stmt : Statement) : Array Diagnostic :=
@@ -585,11 +720,11 @@ private def buildParamEnv
 /-- Check a TS-level statement for mutation violations. -/
 def checkTSStmt (ts : TSStatement) : Array Diagnostic :=
   match ts with
-  | .js s => checkStmt {} s
+  | .js s => checkStmt {} s ++ shadowStmts {} [s]
   | .annotatedVarDecl b _ _ typeAnn initOpt =>
     checkAnn b.loc typeAnn
       ++ (match initOpt with
-          | some e => checkExpr {} e
+          | some e => checkExpr {} e ++ shadowExpr e
           | none => #[])
   -- TH0012: async annotated function declarations — emit diagnostic, still recurse body.
   -- TH0060 is no longer SubsetCheck's responsibility, so no suppression filter is needed.
@@ -605,6 +740,7 @@ def checkTSStmt (ts : TSStatement) : Array Diagnostic :=
       ++ paramTypeDiags
       ++ checkAnn b.loc returnType
       ++ bodyDiags
+      ++ shadowFunc (params.map (·.1)) body
   | .interfaceDecl b _ _ _ members =>
     members.foldl (fun acc m =>
       match m with

--- a/Thales/TypeCheck/Diagnostic.lean
+++ b/Thales/TypeCheck/Diagnostic.lean
@@ -81,6 +81,7 @@ inductive ThalesKind where
   | inheritanceNotSupported
   | switchNotExhaustive (missingKinds : List String)
   | switchNotLowerable
+  | shadowingNotSupported (name : String)
   | cannotVerifyTermination (funcName : String)
   -- @throws / @total diagnostics (TH0060–TH0070)
   -- TH0061 (unusedThrowsAnnotation), TH0062 (untypedCatch), TH0064
@@ -127,6 +128,7 @@ def ThalesKind.thCode : ThalesKind → Nat
   | .inheritanceNotSupported => 31
   | .switchNotExhaustive _ => 40
   | .switchNotLowerable => 41
+  | .shadowingNotSupported _ => 32
   | .cannotVerifyTermination _ => 50
   | .unannotatedThrow _ => 60
   | .nonRecordThrow => 63
@@ -172,6 +174,8 @@ def ThalesKind.message : ThalesKind → String
     s!"Non-exhaustive switch on discriminated union (missing: {String.intercalate ", " missingKinds})"
   | .switchNotLowerable =>
     "Switch not supported here: dispatch on a discriminated-union field (e.g. `switch (shape.kind)`) with every arm ending in `return`"
+  | .shadowingNotSupported name =>
+    s!"Declaration of '{name}' shadows a binding from an enclosing scope; rename the inner binding"
   | .cannotVerifyTermination funcName =>
     s!"Cannot verify termination of '{funcName}'; add @decreasing hint or restructure"
   | .unannotatedThrow .fromThrow =>

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -61,6 +61,7 @@ soundness check).
 | TH0025 | Types        | null/undefined types not supported                  |
 | TH0030 | Declarations | `class` not supported                               |
 | TH0031 | Declarations | Inheritance (`extends`) not supported               |
+| TH0032 | Declarations | Shadowing declaration not supported                 |
 | TH0040 | Matching     | Non-exhaustive switch on discriminated union        |
 | TH0041 | Matching     | Switch shape not lowerable                          |
 | TH0050 | Recursion    | Cannot verify termination                           |
@@ -336,6 +337,24 @@ Rejected: `class Dog extends Animal { ... }`
 [Details in subset.md#th0031--inheritance-extends-not-supported](./subset.md#th0031--inheritance-extends-not-supported)
 
 6+ adds single-dispatch inheritance via typeclasses.
+
+---
+
+### TH0032 — Shadowing declaration not supported
+
+**Message:** `Declaration of '<name>' shadows a binding from an enclosing scope; rename the inner binding`
+
+Rejected: `const n = 0; { const n = 1; } return n;` inside a function.
+
+The emitter flattens bare blocks into their enclosing statement list and
+appends `if`-continuations into branches, so a block-scoped `let`/`const`
+that shadows a name from an enclosing scope of the same function would
+capture references meant for the outer binding — an accepted program with
+silently wrong output (#45). tsc allows shadowing; Thales rejects it.
+Out of scope by design: `var` re-declaration (function-scoped — the same
+binding; conflicts with `let` are tsc's TS2451), nested function/arrow
+parameters and bodies (fresh scopes — Lean lambdas shadow correctly), and
+`catch` parameters (lowered to real match binders).
 
 ---
 

--- a/docs/test262.md
+++ b/docs/test262.md
@@ -50,7 +50,8 @@ on demand).
 
 ## Baseline
 
-thales `3f11f4a` (after #24 mutation widening), test262 `fc32f3e8`, 2026-06-10:
+thales `4177bd1` (after #24 mutation widening and the #40–#45 emitter
+hardening), test262 `fc32f3e8`, 2026-06-11:
 
 ```
 Slice                                             Total  Skip   OoS  Pass  Fail  InSubset   Pass%
@@ -85,6 +86,7 @@ TH0007            1179     18        0
 TH0063            1179      2        0
 TH0021            1179      0        0
 TH0031            1179      0        0
+TH0041            1179      0        0
 TH0060            1179      0        0
 TS2322            1179      0        0
 TS2349            1179      0        0
@@ -110,12 +112,15 @@ Loops (TH0010, 765) remain the dominant body blocker, next up in #25/#26.
 `parse-error` counts tests where thales hard-fails without a structured
 diagnostic (e.g. multi-declarator `var x, y;`).
 
-New shim-attribution row vs the pre-#24 baseline: TS2322 — #24's
+New shim-attribution rows vs the pre-#24 baseline: TS2322 — #24's
 declared-type precision (unannotated/const bindings are no longer `any`)
 exposes a pre-existing truthy-narrowing gap at `harness/assert.ts:34`
 (`if (basic) return basic;` on a nullable: tsc narrows, thales doesn't
-strip the null arm). Tracked with the flow-fidelity follow-ups (#38);
-shim-compilation blockers overall are #31.
+strip the null arm) — and TH0041, the #44 switch classification firing on
+a shim switch (body attribution 0: no test body is newly blocked). The
+#40–#45 hardening left the body attribution untouched — no slice test
+hits the newly rejected combinations. Tracked with the flow-fidelity
+follow-ups (#38); shim-compilation blockers overall are #31.
 
 This table is updated manually when a feature lands; the per-directory
 numbers are the metric quoted in #24–#29.

--- a/tests/conformance/reject/0032-variable-shadowing.ts
+++ b/tests/conformance/reject/0032-variable-shadowing.ts
@@ -1,0 +1,13 @@
+// Subset-rejected example: a block-scoped declaration shadowing an
+// enclosing binding (TH0032). tsc accepts; thales rejects because the
+// emitter flattens bare blocks, so the inner `n` would capture the
+// `return n` reference meant for the outer binding (#45).
+function f(): number {
+  const n = 0;
+  {
+    // @thales-expect-error TH0032
+    const n = 1;
+  }
+  return n;
+}
+console.log(f());


### PR DESCRIPTION
Fixes #45.

The emitter flattens bare blocks into their enclosing statement list and appends if-continuations into branches, so a block-scoped `let`/`const` shadowing a name from an enclosing scope of the same function captured references meant for the outer binding — accepted program, silently wrong output. A scope-stack walker in SubsetCheck now rejects such declarations with the new TH0032. Deliberately exempt: `var` re-declaration (function-scoped — the same binding; `var`-vs-`let` conflicts are tsc's TS2451), nested function/arrow parameters and bodies (fresh stacks — Lean lambdas shadow correctly), and `catch` parameters (lowered to real match binders).

New: 7 shadow pins in `DeclarationCheckTest` and the `0032-variable-shadowing` reject fixture. Also includes the test262 re-measure for the whole #40–#45 hardening stack: body attribution unchanged (TH0001 stays 213), one new shim-only TH0041 row (`docs/test262.md` updated).

**Stacked on #47** (last of three); semantically independent of #43/#44.

Verification at this stack tip: format check, `lake build` + `lake build ThalesTest`, harness self-test 18/18, full corpus 93/93 byte-match, test262 re-measure.