### PR TITLE
Support while / do-while loops; desugar general C-style for (#26)

### DIFF
--- a/Test/Emit/LeanSyntaxDoTest.lean
+++ b/Test/Emit/LeanSyntaxDoTest.lean
@@ -169,7 +169,7 @@ def emptyForExpected : String :=
 
 def t10 : IO Unit := expectRender emptyForStmt emptyForExpected
 
--- whileDo / repeatUntilDo (#26) ---------------------------------------------
+-- whileDo / repeatUntilDo ---------------------------------------------
 
 -- t11: whileDo renders `while c do` with an indented body
 def whileStmtRender : String :=

--- a/Test/Emit/LeanSyntaxDoTest.lean
+++ b/Test/Emit/LeanSyntaxDoTest.lean
@@ -169,6 +169,48 @@ def emptyForExpected : String :=
 
 def t10 : IO Unit := expectRender emptyForStmt emptyForExpected
 
+-- whileDo / repeatUntilDo (#26) ---------------------------------------------
+
+-- t11: whileDo renders `while c do` with an indented body
+def whileStmtRender : String :=
+  renderDoStmt (.whileDo (.binOp "<" (.var "pad") (.var "len")) [
+    .assign "pad" (.binOp "+" (.var "ch") (.var "pad"))
+  ])
+
+def whileExpected : String :=
+  "while (pad < len) do\n" ++
+  "  pad := (ch + pad)"
+
+def t11 : IO Unit := expectRender whileStmtRender whileExpected
+
+-- t12: repeatUntilDo renders `repeat`, indented body, dedented `until c`
+def repeatStmtRender : String :=
+  renderDoStmt (.repeatUntilDo [
+    .assign "n" (.binOp "-" (.var "n") (.int 1))
+  ] (.app (.var "not") [.binOp ">" (.var "n") (.int 0)]))
+
+def repeatExpected : String :=
+  "repeat\n" ++
+  "  n := (n - 1)\n" ++
+  "until (not ((n > 0)))"
+
+def t12 : IO Unit := expectRender repeatStmtRender repeatExpected
+
+-- t13: doStmtsTerminate — while/repeatUntil alone are false; with trailing
+-- ret the list terminates
+def t13 : IO Unit := do
+  unless !doStmtsTerminate [.whileDo (.bool true) [.ret (.var "x")]] do
+    throw (IO.userError "whileDo alone should not terminate")
+  unless doStmtsTerminate [.whileDo (.bool true) [], .ret (.var "x")] do
+    throw (IO.userError "whileDo then ret should terminate")
+  unless !doStmtsTerminate [.repeatUntilDo [.ret (.var "x")] (.bool true)] do
+    throw (IO.userError "repeatUntilDo alone should not terminate")
+
+-- t14: empty whileDo body renders "pure ()" (valid Lean)
+def t14 : IO Unit := expectRender
+  (renderDoStmt (.whileDo (.bool true) []))
+  ("while true do\n" ++ "  pure ()")
+
 #eval t1
 #eval t2
 #eval t3
@@ -179,3 +221,7 @@ def t10 : IO Unit := expectRender emptyForStmt emptyForExpected
 #eval t8
 #eval t9
 #eval t10
+#eval t11
+#eval t12
+#eval t13
+#eval t14

--- a/Test/Emit/LoopEscapeTest.lean
+++ b/Test/Emit/LoopEscapeTest.lean
@@ -1,6 +1,6 @@
 /-
   Test/Emit/LoopEscapeTest.lean
-  Pins the #25 loop-shape flags on `MutationInfo`:
+  Pins the #25/#26 loop-shape flags on `MutationInfo`:
     * `hasLowerableLoop`     — the own body has a loop EscapeAnalysis admits
     * `hasUnloweredLoopShape` — the own body has a loop that poisons do-mode
   Both flags start `false`; lowerable loops set the first, everything
@@ -37,16 +37,16 @@ def t1 : IO Unit := do
   unless info.doModeLowerable do
     throw (IO.userError s!"expected doModeLowerable, got false")
 
--- ── while loop: poisons do-mode ───────────────────────────────────────────────
+-- ── while loop: lowerable (#26) ──────────────────────────────────────────────
 def t2 : IO Unit := do
   let info ← analyzeFirstFuncLoop
     "function f(x: number): number { let n = 0; while (n < x) { n += 1; } return n; }"
-  if info.hasLowerableLoop then
-    throw (IO.userError s!"expected !hasLowerableLoop, got true")
-  unless info.hasUnloweredLoopShape do
-    throw (IO.userError s!"expected hasUnloweredLoopShape, got false")
-  if info.doModeLowerable then
-    throw (IO.userError s!"expected !doModeLowerable, got true")
+  unless info.hasLowerableLoop do
+    throw (IO.userError s!"expected hasLowerableLoop (while, #26), got false")
+  if info.hasUnloweredLoopShape then
+    throw (IO.userError s!"expected !hasUnloweredLoopShape (while, #26), got true")
+  unless info.doModeLowerable do
+    throw (IO.userError s!"expected doModeLowerable (while, #26), got false")
 
 -- ── for-of with loop-var reassignment: poisons do-mode ───────────────────────
 def t3 : IO Unit := do
@@ -97,14 +97,14 @@ def t7 : IO Unit := do
   if info.hasUnloweredLoopShape then
     throw (IO.userError s!"expected !hasUnloweredLoopShape (nested for-of), got true")
 
--- ── for-of with inner while: poisons do-mode ─────────────────────────────────
+-- ── for-of with inner while: both lowerable (#26) ────────────────────────────
 def t8 : IO Unit := do
   let info ← analyzeFirstFuncLoop
     "function f(xs: number[]): number { let t = 0; for (const x of xs) { while (t < x) { t += 1; } } return t; }"
-  unless info.hasUnloweredLoopShape do
-    throw (IO.userError s!"expected hasUnloweredLoopShape (inner while), got false")
-  if info.doModeLowerable then
-    throw (IO.userError s!"expected !doModeLowerable (inner while), got true")
+  unless info.hasLowerableLoop do
+    throw (IO.userError s!"expected hasLowerableLoop (inner while, #26), got false")
+  if info.hasUnloweredLoopShape then
+    throw (IO.userError s!"expected !hasUnloweredLoopShape (inner while, #26), got true")
 
 -- ── no loops: both flags false (regression guard) ────────────────────────────
 def t9 : IO Unit := do
@@ -154,6 +154,58 @@ def t_labeledLoopNoBreak : IO Unit := do
   if info.doModeLowerable then
     throw (IO.userError "expected !doModeLowerable (labeled loop, no break), got true")
 
+-- ── #26: do-while is lowerable ───────────────────────────────────────────────
+def t_doWhile : IO Unit := do
+  let info ← analyzeFirstFuncLoop
+    "function f(n: number): number { let s = 0; do { s += 1; n -= 1; } while (n > 0); return s; }"
+  unless info.hasLowerableLoop do
+    throw (IO.userError "expected hasLowerableLoop (do-while), got false")
+  if info.hasUnloweredLoopShape then
+    throw (IO.userError "expected !hasUnloweredLoopShape (do-while), got true")
+
+-- ── #26: do-while with loop-level continue poisons ──────────────────────────
+-- TS `continue` jumps to the test; `repeat … until` re-enters the body
+-- without checking it, so the shape cannot lower.
+def t_doWhileContinue : IO Unit := do
+  let info ← analyzeFirstFuncLoop
+    "function f(n: number): number { do { if (n > 0) { continue; } } while (n > 0); return n; }"
+  unless info.hasUnloweredLoopShape do
+    throw (IO.userError "expected hasUnloweredLoopShape (do-while continue), got false")
+  if info.doModeLowerable then
+    throw (IO.userError "expected !doModeLowerable (do-while continue), got true")
+
+-- ── #26: while with continue is fine (Lean's while re-checks the test) ──────
+def t_whileContinue : IO Unit := do
+  let info ← analyzeFirstFuncLoop
+    "function f(n: number): number { let s = 0; while (s < n) { s += 1; if (s > 2) { continue; } } return s; }"
+  unless info.hasLowerableLoop do
+    throw (IO.userError "expected hasLowerableLoop (while continue), got false")
+  if info.hasUnloweredLoopShape then
+    throw (IO.userError "expected !hasUnloweredLoopShape (while continue), got true")
+
+-- ── #26: while with labeled break poisons ────────────────────────────────────
+def t_whileLabeledBreak : IO Unit := do
+  let info ← analyzeFirstFuncLoop
+    "function f(n: number): number { outer: while (n > 0) { break outer; } return n; }"
+  unless info.hasUnloweredLoopShape do
+    throw (IO.userError "expected hasUnloweredLoopShape (while labeled break), got false")
+
+-- ── #26: non-canonical for (compound step) is lowerable via while-desugar ───
+def t_generalFor : IO Unit := do
+  let info ← analyzeFirstFuncLoop
+    "function f(n: number): number { let t = 0; for (let i = n; i > 0; i -= 2) { t += i; } return t; }"
+  unless info.hasLowerableLoop do
+    throw (IO.userError "expected hasLowerableLoop (general for, #26), got false")
+  if info.hasUnloweredLoopShape then
+    throw (IO.userError "expected !hasUnloweredLoopShape (general for, #26), got true")
+
+-- ── #26: general for + loop-level continue (update would be skipped) ────────
+def t_generalForContinue : IO Unit := do
+  let info ← analyzeFirstFuncLoop
+    "function f(n: number): number { let t = 0; for (let i = n; i > 0; i -= 2) { if (i > 4) { continue; } t += i; } return t; }"
+  unless info.hasUnloweredLoopShape do
+    throw (IO.userError "expected hasUnloweredLoopShape (general for continue), got false")
+
 #eval t1
 #eval t2
 #eval t3
@@ -166,3 +218,9 @@ def t_labeledLoopNoBreak : IO Unit := do
 #eval t_shadowedLoopVar
 #eval t_shadowedLoopVarCleanBody
 #eval t_labeledLoopNoBreak
+#eval t_doWhile
+#eval t_doWhileContinue
+#eval t_whileContinue
+#eval t_whileLabeledBreak
+#eval t_generalFor
+#eval t_generalForContinue

--- a/Test/Emit/LoopEscapeTest.lean
+++ b/Test/Emit/LoopEscapeTest.lean
@@ -1,6 +1,6 @@
 /-
   Test/Emit/LoopEscapeTest.lean
-  Pins the #25/#26 loop-shape flags on `MutationInfo`:
+  Pins the loop-shape flags on `MutationInfo`:
     * `hasLowerableLoop`     — the own body has a loop EscapeAnalysis admits
     * `hasUnloweredLoopShape` — the own body has a loop that poisons do-mode
   Both flags start `false`; lowerable loops set the first, everything
@@ -37,16 +37,16 @@ def t1 : IO Unit := do
   unless info.doModeLowerable do
     throw (IO.userError s!"expected doModeLowerable, got false")
 
--- ── while loop: lowerable (#26) ──────────────────────────────────────────────
+-- ── while loop: lowerable ──────────────────────────────────────────────
 def t2 : IO Unit := do
   let info ← analyzeFirstFuncLoop
     "function f(x: number): number { let n = 0; while (n < x) { n += 1; } return n; }"
   unless info.hasLowerableLoop do
-    throw (IO.userError s!"expected hasLowerableLoop (while, #26), got false")
+    throw (IO.userError s!"expected hasLowerableLoop (while), got false")
   if info.hasUnloweredLoopShape then
-    throw (IO.userError s!"expected !hasUnloweredLoopShape (while, #26), got true")
+    throw (IO.userError s!"expected !hasUnloweredLoopShape (while), got true")
   unless info.doModeLowerable do
-    throw (IO.userError s!"expected doModeLowerable (while, #26), got false")
+    throw (IO.userError s!"expected doModeLowerable (while), got false")
 
 -- ── for-of with loop-var reassignment: poisons do-mode ───────────────────────
 def t3 : IO Unit := do
@@ -97,14 +97,14 @@ def t7 : IO Unit := do
   if info.hasUnloweredLoopShape then
     throw (IO.userError s!"expected !hasUnloweredLoopShape (nested for-of), got true")
 
--- ── for-of with inner while: both lowerable (#26) ────────────────────────────
+-- ── for-of with inner while: both lowerable ────────────────────────────
 def t8 : IO Unit := do
   let info ← analyzeFirstFuncLoop
     "function f(xs: number[]): number { let t = 0; for (const x of xs) { while (t < x) { t += 1; } } return t; }"
   unless info.hasLowerableLoop do
-    throw (IO.userError s!"expected hasLowerableLoop (inner while, #26), got false")
+    throw (IO.userError s!"expected hasLowerableLoop (inner while), got false")
   if info.hasUnloweredLoopShape then
-    throw (IO.userError s!"expected !hasUnloweredLoopShape (inner while, #26), got true")
+    throw (IO.userError s!"expected !hasUnloweredLoopShape (inner while), got true")
 
 -- ── no loops: both flags false (regression guard) ────────────────────────────
 def t9 : IO Unit := do
@@ -154,7 +154,7 @@ def t_labeledLoopNoBreak : IO Unit := do
   if info.doModeLowerable then
     throw (IO.userError "expected !doModeLowerable (labeled loop, no break), got true")
 
--- ── #26: do-while is lowerable ───────────────────────────────────────────────
+-- ── do-while is lowerable ───────────────────────────────────────────────
 def t_doWhile : IO Unit := do
   let info ← analyzeFirstFuncLoop
     "function f(n: number): number { let s = 0; do { s += 1; n -= 1; } while (n > 0); return s; }"
@@ -163,7 +163,7 @@ def t_doWhile : IO Unit := do
   if info.hasUnloweredLoopShape then
     throw (IO.userError "expected !hasUnloweredLoopShape (do-while), got true")
 
--- ── #26: do-while with loop-level continue poisons ──────────────────────────
+-- ── do-while with loop-level continue poisons ──────────────────────────
 -- TS `continue` jumps to the test; `repeat … until` re-enters the body
 -- without checking it, so the shape cannot lower.
 def t_doWhileContinue : IO Unit := do
@@ -174,7 +174,7 @@ def t_doWhileContinue : IO Unit := do
   if info.doModeLowerable then
     throw (IO.userError "expected !doModeLowerable (do-while continue), got true")
 
--- ── #26: while with continue is fine (Lean's while re-checks the test) ──────
+-- ── while with continue is fine (Lean's while re-checks the test) ──────
 def t_whileContinue : IO Unit := do
   let info ← analyzeFirstFuncLoop
     "function f(n: number): number { let s = 0; while (s < n) { s += 1; if (s > 2) { continue; } } return s; }"
@@ -183,23 +183,23 @@ def t_whileContinue : IO Unit := do
   if info.hasUnloweredLoopShape then
     throw (IO.userError "expected !hasUnloweredLoopShape (while continue), got true")
 
--- ── #26: while with labeled break poisons ────────────────────────────────────
+-- ── while with labeled break poisons ────────────────────────────────────
 def t_whileLabeledBreak : IO Unit := do
   let info ← analyzeFirstFuncLoop
     "function f(n: number): number { outer: while (n > 0) { break outer; } return n; }"
   unless info.hasUnloweredLoopShape do
     throw (IO.userError "expected hasUnloweredLoopShape (while labeled break), got false")
 
--- ── #26: non-canonical for (compound step) is lowerable via while-desugar ───
+-- ── non-canonical for (compound step) is lowerable via while-desugar ───
 def t_generalFor : IO Unit := do
   let info ← analyzeFirstFuncLoop
     "function f(n: number): number { let t = 0; for (let i = n; i > 0; i -= 2) { t += i; } return t; }"
   unless info.hasLowerableLoop do
-    throw (IO.userError "expected hasLowerableLoop (general for, #26), got false")
+    throw (IO.userError "expected hasLowerableLoop (general for), got false")
   if info.hasUnloweredLoopShape then
-    throw (IO.userError "expected !hasUnloweredLoopShape (general for, #26), got true")
+    throw (IO.userError "expected !hasUnloweredLoopShape (general for), got true")
 
--- ── #26: general for + loop-level continue (update would be skipped) ────────
+-- ── general for + loop-level continue (update would be skipped) ────────
 def t_generalForContinue : IO Unit := do
   let info ← analyzeFirstFuncLoop
     "function f(n: number): number { let t = 0; for (let i = n; i > 0; i -= 2) { if (i > 4) { continue; } t += i; } return t; }"

--- a/Test/Emit/LoopShapeTest.lean
+++ b/Test/Emit/LoopShapeTest.lean
@@ -194,6 +194,69 @@ def t_labeledBreak_nestedFunction : IO Unit := do
   if hasLabeledBreakOrContinue s then
     throw (IO.userError "labeled break inside nested function should not be flagged")
 
+-- ── generalForDesugarable / hasOwnUnlabeledContinue (#26) ──────────────────
+
+private def assertGeneralFor (loop : String) (expected : Bool) : IO Unit := do
+  let s ← firstStmt s!"function f(xs: number[]): void \{ {loop} }"
+  unless generalForDesugarable s == expected do
+    throw (IO.userError
+      s!"expected generalForDesugarable = {expected} for: {loop}")
+
+-- non-canonical shapes that desugar
+def t_generalFor_compoundStep : IO Unit :=
+  assertGeneralFor "for (let i = 9; i > 0; i -= 2) { }" true
+def t_generalFor_noInit : IO Unit :=
+  assertGeneralFor "for (; xs.length > 0;) { }" true
+-- bare-expression init (the predicate is syntactic; binding rules are the
+-- callers' concern)
+def t_generalFor_exprInit : IO Unit :=
+  assertGeneralFor "for (i = 5; i > 0; i -= 1) { }" true
+
+-- canonical shape must NOT fall back to the desugar (keeps its range
+-- lowering, and keeps #25's operand rejections intact)
+def t_generalFor_canonicalExcluded : IO Unit :=
+  assertGeneralFor "for (let i = 0; i < 5; i++) { }" false
+def t_generalFor_canonicalStringBoundExcluded : IO Unit := do
+  let s ← firstStmt
+    "function f(s: string): void { for (let i = 0; i < s.length; i++) { } }"
+  unless generalForDesugarable s == false do
+    throw (IO.userError
+      "canonical-SHAPED loop (string bound) must not fall back to desugar")
+
+-- `var` init hoists; out of subset
+def t_generalFor_varInit : IO Unit :=
+  assertGeneralFor "for (var i = 9; i > 0; i -= 2) { }" false
+
+-- loop-level continue + update clause → not desugarable
+def t_generalFor_continueWithUpdate : IO Unit :=
+  assertGeneralFor "for (let i = 9; i > 0; i -= 2) { if (i > 4) { continue; } }" false
+
+-- loop-level continue WITHOUT update clause → fine (test is re-checked)
+def t_generalFor_continueNoUpdate : IO Unit :=
+  assertGeneralFor "for (let i = 9; i > 0;) { i -= 1; if (i > 4) { continue; } }" true
+
+-- continue inside a NESTED loop binds to the inner loop → outer desugarable
+def t_generalFor_nestedLoopContinue : IO Unit :=
+  assertGeneralFor
+    "for (let i = 9; i > 0; i -= 2) { for (const x of xs) { continue; } }" true
+
+private def assertOwnContinue (body : String) (expected : Bool) : IO Unit := do
+  let s ← firstStmt s!"function f(xs: number[]): void \{ {body} }"
+  match s with
+  | .whileStmt _ _ b | .doWhileStmt _ b _ =>
+    unless hasOwnUnlabeledContinue b == expected do
+      throw (IO.userError
+        s!"expected hasOwnUnlabeledContinue = {expected} for: {body}")
+  | _ => throw (IO.userError s!"setup: expected a while/do-while: {body}")
+
+def t_ownContinue_direct : IO Unit :=
+  assertOwnContinue "do { if (xs.length > 0) { continue; } } while (false);" true
+def t_ownContinue_nestedLoop : IO Unit :=
+  assertOwnContinue "do { for (const x of xs) { continue; } } while (false);" false
+def t_ownContinue_switch : IO Unit :=
+  assertOwnContinue
+    "while (false) { switch (xs.length) { default: continue; } }" true
+
 -- ── eval ──────────────────────────────────────────────────────────────────
 
 #eval t_forOf_const
@@ -218,3 +281,15 @@ def t_labeledBreak_nestedFunction : IO Unit := do
 #eval t_labeledBreak_positive
 #eval t_labeledBreak_negative
 #eval t_labeledBreak_nestedFunction
+#eval t_generalFor_compoundStep
+#eval t_generalFor_noInit
+#eval t_generalFor_exprInit
+#eval t_generalFor_canonicalExcluded
+#eval t_generalFor_canonicalStringBoundExcluded
+#eval t_generalFor_varInit
+#eval t_generalFor_continueWithUpdate
+#eval t_generalFor_continueNoUpdate
+#eval t_generalFor_nestedLoopContinue
+#eval t_ownContinue_direct
+#eval t_ownContinue_nestedLoop
+#eval t_ownContinue_switch

--- a/Test/Emit/LoopShapeTest.lean
+++ b/Test/Emit/LoopShapeTest.lean
@@ -194,7 +194,7 @@ def t_labeledBreak_nestedFunction : IO Unit := do
   if hasLabeledBreakOrContinue s then
     throw (IO.userError "labeled break inside nested function should not be flagged")
 
--- ── generalForDesugarable / hasOwnUnlabeledContinue (#26) ──────────────────
+-- ── generalForDesugarable / hasOwnUnlabeledContinue ──────────────────
 
 private def assertGeneralFor (loop : String) (expected : Bool) : IO Unit := do
   let s ← firstStmt s!"function f(xs: number[]): void \{ {loop} }"
@@ -213,7 +213,7 @@ def t_generalFor_exprInit : IO Unit :=
   assertGeneralFor "for (i = 5; i > 0; i -= 1) { }" true
 
 -- canonical shape must NOT fall back to the desugar (keeps its range
--- lowering, and keeps #25's operand rejections intact)
+-- lowering, and keeps the canonical-for operand rejections intact)
 def t_generalFor_canonicalExcluded : IO Unit :=
   assertGeneralFor "for (let i = 0; i < 5; i++) { }" false
 def t_generalFor_canonicalStringBoundExcluded : IO Unit := do
@@ -257,6 +257,33 @@ def t_ownContinue_switch : IO Unit :=
   assertOwnContinue
     "while (false) { switch (xs.length) { default: continue; } }" true
 
+-- ── desugarGeneralFor: the one decomposition all phases consume ─────────────
+
+-- `for (init; test; update) body` → `init; while (test) { body; update }`
+def t_desugar_shape : IO Unit := do
+  let s ← firstStmt
+    "function f(xs: number[]): void { for (let i = 9; i > 0; i -= 2) { } }"
+  match desugarGeneralFor s with
+  | some [.variableDecl _,
+          .whileStmt _ _ (.blockStmt _ [.exprStmt _ _])] => pure ()
+  | some _ => throw (IO.userError
+      "desugar: expected `init; while` with the update appended to the body")
+  | none => throw (IO.userError "expected a desugar for a compound-step for")
+
+-- a missing test desugars to `while (true)`
+def t_desugar_missingTest : IO Unit := do
+  let s ← firstStmt "function f(xs: number[]): void { for (;;) { break; } }"
+  match desugarGeneralFor s with
+  | some [.whileStmt _ (.literal _ (.boolean true) _) _] => pure ()
+  | _ => throw (IO.userError "expected a missing test to desugar to while (true)")
+
+-- a body with a labeled break never desugars (no loop lowering has labels)
+def t_desugar_labeledBreak : IO Unit := do
+  let s ← firstStmt
+    "function f(xs: number[]): void { for (let i = 9; i > 0; i -= 2) { outer: { break outer; } } }"
+  unless (desugarGeneralFor s).isNone do
+    throw (IO.userError "a body with a labeled break must not desugar")
+
 -- ── eval ──────────────────────────────────────────────────────────────────
 
 #eval t_forOf_const
@@ -293,3 +320,6 @@ def t_ownContinue_switch : IO Unit :=
 #eval t_ownContinue_direct
 #eval t_ownContinue_nestedLoop
 #eval t_ownContinue_switch
+#eval t_desugar_shape
+#eval t_desugar_missingTest
+#eval t_desugar_labeledBreak

--- a/Test/Emit/LoopSubsetCheckTest.lean
+++ b/Test/Emit/LoopSubsetCheckTest.lean
@@ -1,6 +1,6 @@
 /-
   Test/Emit/LoopSubsetCheckTest.lean
-  Verifies shape-aware TH0010 routing in SubsetCheck (#25/#26):
+  Verifies shape-aware TH0010 routing in SubsetCheck:
   - Admitted for-of, canonical-for, while, do-while, and desugarable
     general-for shapes in do-mode-lowerable functions are accepted (no
     TH0010).
@@ -51,7 +51,7 @@ def testCanonicalForAdmitted : IO Unit := expectTH
   "function f(): number { let t = 0; for (let i = 0; i < 5; i++) { t += i; } return t; }"
   []
 
--- ── Case 3: while inside a function — admitted (#26) ──
+-- ── Case 3: while inside a function — admitted ──
 def testWhileAdmitted : IO Unit := expectTH
   "function f(n: number): number { let i = 0; while (i < n) { i++; } return i; }"
   []
@@ -152,31 +152,31 @@ def testForStringLengthBoundTH0010 : IO Unit := expectTH
   "function f(s: string): number { let t = 0; for (let i = 0; i < s.length; i++) { t += i; } return t; }"
   ["TH0010"]
 
--- ── Case 17: do-while inside a function — admitted (#26) ──
+-- ── Case 17: do-while inside a function — admitted ──
 def testDoWhileAdmitted : IO Unit := expectTH
   "function f(n: number): number { let s = 0; do { s += 1; n -= 1; } while (n > 0); return s; }"
   []
 
--- ── Case 18: do-while with loop-level continue → TH0010 (#26) ──
+-- ── Case 18: do-while with loop-level continue → TH0010 ──
 -- `repeat … until` re-enters the body without checking the test where TS
 -- jumps to it; EscapeAnalysis poisons the function, SubsetCheck rejects.
 def testDoWhileContinueTH0010 : IO Unit := expectTH
   "function f(n: number): number { do { if (n > 0) { continue; } } while (n > 0); return n; }"
   ["TH0010"]
 
--- ── Case 19: while inside a @throws function → TH0010 (#26) ──
+-- ── Case 19: while inside a @throws function → TH0010 ──
 def testWhileThrowsFnTH0010 : IO Unit := expectTH
   "/** @throws RangeError */\nfunction f(n: number): number { while (n > 0) { } return 0; }"
   ["TH0010"]
 
--- ── Case 20: while inside a @total function → TH0068 (#26) ──
+-- ── Case 20: while inside a @total function → TH0068 ──
 -- The lowering is partial-backed; the lake-side termination verification
 -- would pass vacuously, so the combination is rejected outright.
 def testTotalWhileTH0068 : IO Unit := expectTH
   "/** @total */\nfunction f(n: number): number { while (n > 0) { } return 0; }"
   ["TH0068"]
 
--- ── Case 21: do-while inside a @total function → TH0068 (#26) ──
+-- ── Case 21: do-while inside a @total function → TH0068 ──
 def testTotalDoWhileTH0068 : IO Unit := expectTH
   "/** @total */\nfunction f(n: number): number { do { } while (n > 0); return 0; }"
   ["TH0068"]
@@ -187,18 +187,18 @@ def testTotalCanonicalForOk : IO Unit := expectTH
   "/** @total */\nfunction f(): number { let t = 0; for (let i = 0; i < 5; i++) { t += i; } return t; }"
   []
 
--- ── Case 23: non-canonical for — admitted via while-desugar (#26) ──
+-- ── Case 23: non-canonical for — admitted via while-desugar ──
 def testGeneralForAdmitted : IO Unit := expectTH
   "function f(n: number): number { let t = 0; for (let i = n; i > 0; i -= 2) { t += i; } return t; }"
   []
 
--- ── Case 24: non-canonical for inside a @total function → TH0068 (#26) ──
+-- ── Case 24: non-canonical for inside a @total function → TH0068 ──
 -- The desugared lowering is the partial-backed `while`, same as Case 20.
 def testTotalGeneralForTH0068 : IO Unit := expectTH
   "/** @total */\nfunction f(n: number): number { let t = 0; for (let i = n; i > 0; i -= 2) { t += i; } return t; }"
   ["TH0068"]
 
--- ── Case 25: non-canonical for with loop-level continue → TH0010 (#26) ──
+-- ── Case 25: non-canonical for with loop-level continue → TH0010 ──
 -- The desugared body would skip the update clause on `continue`.
 def testGeneralForContinueTH0010 : IO Unit := expectTH
   "function f(n: number): number { let t = 0; for (let i = n; i > 0; i -= 2) { if (i > 4) { continue; } t += i; } return t; }"

--- a/Test/Emit/LoopSubsetCheckTest.lean
+++ b/Test/Emit/LoopSubsetCheckTest.lean
@@ -1,14 +1,16 @@
 /-
   Test/Emit/LoopSubsetCheckTest.lean
-  Verifies shape-aware TH0010 routing in SubsetCheck (#25):
-  - Admitted for-of and canonical-for shapes in do-mode-lowerable functions
-    are accepted (no TH0010).
-  - Non-lowerable loops (while, for-in, destructuring heads, call RHS,
-    etc.) always draw TH0010.
-  - do-mode poison (try/catch, @throws, mixed admitted+while) forces TH0010
+  Verifies shape-aware TH0010 routing in SubsetCheck (#25/#26):
+  - Admitted for-of, canonical-for, while, do-while, and desugarable
+    general-for shapes in do-mode-lowerable functions are accepted (no
+    TH0010).
+  - Non-lowerable loops (for-in, destructuring heads, call RHS, do-while
+    with loop-level continue, etc.) always draw TH0010.
+  - do-mode poison (try/catch, @throws, labeled loops) forces TH0010
     even for otherwise-admitted shapes.
   - Module-level loops draw TH0010 (no function context).
   - Unlabeled break/continue inside admitted for-of is fine (no TH0010).
+  - while/do-while/general-for inside a @total function draw TH0068.
 -/
 import Thales.Emit.SubsetCheck
 import Thales.Parser.Native
@@ -49,10 +51,10 @@ def testCanonicalForAdmitted : IO Unit := expectTH
   "function f(): number { let t = 0; for (let i = 0; i < 5; i++) { t += i; } return t; }"
   []
 
--- ── Case 3: while inside a function — TH0010 ──
-def testWhileTH0010 : IO Unit := expectTH
+-- ── Case 3: while inside a function — admitted (#26) ──
+def testWhileAdmitted : IO Unit := expectTH
   "function f(n: number): number { let i = 0; while (i < n) { i++; } return i; }"
-  ["TH0010"]
+  []
 
 -- ── Case 4: for-of with destructuring head — not admitted, TH0010 ──
 -- Pattern binder (not a simple identifier) → classifyLoop = .notLowerable
@@ -85,12 +87,13 @@ def testForOfThrowsFnTH0010 : IO Unit := expectTH
   "/** @throws RangeError */\nfunction f(xs: number[]): number { for (const x of xs) { } return 0; }"
   ["TH0010"]
 
--- ── Case 8: function with BOTH admitted for-of AND while → both TH0010 ──
--- hasUnloweredLoopShape=true (from while) → doModeLowerable=false →
--- neither loop is admitted; both draw TH0010.
+-- ── Case 8: function with admitted for-of AND a labeled while → both TH0010 ──
+-- hasUnloweredLoopShape=true (label on the while) → doModeLowerable=false →
+-- neither loop is admitted; both draw TH0010. Pins the function-level
+-- poisoning: one unlowerable loop rejects every loop in the function.
 -- No mutation in bodies to keep the diagnostic set clean.
-def testBothAdmittedAndWhileTH0010 : IO Unit := expectTH
-  "function f(xs: number[]): number { for (const x of xs) { } while (false) { } return 0; }"
+def testBothAdmittedAndLabeledWhileTH0010 : IO Unit := expectTH
+  "function f(xs: number[]): number { for (const x of xs) { } outer: while (false) { break outer; } return 0; }"
   ["TH0010", "TH0010"]
 
 -- ── Case 9: module-level (top-level) for-of → TH0010 (no function context) ──
@@ -149,14 +152,71 @@ def testForStringLengthBoundTH0010 : IO Unit := expectTH
   "function f(s: string): number { let t = 0; for (let i = 0; i < s.length; i++) { t += i; } return t; }"
   ["TH0010"]
 
+-- ── Case 17: do-while inside a function — admitted (#26) ──
+def testDoWhileAdmitted : IO Unit := expectTH
+  "function f(n: number): number { let s = 0; do { s += 1; n -= 1; } while (n > 0); return s; }"
+  []
+
+-- ── Case 18: do-while with loop-level continue → TH0010 (#26) ──
+-- `repeat … until` re-enters the body without checking the test where TS
+-- jumps to it; EscapeAnalysis poisons the function, SubsetCheck rejects.
+def testDoWhileContinueTH0010 : IO Unit := expectTH
+  "function f(n: number): number { do { if (n > 0) { continue; } } while (n > 0); return n; }"
+  ["TH0010"]
+
+-- ── Case 19: while inside a @throws function → TH0010 (#26) ──
+def testWhileThrowsFnTH0010 : IO Unit := expectTH
+  "/** @throws RangeError */\nfunction f(n: number): number { while (n > 0) { } return 0; }"
+  ["TH0010"]
+
+-- ── Case 20: while inside a @total function → TH0068 (#26) ──
+-- The lowering is partial-backed; the lake-side termination verification
+-- would pass vacuously, so the combination is rejected outright.
+def testTotalWhileTH0068 : IO Unit := expectTH
+  "/** @total */\nfunction f(n: number): number { while (n > 0) { } return 0; }"
+  ["TH0068"]
+
+-- ── Case 21: do-while inside a @total function → TH0068 (#26) ──
+def testTotalDoWhileTH0068 : IO Unit := expectTH
+  "/** @total */\nfunction f(n: number): number { do { } while (n > 0); return 0; }"
+  ["TH0068"]
+
+-- ── Case 22: canonical for inside a @total function → no TH codes ──
+-- Structural `for i in [0:B]` is termination-checker-visible; @total keeps it.
+def testTotalCanonicalForOk : IO Unit := expectTH
+  "/** @total */\nfunction f(): number { let t = 0; for (let i = 0; i < 5; i++) { t += i; } return t; }"
+  []
+
+-- ── Case 23: non-canonical for — admitted via while-desugar (#26) ──
+def testGeneralForAdmitted : IO Unit := expectTH
+  "function f(n: number): number { let t = 0; for (let i = n; i > 0; i -= 2) { t += i; } return t; }"
+  []
+
+-- ── Case 24: non-canonical for inside a @total function → TH0068 (#26) ──
+-- The desugared lowering is the partial-backed `while`, same as Case 20.
+def testTotalGeneralForTH0068 : IO Unit := expectTH
+  "/** @total */\nfunction f(n: number): number { let t = 0; for (let i = n; i > 0; i -= 2) { t += i; } return t; }"
+  ["TH0068"]
+
+-- ── Case 25: non-canonical for with loop-level continue → TH0010 (#26) ──
+-- The desugared body would skip the update clause on `continue`.
+def testGeneralForContinueTH0010 : IO Unit := expectTH
+  "function f(n: number): number { let t = 0; for (let i = n; i > 0; i -= 2) { if (i > 4) { continue; } t += i; } return t; }"
+  ["TH0010"]
+
+-- ── Case 26: module-level while → TH0010 (no function context) ──
+def testTopLevelWhileTH0010 : IO Unit := expectTH
+  "while (false) { }"
+  ["TH0010"]
+
 #eval testForOfAdmitted
 #eval testCanonicalForAdmitted
-#eval testWhileTH0010
+#eval testWhileAdmitted
 #eval testForOfDestructuringTH0010
 #eval testForOfCallRhsTH0010
 #eval testForOfWithTryTH0010
 #eval testForOfThrowsFnTH0010
-#eval testBothAdmittedAndWhileTH0010
+#eval testBothAdmittedAndLabeledWhileTH0010
 #eval testTopLevelForOfTH0010
 #eval testUnlabeledBreakInForOfOk
 #eval testCanonicalForLengthBound
@@ -165,3 +225,13 @@ def testForStringLengthBoundTH0010 : IO Unit := expectTH
 #eval testForOfBodyDeclArrayTH0010
 #eval testLabeledForOfNoBreakTH0010
 #eval testForStringLengthBoundTH0010
+#eval testDoWhileAdmitted
+#eval testDoWhileContinueTH0010
+#eval testWhileThrowsFnTH0010
+#eval testTotalWhileTH0068
+#eval testTotalDoWhileTH0068
+#eval testTotalCanonicalForOk
+#eval testGeneralForAdmitted
+#eval testTotalGeneralForTH0068
+#eval testGeneralForContinueTH0010
+#eval testTopLevelWhileTH0010

--- a/Thales/Emit/EscapeAnalysis.lean
+++ b/Thales/Emit/EscapeAnalysis.lean
@@ -63,8 +63,9 @@ structure MutationInfo where
   hasLowerableLoop : Bool := false
   /-- The own body contains a loop do-mode cannot lower: `notLowerable`
       shape, a loop variable that is reassigned, a canonical-for bound
-      identifier that is reassigned, or a labeled break/continue. Poisons
-      do-mode wholesale, like `hasTryShape`. -/
+      identifier that is reassigned, a labeled break/continue, or a
+      do-while with a loop-level `continue` (#26). Poisons do-mode
+      wholesale, like `hasTryShape`. -/
   hasUnloweredLoopShape : Bool := false
 
 def MutationInfo.eligible (info : MutationInfo) (name : String) : Bool :=
@@ -266,12 +267,25 @@ partial def walkStmt (acc : MutationInfo) : Statement → MutationInfo
             | some _ => { a with initializedLets := a.initializedLets.insert id.name }
             | none => { a with uninitializedLets := a.uninitializedLets.insert id.name }
         | _ => a) acc
+  -- #26: while/do-while have no loop variable or bound to constrain — any
+  -- test expression is re-evaluated per iteration by Lean's `while` /
+  -- `repeat … until` exactly as in TS. Only labeled break/continue (no
+  -- labeledStmt lowering) and, for do-while, a loop-level `continue`
+  -- (Lean's `repeat … until` re-enters the body without checking the test,
+  -- where TS jumps to it) poison the shape.
   | .whileStmt _ t b =>
       let acc := walkStmt (walkExpr acc t) b
-      { acc with hasUnloweredLoopShape := true }
+      if LoopShape.hasLabeledBreakOrContinue b then
+        { acc with hasUnloweredLoopShape := true }
+      else
+        { acc with hasLowerableLoop := true }
   | .doWhileStmt _ b t =>
       let acc := walkExpr (walkStmt acc b) t
-      { acc with hasUnloweredLoopShape := true }
+      if LoopShape.hasLabeledBreakOrContinue b
+          || LoopShape.hasOwnUnlabeledContinue b then
+        { acc with hasUnloweredLoopShape := true }
+      else
+        { acc with hasLowerableLoop := true }
   | s@(.forStmt _ init t u b) =>
       -- Walk order: init, test, body, THEN the update — `accAfterBody`
       -- excludes the structural `i++` so it can't poison the loop var.
@@ -297,7 +311,14 @@ partial def walkStmt (acc : MutationInfo) : Statement → MutationInfo
             { accFinal with hasUnloweredLoopShape := true }
           else
             { accFinal with hasLowerableLoop := true }
-      | _ => { accFinal with hasUnloweredLoopShape := true }
+      | _ =>
+          -- #26: a non-canonical `for` that can desugar to
+          -- `init; while (test) { body; update }` is lowerable.
+          if LoopShape.generalForDesugarable s
+              && !LoopShape.hasLabeledBreakOrContinue b then
+            { accFinal with hasLowerableLoop := true }
+          else
+            { accFinal with hasUnloweredLoopShape := true }
   | s@(.forOfStmt _ left r b _) =>
       -- Walk children first so the mutated set is populated, then classify.
       let acc := match left with

--- a/Thales/Emit/EscapeAnalysis.lean
+++ b/Thales/Emit/EscapeAnalysis.lean
@@ -64,7 +64,7 @@ structure MutationInfo where
   /-- The own body contains a loop do-mode cannot lower: `notLowerable`
       shape, a loop variable that is reassigned, a canonical-for bound
       identifier that is reassigned, a labeled break/continue, or a
-      do-while with a loop-level `continue` (#26). Poisons do-mode
+      do-while with a loop-level `continue`. Poisons do-mode
       wholesale, like `hasTryShape`. -/
   hasUnloweredLoopShape : Bool := false
 
@@ -267,7 +267,7 @@ partial def walkStmt (acc : MutationInfo) : Statement → MutationInfo
             | some _ => { a with initializedLets := a.initializedLets.insert id.name }
             | none => { a with uninitializedLets := a.uninitializedLets.insert id.name }
         | _ => a) acc
-  -- #26: while/do-while have no loop variable or bound to constrain — any
+  -- while/do-while have no loop variable or bound to constrain — any
   -- test expression is re-evaluated per iteration by Lean's `while` /
   -- `repeat … until` exactly as in TS. Only labeled break/continue (no
   -- labeledStmt lowering) and, for do-while, a loop-level `continue`
@@ -312,10 +312,9 @@ partial def walkStmt (acc : MutationInfo) : Statement → MutationInfo
           else
             { accFinal with hasLowerableLoop := true }
       | _ =>
-          -- #26: a non-canonical `for` that can desugar to
+          -- A non-canonical `for` that can desugar to
           -- `init; while (test) { body; update }` is lowerable.
-          if LoopShape.generalForDesugarable s
-              && !LoopShape.hasLabeledBreakOrContinue b then
+          if (LoopShape.desugarGeneralFor s).isSome then
             { accFinal with hasLowerableLoop := true }
           else
             { accFinal with hasUnloweredLoopShape := true }

--- a/Thales/Emit/Lean.lean
+++ b/Thales/Emit/Lean.lean
@@ -1206,40 +1206,15 @@ partial def emitBodyDo (env : EmitEnv) (info : EscapeAnalysis.MutationInfo)
                 { env with bindingEnv := env.bindingEnv.insert i .number }
               .forDo i iterExpr (shim :: emitBodyDo env' info (blockStmts body))
                 :: emitBodyDo env info rest
-      -- #26: a non-canonical `for` desugars at the AST level to
-      -- `init; while (test) { body; update }` and re-enters this function,
-      -- reusing the while lowering (and `emitVarDeclDo`'s `let mut`
-      -- routing for the init declarator). A missing test is `while true`.
-      -- The init binding outliving the loop in the Lean block is safe:
-      -- shadowing rejection (TH0032) keeps any same-named outer binding
-      -- out, so no later read can resolve to the loop variable.
+      -- A non-canonical `for` desugars to `init; while (test) { body;
+      -- update }` and re-enters this function, reusing the while lowering.
       | .notLowerable =>
-          match s with
-          | .forStmt fb init test update body =>
-              if LoopShape.generalForDesugarable s
-                  && !(LoopShape.hasLabeledBreakOrContinue body) then
-                let initStmts : List Statement := match init with
-                  | none => []
-                  | some (.inl e) => [.exprStmt fb e]
-                  | some (.inr vd) => [.variableDecl vd]
-                let testE : Expression := match test with
-                  | some e => e
-                  | none => .literal fb (.boolean true) "true"
-                let bodyStmts := blockStmts body
-                  ++ (match update with
-                      | some u => [.exprStmt fb u]
-                      | none => [])
-                emitBodyDo env info
-                  (initStmts
-                    ++ .whileStmt fb testE (.blockStmt fb bodyStmts) :: rest)
-              else unloweredDoStmt
-          | _ => unloweredDoStmt
-  -- #26 loop lowering: `while (c) body` → `while c do …`; `do body while (c)`
-  -- → `repeat … until !(c)` (TS loops WHILE the test holds, Lean loops UNTIL
-  -- it does). EscapeAnalysis admits only lowerable shapes into do-mode —
-  -- labeled break/continue, and a do-while whose loop-level `continue` would
-  -- skip the until-check, were poisoned upstream; the re-checks here are
-  -- defence-in-depth against phase drift, like the for cases above.
+          match LoopShape.desugarGeneralFor s with
+          | some desugared => emitBodyDo env info (desugared ++ rest)
+          | none => unloweredDoStmt
+  -- `while (c) body` → `while c do …`; `do body while (c)` →
+  -- `repeat … until !(c)`: TS loops WHILE the test holds, Lean's `repeat`
+  -- runs UNTIL it does. The shape re-checks are defence-in-depth, as above.
   | .whileStmt _ test body :: rest =>
       if LoopShape.hasLabeledBreakOrContinue body then unloweredDoStmt
       else

--- a/Thales/Emit/Lean.lean
+++ b/Thales/Emit/Lean.lean
@@ -1206,7 +1206,52 @@ partial def emitBodyDo (env : EmitEnv) (info : EscapeAnalysis.MutationInfo)
                 { env with bindingEnv := env.bindingEnv.insert i .number }
               .forDo i iterExpr (shim :: emitBodyDo env' info (blockStmts body))
                 :: emitBodyDo env info rest
-      | .notLowerable => unloweredDoStmt
+      -- #26: a non-canonical `for` desugars at the AST level to
+      -- `init; while (test) { body; update }` and re-enters this function,
+      -- reusing the while lowering (and `emitVarDeclDo`'s `let mut`
+      -- routing for the init declarator). A missing test is `while true`.
+      -- The init binding outliving the loop in the Lean block is safe:
+      -- shadowing rejection (TH0032) keeps any same-named outer binding
+      -- out, so no later read can resolve to the loop variable.
+      | .notLowerable =>
+          match s with
+          | .forStmt fb init test update body =>
+              if LoopShape.generalForDesugarable s
+                  && !(LoopShape.hasLabeledBreakOrContinue body) then
+                let initStmts : List Statement := match init with
+                  | none => []
+                  | some (.inl e) => [.exprStmt fb e]
+                  | some (.inr vd) => [.variableDecl vd]
+                let testE : Expression := match test with
+                  | some e => e
+                  | none => .literal fb (.boolean true) "true"
+                let bodyStmts := blockStmts body
+                  ++ (match update with
+                      | some u => [.exprStmt fb u]
+                      | none => [])
+                emitBodyDo env info
+                  (initStmts
+                    ++ .whileStmt fb testE (.blockStmt fb bodyStmts) :: rest)
+              else unloweredDoStmt
+          | _ => unloweredDoStmt
+  -- #26 loop lowering: `while (c) body` → `while c do …`; `do body while (c)`
+  -- → `repeat … until !(c)` (TS loops WHILE the test holds, Lean loops UNTIL
+  -- it does). EscapeAnalysis admits only lowerable shapes into do-mode —
+  -- labeled break/continue, and a do-while whose loop-level `continue` would
+  -- skip the until-check, were poisoned upstream; the re-checks here are
+  -- defence-in-depth against phase drift, like the for cases above.
+  | .whileStmt _ test body :: rest =>
+      if LoopShape.hasLabeledBreakOrContinue body then unloweredDoStmt
+      else
+        .whileDo (emitExprEnv env test) (emitBodyDo env info (blockStmts body))
+          :: emitBodyDo env info rest
+  | .doWhileStmt _ body test :: rest =>
+      if LoopShape.hasLabeledBreakOrContinue body
+          || LoopShape.hasOwnUnlabeledContinue body then unloweredDoStmt
+      else
+        .repeatUntilDo (emitBodyDo env info (blockStmts body))
+            (.app (.var "not") [emitExprEnv env test])
+          :: emitBodyDo env info rest
   -- #25: unlabeled break/continue map 1:1; trailing statements are dead code
   -- and dropped (same convention as `return`). Labeled forms fall through to
   -- the loud marker (EscapeAnalysis poisons them upstream).

--- a/Thales/Emit/LeanSyntax.lean
+++ b/Thales/Emit/LeanSyntax.lean
@@ -87,10 +87,10 @@ inductive LDoStmt where
   | matchDo (scrutinee : LExpr) (arms : List (LPattern × List LDoStmt))
   -- `for v in iter do …` (#25); may run zero iterations, so not terminating
   | forDo (var : String) (iter : LExpr) (body : List LDoStmt)
-  -- `while c do …` (#26); the condition is re-evaluated per iteration and
+  -- `while c do …`; the condition is re-evaluated per iteration and
   -- `continue` re-checks it, matching TS `while`
   | whileDo (cond : LExpr) (body : List LDoStmt)
-  -- `repeat … until c` (#26); body runs at least once — TS `do`/`while`
+  -- `repeat … until c`; body runs at least once — TS `do`/`while`
   -- (callers negate the TS test: TS loops WHILE true, Lean loops UNTIL true)
   | repeatUntilDo (body : List LDoStmt) (cond : LExpr)
   | breakDo                                                       -- break
@@ -113,7 +113,7 @@ partial def doStmtsTerminate (stmts : List LDoStmt) : Bool :=
   | some (.matchDo _ arms) =>
       !arms.isEmpty && arms.all fun (_, ss) => doStmtsTerminate ss
   -- Deliberately covers letMut/letPure/assign/forDo/whileDo/repeatUntilDo/
-  -- breakDo/continueDo. forDo and whileDo may run zero iterations (#25/#26);
+  -- breakDo/continueDo. forDo and whileDo may run zero iterations;
   -- repeatUntilDo runs at least once but its exits (until-check, break) need
   -- no trailing return, so all three stay conservatively non-terminating.
   | some _ => false

--- a/Thales/Emit/LeanSyntax.lean
+++ b/Thales/Emit/LeanSyntax.lean
@@ -87,6 +87,12 @@ inductive LDoStmt where
   | matchDo (scrutinee : LExpr) (arms : List (LPattern × List LDoStmt))
   -- `for v in iter do …` (#25); may run zero iterations, so not terminating
   | forDo (var : String) (iter : LExpr) (body : List LDoStmt)
+  -- `while c do …` (#26); the condition is re-evaluated per iteration and
+  -- `continue` re-checks it, matching TS `while`
+  | whileDo (cond : LExpr) (body : List LDoStmt)
+  -- `repeat … until c` (#26); body runs at least once — TS `do`/`while`
+  -- (callers negate the TS test: TS loops WHILE true, Lean loops UNTIL true)
+  | repeatUntilDo (body : List LDoStmt) (cond : LExpr)
   | breakDo                                                       -- break
   | continueDo                                                    -- continue
 
@@ -106,8 +112,10 @@ partial def doStmtsTerminate (stmts : List LDoStmt) : Bool :=
       !els.isEmpty && doStmtsTerminate thn && doStmtsTerminate els
   | some (.matchDo _ arms) =>
       !arms.isEmpty && arms.all fun (_, ss) => doStmtsTerminate ss
-  -- Deliberately covers letMut/letPure/assign/forDo/breakDo/continueDo.
-  -- forDo may run zero iterations and so is never itself terminating (#25).
+  -- Deliberately covers letMut/letPure/assign/forDo/whileDo/repeatUntilDo/
+  -- breakDo/continueDo. forDo and whileDo may run zero iterations (#25/#26);
+  -- repeatUntilDo runs at least once but its exits (until-check, break) need
+  -- no trailing return, so all three stay conservatively non-terminating.
   | some _ => false
 
 /-- Top-level declaration. -/
@@ -297,6 +305,10 @@ mutual
         s!"match {renderExpr scrut} with\n{lines armsS}"
     | .forDo var iter body =>
         s!"for {var} in {renderExpr iter} do\n{indent (renderDoStmts body)}"
+    | .whileDo cond body =>
+        s!"while {renderExpr cond} do\n{indent (renderDoStmts body)}"
+    | .repeatUntilDo body cond =>
+        s!"repeat\n{indent (renderDoStmts body)}\nuntil {renderExpr cond}"
     | .breakDo    => "break"
     | .continueDo => "continue"
 

--- a/Thales/Emit/LoopShape.lean
+++ b/Thales/Emit/LoopShape.lean
@@ -99,4 +99,61 @@ partial def hasLabeledBreakOrContinue : Statement → Bool
         || (match f with | some s => hasLabeledBreakOrContinue s | none => false)
   | _ => false
 
+/-- An unlabeled `continue` that binds to THIS loop: the walk descends
+    through blocks/ifs/switch/try but stops at nested loops (whose own
+    `continue` binds to them) and nested functions. TS `continue` in a
+    do-while jumps to the test, but Lean's `repeat ... until` re-enters the
+    body without checking — and in a while-desugared `for`, `continue`
+    would skip the update clause — so those loop bodies stay rejected
+    when this holds (#26). -/
+partial def hasOwnUnlabeledContinue : Statement → Bool
+  | .continueStmt _ none => true
+  | .blockStmt _ ss => ss.any hasOwnUnlabeledContinue
+  | .ifStmt _ _ c a =>
+      hasOwnUnlabeledContinue c
+        || (match a with | some s => hasOwnUnlabeledContinue s | none => false)
+  | .labeledStmt _ _ b | .withStmt _ _ b => hasOwnUnlabeledContinue b
+  | .switchStmt _ _ cases =>
+      cases.any fun (.mk _ _ ss) => ss.any hasOwnUnlabeledContinue
+  | .tryStmt _ b h f =>
+      hasOwnUnlabeledContinue b
+        || (match h with
+            | some (.mk _ _ hb _) => hasOwnUnlabeledContinue hb
+            | none => false)
+        || (match f with | some s => hasOwnUnlabeledContinue s | none => false)
+  -- Nested loops and (nested-function-bearing) statements stop the walk.
+  | _ => false
+
+/-- A non-canonical C-style `for` that can desugar to
+    `init; while (test) { body; update }` (#26). Conditions:
+
+    * NOT `canonicalFor`-shaped — the canonical form keeps its structural
+      `for i in [0:B]` lowering (`@total`-friendly; a desugared `while` is
+      not). A canonical SHAPE whose operand later fails the caller's array
+      check stays rejected rather than falling back here, preserving the
+      #25 boundaries.
+    * init is empty, a bare expression, or a single-identifier `let`/`const`
+      declarator WITH an initializer (`var` hoists; out of subset).
+    * if an update clause exists, the body has no loop-level `continue` —
+      TS `continue` runs the update, but the desugared `while` body would
+      skip it. With no update clause, `continue` just re-checks the test
+      in both, so it stays admitted.
+
+    A missing test means `while (true)`. Labeled break/continue is the
+    callers' (existing) poison check, as for the other loop shapes. -/
+def generalForDesugarable : Statement → Bool
+  | s@(.forStmt _ init _ update body) =>
+      (match classifyLoop s with
+       | .canonicalFor _ _ _ => false
+       | .forOf _ _ _ _ => false
+       | .notLowerable =>
+        (match init with
+         | none => true
+         | some (.inl _) => true
+         | some (.inr (.mk _ [.mk _ (.identifier _) (some _) _] kind)) =>
+             kind != .var
+         | some (.inr _) => false)
+        && (update.isNone || !hasOwnUnlabeledContinue body))
+  | _ => false
+
 end Thales.Emit.LoopShape

--- a/Thales/Emit/LoopShape.lean
+++ b/Thales/Emit/LoopShape.lean
@@ -105,7 +105,7 @@ partial def hasLabeledBreakOrContinue : Statement → Bool
     do-while jumps to the test, but Lean's `repeat ... until` re-enters the
     body without checking — and in a while-desugared `for`, `continue`
     would skip the update clause — so those loop bodies stay rejected
-    when this holds (#26). -/
+    when this holds. -/
 partial def hasOwnUnlabeledContinue : Statement → Bool
   | .continueStmt _ none => true
   | .blockStmt _ ss => ss.any hasOwnUnlabeledContinue
@@ -125,13 +125,13 @@ partial def hasOwnUnlabeledContinue : Statement → Bool
   | _ => false
 
 /-- A non-canonical C-style `for` that can desugar to
-    `init; while (test) { body; update }` (#26). Conditions:
+    `init; while (test) { body; update }`. Conditions:
 
     * NOT `canonicalFor`-shaped — the canonical form keeps its structural
       `for i in [0:B]` lowering (`@total`-friendly; a desugared `while` is
       not). A canonical SHAPE whose operand later fails the caller's array
       check stays rejected rather than falling back here, preserving the
-      #25 boundaries.
+      canonical-for operand boundaries.
     * init is empty, a bare expression, or a single-identifier `let`/`const`
       declarator WITH an initializer (`var` hoists; out of subset).
     * if an update clause exists, the body has no loop-level `continue` —
@@ -155,5 +155,36 @@ def generalForDesugarable : Statement → Bool
          | some (.inr _) => false)
         && (update.isNone || !hasOwnUnlabeledContinue body))
   | _ => false
+
+/-- The desugaring of a non-canonical `for`:
+    `for (init; test; update) body` → `init; while (test) { body; update }`,
+    with a missing test desugaring to `while (true)`. `none` unless
+    `generalForDesugarable` holds and the body is free of labeled
+    break/continue (no loop lowering supports labels). EscapeAnalysis,
+    SubsetCheck, and the emitter all consume this one decomposition, so the
+    phases cannot disagree about whether a `for` desugars or what it
+    desugars to. The init binding outliving the loop in the enclosing block
+    is safe: shadowing rejection (TH0032) keeps any same-named outer
+    binding out, so no later read can resolve to the loop variable. -/
+def desugarGeneralFor : Statement → Option (List Statement)
+  | s@(.forStmt fb init test update body) =>
+      if generalForDesugarable s && !hasLabeledBreakOrContinue body then
+        let initStmts : List Statement := match init with
+          | none => []
+          | some (.inl e) => [.exprStmt fb e]
+          | some (.inr vd) => [.variableDecl vd]
+        let testE : Expression := match test with
+          | some e => e
+          | none => .literal fb (.boolean true) "true"
+        let bodyStmts : List Statement :=
+          (match body with
+           | .blockStmt _ ss => ss
+           | other => [other])
+          ++ (match update with
+              | some u => [.exprStmt fb u]
+              | none => [])
+        some (initStmts ++ [.whileStmt fb testE (.blockStmt fb bodyStmts)])
+      else none
+  | _ => none
 
 end Thales.Emit.LoopShape

--- a/Thales/Emit/SubsetCheck.lean
+++ b/Thales/Emit/SubsetCheck.lean
@@ -49,6 +49,11 @@ structure MutCtx where
       stays rejected in v1 even when the eligibility analysis would allow
       it. -/
   allowEligible : Bool := false
+  /-- Inside a `@total` function body. while/do-while (and while-desugared
+      `for`) lower to a partial-backed combinator the termination verifier
+      cannot see through, so they draw TH0068 here instead of being
+      admitted (#26). -/
+  inTotalFn : Bool := false
   /-- Type alias environment threaded from the enclosing `annotatedFuncDecl`
       context; used to resolve array types for for-of admission. -/
   aliasEnv : Std.HashMap String TSType := {}
@@ -291,25 +296,64 @@ partial def checkStmt (ctx : MutCtx) (stmt : Statement) : Array Diagnostic :=
   -- shape AND its array operand (for-of RHS / length bound) passes
   -- `identIsArray`; otherwise exactly one TH0010 and no body recursion.
   -- doModeLowerable keeps the phases agreeing: a function holding both an
-  -- admitted-shape loop and a `while` rejects BOTH loops.
-  | .whileStmt b _ _ =>
-    #[mkThalesDiag .loopNotSupported b.loc]
-  | .doWhileStmt b _ _ =>
-    #[mkThalesDiag .loopNotSupported b.loc]
+  -- admitted-shape loop and an unlowerable one (labeled break/continue,
+  -- do-while with loop-level `continue`) rejects BOTH loops.
+  --
+  -- #26: while/do-while have no per-loop shape conditions beyond what
+  -- EscapeAnalysis already folded into `doModeLowerable` (labels,
+  -- do-while `continue`). In a `@total` function the admitted shapes draw
+  -- TH0068 instead: their lowering is partial-backed and would make the
+  -- lake-side termination verification pass vacuously.
+  | .whileStmt b test body =>
+    if loopContextAdmitted ctx then
+      if ctx.inTotalFn then
+        #[mkThalesDiag .totalHasUnverifiableLoop b.loc]
+      else
+        checkExpr ctx test ++ checkStmt ctx body
+    else
+      #[mkThalesDiag .loopNotSupported b.loc]
+  | .doWhileStmt b body test =>
+    if loopContextAdmitted ctx then
+      if ctx.inTotalFn then
+        #[mkThalesDiag .totalHasUnverifiableLoop b.loc]
+      else
+        checkStmt ctx body ++ checkExpr ctx test
+    else
+      #[mkThalesDiag .loopNotSupported b.loc]
   | .forInStmt b _ _ _ =>
     #[mkThalesDiag .loopNotSupported b.loc]
-  | s@(.forStmt b _ _ _ body) =>
-    let admitted :=
-      loopContextAdmitted ctx
-        && (match LoopShape.classifyLoop s with
-            | .canonicalFor _ (.inl _) _ => true
-            | .canonicalFor _ (.inr arrName) _ => identIsArray ctx arrName
-            | _ => false)
-    if admitted then
+  | s@(.forStmt b init test update body) =>
+    let canonicalAdmitted :=
+      match LoopShape.classifyLoop s with
+      | .canonicalFor _ (.inl _) _ => true
+      | .canonicalFor _ (.inr arrName) _ => identIsArray ctx arrName
+      | _ => false
+    if loopContextAdmitted ctx && canonicalAdmitted then
       -- Only the body: classifyLoop already constrained init/test/update to
       -- bare shapes, and routing `i++` through checkExpr would draw
       -- .assignmentInExpressionPosition.
       checkStmt ctx body
+    else if loopContextAdmitted ctx && LoopShape.generalForDesugarable s then
+      -- #26: desugars to `init; while (test) { body; update }`. In a
+      -- `@total` function that lowering is partial-backed — TH0068, like
+      -- while itself. Init and update are checked in STATEMENT position
+      -- (that is where the desugar puts them), so `i -= 2` routes through
+      -- the statement-position mutation rules, not
+      -- .assignmentInExpressionPosition.
+      if ctx.inTotalFn then
+        #[mkThalesDiag .totalHasUnverifiableLoop b.loc]
+      else
+        (match init with
+          | some (.inr vd) => checkStmt ctx (.variableDecl vd)
+          | some (.inl e) => checkStmt ctx (.exprStmt b e)
+          | none => #[])
+          ++ (match test with
+              | some e => checkExpr ctx e
+              | none => #[])
+          ++ checkStmt ctx body
+          ++ (match update with
+              | some u => checkStmt ctx (.exprStmt b u)
+              | none => #[])
     else
       #[mkThalesDiag .loopNotSupported b.loc]
   | s@(.forOfStmt b _ right body _) =>
@@ -792,11 +836,12 @@ def checkTSStmt (aliasEnv : Std.HashMap String TSType) (ts : TSStatement) : Arra
           | none => #[])
   -- TH0012: async annotated function declarations — emit diagnostic, still recurse body.
   -- TH0060 is no longer SubsetCheck's responsibility, so no suppression filter is needed.
-  | .annotatedFuncDecl b _ _ params returnType body _ async throwsAnn _ =>
+  | .annotatedFuncDecl b _ _ params returnType body _ async throwsAnn isTotal =>
     let ctx : MutCtx :=
       { info := some (EscapeAnalysis.analyze (params.map (·.1)) body),
         noMutZone := throwsAnn != .absent,
         allowEligible := true,
+        inTotalFn := isTotal,
         aliasEnv := aliasEnv,
         bindingEnv := buildParamEnv params }
     let paramTypeDiags := params.foldl (fun acc (_, ann, _, _) =>

--- a/Thales/Emit/SubsetCheck.lean
+++ b/Thales/Emit/SubsetCheck.lean
@@ -52,7 +52,7 @@ structure MutCtx where
   /-- Inside a `@total` function body. while/do-while (and while-desugared
       `for`) lower to a partial-backed combinator the termination verifier
       cannot see through, so they draw TH0068 here instead of being
-      admitted (#26). -/
+      admitted. -/
   inTotalFn : Bool := false
   /-- Type alias environment threaded from the enclosing `annotatedFuncDecl`
       context; used to resolve array types for for-of admission. -/
@@ -91,6 +91,20 @@ private def loopContextAdmitted (ctx : MutCtx) : Bool :=
   match ctx.info with
   | none => false
   | some info => info.doModeLowerable && !ctx.noMutZone && ctx.allowEligible
+
+/-- Shared gate for the while-family loop arms (`while`, `do`/`while`,
+    desugared `for`): an admitted loop inside `@total` draws TH0068 — its
+    lowering is partial-backed, so the lake-side termination verification
+    would pass vacuously — otherwise the operand checks run. An unadmitted
+    loop is exactly one TH0010, no operand recursion. -/
+private def checkAdmittedLoop (ctx : MutCtx) (loc : Option SourceLocation)
+    (admitted : Bool) (operands : Unit → Array Diagnostic)
+    : Array Diagnostic :=
+  if admitted then
+    if ctx.inTotalFn then #[mkThalesDiag .totalHasUnverifiableLoop loc]
+    else operands ()
+  else
+    #[mkThalesDiag .loopNotSupported loc]
 
 /-- Resolve a TSType through type alias references.
     Follows at most one level of .ref to avoid infinite loops in v1. -/
@@ -299,30 +313,21 @@ partial def checkStmt (ctx : MutCtx) (stmt : Statement) : Array Diagnostic :=
   -- admitted-shape loop and an unlowerable one (labeled break/continue,
   -- do-while with loop-level `continue`) rejects BOTH loops.
   --
-  -- #26: while/do-while have no per-loop shape conditions beyond what
-  -- EscapeAnalysis already folded into `doModeLowerable` (labels,
-  -- do-while `continue`). In a `@total` function the admitted shapes draw
-  -- TH0068 instead: their lowering is partial-backed and would make the
-  -- lake-side termination verification pass vacuously.
+  -- while has no per-loop shape conditions beyond what EscapeAnalysis
+  -- already folded into `doModeLowerable` (labels poison it there).
   | .whileStmt b test body =>
-    if loopContextAdmitted ctx then
-      if ctx.inTotalFn then
-        #[mkThalesDiag .totalHasUnverifiableLoop b.loc]
-      else
-        checkExpr ctx test ++ checkStmt ctx body
-    else
-      #[mkThalesDiag .loopNotSupported b.loc]
+    checkAdmittedLoop ctx b.loc (loopContextAdmitted ctx) fun _ =>
+      checkExpr ctx test ++ checkStmt ctx body
+  -- A do-while loop-level `continue` is rejected here, not only via
+  -- EscapeAnalysis poisoning: TS `continue` jumps to the test, but the
+  -- `repeat … until` lowering re-enters the body without checking it.
   | .doWhileStmt b body test =>
-    if loopContextAdmitted ctx then
-      if ctx.inTotalFn then
-        #[mkThalesDiag .totalHasUnverifiableLoop b.loc]
-      else
-        checkStmt ctx body ++ checkExpr ctx test
-    else
-      #[mkThalesDiag .loopNotSupported b.loc]
+    checkAdmittedLoop ctx b.loc
+      (loopContextAdmitted ctx && !LoopShape.hasOwnUnlabeledContinue body)
+      fun _ => checkStmt ctx body ++ checkExpr ctx test
   | .forInStmt b _ _ _ =>
     #[mkThalesDiag .loopNotSupported b.loc]
-  | s@(.forStmt b init test update body) =>
+  | s@(.forStmt b _ _ _ body) =>
     let canonicalAdmitted :=
       match LoopShape.classifyLoop s with
       | .canonicalFor _ (.inl _) _ => true
@@ -333,29 +338,20 @@ partial def checkStmt (ctx : MutCtx) (stmt : Statement) : Array Diagnostic :=
       -- bare shapes, and routing `i++` through checkExpr would draw
       -- .assignmentInExpressionPosition.
       checkStmt ctx body
-    else if loopContextAdmitted ctx && LoopShape.generalForDesugarable s then
-      -- #26: desugars to `init; while (test) { body; update }`. In a
-      -- `@total` function that lowering is partial-backed — TH0068, like
-      -- while itself. Init and update are checked in STATEMENT position
-      -- (that is where the desugar puts them), so `i -= 2` routes through
-      -- the statement-position mutation rules, not
-      -- .assignmentInExpressionPosition.
-      if ctx.inTotalFn then
-        #[mkThalesDiag .totalHasUnverifiableLoop b.loc]
-      else
-        (match init with
-          | some (.inr vd) => checkStmt ctx (.variableDecl vd)
-          | some (.inl e) => checkStmt ctx (.exprStmt b e)
-          | none => #[])
-          ++ (match test with
-              | some e => checkExpr ctx e
-              | none => #[])
-          ++ checkStmt ctx body
-          ++ (match update with
-              | some u => checkStmt ctx (.exprStmt b u)
-              | none => #[])
     else
-      #[mkThalesDiag .loopNotSupported b.loc]
+      match LoopShape.desugarGeneralFor s with
+      | some desugared =>
+        if loopContextAdmitted ctx then
+          -- Check the statements the emitter will actually lower: init and
+          -- update land in STATEMENT position (so `i -= 2` routes through
+          -- the statement-position mutation rules, not
+          -- .assignmentInExpressionPosition) and the while arm supplies
+          -- the `@total` gate (TH0068).
+          desugared.foldl (fun acc d => acc ++ checkStmt ctx d) #[]
+        else
+          #[mkThalesDiag .loopNotSupported b.loc]
+      | none =>
+        #[mkThalesDiag .loopNotSupported b.loc]
   | s@(.forOfStmt b _ right body _) =>
     let rhsIsArray : Bool :=
       match right with

--- a/Thales/TS/Runtime.lean
+++ b/Thales/TS/Runtime.lean
@@ -191,6 +191,13 @@ axiom Float.ofInt_le (m n : Int) (hm : m.natAbs ≤ 9007199254740991)
     no theorem in Lean's stdlib asserts this directly. -/
 axiom Nat.toFloat_nonneg (n : Nat) : n.toFloat ≥ 0.0
 
+/-- JS `+` on two strings is concatenation. The emitter lowers TS `+`
+    uniformly to Lean `+`; this instance covers the String × String case
+    (#26 left-pad arc). Mixed string/number `+` (JS coerces) deliberately
+    has no instance — it fails loudly at the Lean stage rather than
+    miscompiling. -/
+instance : HAdd String String String := ⟨String.append⟩
+
 /-- Embed a `String`'s `length` as a `Natural`. Same shape as
     `Array.toNaturalSize`; bounds the length at MAX_SAFE_INTEGER. -/
 def String.toNaturalLength (s : String) : Natural :=

--- a/Thales/TS/Runtime.lean
+++ b/Thales/TS/Runtime.lean
@@ -192,8 +192,8 @@ axiom Float.ofInt_le (m n : Int) (hm : m.natAbs ≤ 9007199254740991)
 axiom Nat.toFloat_nonneg (n : Nat) : n.toFloat ≥ 0.0
 
 /-- JS `+` on two strings is concatenation. The emitter lowers TS `+`
-    uniformly to Lean `+`; this instance covers the String × String case
-    (#26 left-pad arc). Mixed string/number `+` (JS coerces) deliberately
+    uniformly to Lean `+`; this instance covers the String × String case.
+    Mixed string/number `+` (JS coerces) deliberately
     has no instance — it fails loudly at the Lean stage rather than
     miscompiling. -/
 instance : HAdd String String String := ⟨String.append⟩

--- a/Thales/TypeCheck/Diagnostic.lean
+++ b/Thales/TypeCheck/Diagnostic.lean
@@ -94,6 +94,10 @@ inductive ThalesKind where
   | throwsRequiresTypeList
   | totalConflictsWithThrows
   | totalHasUncaughtThrow (source : ThrowSource)
+  -- TH0068: while/do-while (and while-desugared `for`) lower to a
+  -- partial-backed combinator the termination verifier cannot see through,
+  -- so they cannot substantiate a `@total` claim (#26).
+  | totalHasUnverifiableLoop
   | totalityUnverified (leanError : String)
   -- Refinement-type diagnostics (TH0080–TH0081)
   | literalOutOfRange (literal : Float) (typeName : String) (min : Option Float) (max : Option Float)
@@ -135,6 +139,7 @@ def ThalesKind.thCode : ThalesKind → Nat
   | .throwsRequiresTypeList => 65
   | .totalConflictsWithThrows => 66
   | .totalHasUncaughtThrow _ => 67
+  | .totalHasUnverifiableLoop => 68
   | .totalityUnverified _ => 70
   | .literalOutOfRange .. => 80
   | .refinementNeedsEvidence .. => 81
@@ -192,6 +197,8 @@ def ThalesKind.message : ThalesKind → String
     "`@total` function has an uncaught `throw`; wrap it in `try`/`catch` or remove `@total`"
   | .totalHasUncaughtThrow (.fromCall callee) =>
     s!"`@total` function calls `@throws`-annotated `{callee}` outside `try`/`catch`; catch the failure or remove `@total`"
+  | .totalHasUnverifiableLoop =>
+    "`@total` function contains a loop whose termination cannot be verified; use a for-of loop or recursion, or remove `@total`"
   | .totalityUnverified leanError =>
     s!"`@total` asserted but Lean could not prove termination: {leanError}"
   | .literalOutOfRange lit tyName min max =>

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -217,16 +217,14 @@ do-mode-lowerable declared functions:
   `B` is a non-negative integer literal or an array-typed `arr.length`, bound
   array not reassigned in the body.
 - `while (test) body` — any test expression; lowered to Lean do-notation
-  `while` ([#26](https://github.com/jessealama/thales/issues/26)). Not
-  allowed in `@total` functions — see TH0068.
+  `while`. Not allowed in `@total` functions — see TH0068.
 - `do body while (test)` — lowered to `repeat ... until !(test)`; the body
   runs at least once, as in TS. Same `@total` exclusion. A loop-level
   `continue` keeps a do-while rejected: TS `continue` jumps to the test,
   but Lean's `repeat ... until` re-enters the body without checking it.
 - Non-canonical C-style `for` (any init/test/update combination with a
   simple-identifier `let`/`const` init declarator, bare-expression init, or
-  no init) — desugared to `init; while (test) { body; update }`
-  ([#26](https://github.com/jessealama/thales/issues/26)). Same `@total`
+  no init) — desugared to `init; while (test) { body; update }`. Same `@total`
   exclusion as `while` (TH0068), and a loop-level `continue` keeps the
   shape rejected when an update clause exists (the desugared body would
   skip the update where TS runs it).

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -20,7 +20,7 @@ displayed in diagnostics for human readability.
 See `docs/superpowers/specs/2026-04-21-conformance-harness-design.md` for
 the full contract and harness details.
 
-This reference lists all 20 subset `TH####` codes plus the 5 directive
+This reference lists all subset `TH####` codes plus the 5 directive
 codes (TH9000–TH9004) with minimal detail. For full explanation,
 rationale, and idiomatic replacements, see [subset.md](./subset.md).
 
@@ -67,6 +67,7 @@ soundness check).
 | TH0050 | Recursion    | Cannot verify termination                           |
 | TH0066 | Totality     | `@total` and `@throws` declared together            |
 | TH0067 | Totality     | `@total` function has uncaught throw                |
+| TH0068 | Totality     | `@total` function contains an unverifiable loop     |
 | TH0070 | Totality     | `@total` asserted but Lean rejects termination      |
 | TH0060 | Exceptions   | Unannotated `throw`                                 |
 | TH0061 | Exceptions   | Unused `@throws` annotation                         |
@@ -215,18 +216,34 @@ do-mode-lowerable declared functions:
 - `for (let i = 0; i < B; i++)` — canonical C-style with `i++` update, bound
   `B` is a non-negative integer literal or an array-typed `arr.length`, bound
   array not reassigned in the body.
+- `while (test) body` — any test expression; lowered to Lean do-notation
+  `while` ([#26](https://github.com/jessealama/thales/issues/26)). Not
+  allowed in `@total` functions — see TH0068.
+- `do body while (test)` — lowered to `repeat ... until !(test)`; the body
+  runs at least once, as in TS. Same `@total` exclusion. A loop-level
+  `continue` keeps a do-while rejected: TS `continue` jumps to the test,
+  but Lean's `repeat ... until` re-enters the body without checking it.
+- Non-canonical C-style `for` (any init/test/update combination with a
+  simple-identifier `let`/`const` init declarator, bare-expression init, or
+  no init) — desugared to `init; while (test) { body; update }`
+  ([#26](https://github.com/jessealama/thales/issues/26)). Same `@total`
+  exclusion as `while` (TH0068), and a loop-level `continue` keeps the
+  shape rejected when an update clause exists (the desugared body would
+  skip the update where TS runs it).
 - Unlabeled `break`, `continue`, and early `return` inside admitted loops.
 - Mutation inside an admitted loop follows the same rules as mutation
   elsewhere in do-mode (see TH0001–TH0007).
 
-**Still rejected:** `while` / `do-while` (issue [#26](https://github.com/jessealama/thales/issues/26)); `for-in`; `for await`; non-canonical
-C-style `for` (any shape other than `i++` / non-negative literal or
-array-typed `arr.length` bound); destructuring or expression loop-variable
-heads;
+**Still rejected:** `for-in`; `for await`; `var` or destructuring or
+expression loop-variable heads; canonical-shaped `for` whose bound is not a
+non-negative integer literal or array-typed `arr.length` (e.g. a
+string-typed `s.length`);
 `for-of` with a call on the right-hand side; loop-variable or bound-array
-reassignment in the body; labeled `break`/`continue`; any loop in a
-`@throws`-annotated function, or a function that contains `try`/`catch` or
-other do-mode-poisoning constructs.
+reassignment in a canonical-for body; labeled `break`/`continue`; a
+loop-level `continue` in a do-while body or in a general `for` body with an
+update clause; any loop at module level, in a
+`@throws`-annotated function, or in a function that contains `try`/`catch`
+or other do-mode-poisoning constructs.
 
 [Details in subset.md#th0010--loop-not-supported-use-recursion-or-array-methods](./subset.md#th0010--loop-not-supported-use-recursion-or-array-methods)
 
@@ -427,7 +444,7 @@ Rejected: `function f(n: bigint): bigint { ... return f(n - 1); ... /* non-struc
 
 ## Totality
 
-`@total` is the Thales-TS claim that **a function always returns a value of its declared return type** — it terminates and has no observable failure modes. Three diagnostics enforce this contract: TH0066 (the annotation can't coexist with `@throws`), TH0067 (no failures may escape the body), and TH0070 (Lean's termination checker must accept the emitted `def`).
+`@total` is the Thales-TS claim that **a function always returns a value of its declared return type** — it terminates and has no observable failure modes. Four diagnostics enforce this contract: TH0066 (the annotation can't coexist with `@throws`), TH0067 (no failures may escape the body), TH0068 (no loops the termination checker can't see through), and TH0070 (Lean's termination checker must accept the emitted `def`).
 
 ### TH0066 — `@total` and `@throws` declared together
 
@@ -488,6 +505,32 @@ function outer(n: number): number {
 ```
 
 Fix: handle the failure case with `try`/`catch`, or annotate the function with `@throws` instead of `@total`.
+
+---
+
+### TH0068 — `@total` function contains an unverifiable loop
+
+**Message:** `` `@total` function contains a loop whose termination cannot be verified; use a for-of loop or recursion, or remove `@total` ``
+
+Emitted at each `while` / `do-while` loop inside a `@total` function. These loops lower to Lean do-notation `while` / `repeat ... until`, which are backed by a partial combinator: the emitted code compiles whether or not the loop terminates, so the lake-side termination verification (TH0070) would pass vacuously instead of checking anything. Rather than let `@total` make a claim the verifier cannot inspect, the combination is rejected outright — mirroring how TH0066 keeps `@total` and `@throws` apart.
+
+`for-of` and canonical `for` loops are unaffected: they lower to Lean's structural `for ... in`, which the termination checker does see through (see `loop-total-forof.ts` in the conformance corpus).
+
+Example (rejected):
+
+```typescript
+/** @total */
+function drain(n: number): number {
+  let i = n;
+  while (i > 0) {
+    // TH0068 (would diverge for non-integer n, unprovable either way)
+    i -= 1;
+  }
+  return i;
+}
+```
+
+Fix: rewrite the loop as for-of/canonical `for` or recursion, or remove `@total` to fall back to `partial def`.
 
 ---
 

--- a/docs/subset.md
+++ b/docs/subset.md
@@ -268,29 +268,62 @@ integer literal or `arr.length` for an array-typed parameter `arr` (a
 bound array (if any) is not reassigned in the body. Lowers to a Lean range
 loop (`for i in [0:B] do`) inside `Id.run do`.
 
+**`while` and `do`/`while`** ([#26](https://github.com/jessealama/thales/issues/26)):
+
+```typescript
+function leftPad(str: string, len: number, ch: string): string {
+  let pad = str;
+  while (pad.length < len) {
+    pad = ch + pad;
+  }
+  return pad;
+}
+```
+
+Any test expression is accepted. `while` lowers to Lean do-notation
+`while`; `do`/`while` lowers to `repeat ... until !(test)` (body runs at
+least once, as in TS). Both are backed by a partial combinator — fine for
+evaluation (the byte-match contract is unaffected), opaque to termination
+proofs — so they are **mutually exclusive with `@total`** (TH0068),
+mirroring the `@total`/`@throws` exclusivity. A do-while whose body has a
+loop-level `continue` stays rejected: TS `continue` jumps to the test,
+but Lean's `repeat ... until` re-enters the body without checking it.
+
+**Non-canonical C-style `for`** ([#26](https://github.com/jessealama/thales/issues/26)):
+any `for (init; test; update)` where init is empty, a bare expression, or
+a single-identifier `let`/`const` declarator with an initializer.
+Desugars to `init; while (test) { body; update }`, so it inherits the
+`while` rules (including the `@total` exclusion, TH0068). A loop-level
+`continue` is rejected when an update clause exists (the desugared body
+would skip the update where TS runs it before re-testing). The canonical
+`for (let i = 0; i < B; i++)` shape keeps its structural range lowering
+above — including its operand restrictions — and stays `@total`-friendly.
+
 **Inside admitted loops:** unlabeled `break`, `continue`, early `return`, and
 mutation following the TH0001–TH0007 rules are all accepted.
 
 #### Still rejected
 
-- `while` and `do`/`while` — issue [#26](https://github.com/jessealama/thales/issues/26).
-  Workaround: recursive helper or array methods.
 - `for-in`, `for await`.
-- Non-canonical C-style `for` (update other than `i++`, bound other than a
-  non-negative integer literal or an array-typed `arr.length`, init other
-  than `let i = 0`).
-- Destructuring or expression loop-variable heads.
+- Canonical-shaped `for` whose bound is not a non-negative integer
+  literal or an array-typed `arr.length` (e.g. a `string`-typed
+  `s.length`) — the canonical shape never falls back to the while-desugar.
+- `var` loop-variable heads; destructuring or expression loop-variable
+  heads in `for-of`.
 - `for-of` with a call expression on the right-hand side.
-- Loop variable or bound array reassigned in the body.
+- Loop variable or bound array reassigned in a canonical-for body.
 - Labeled `break`/`continue`.
-- Any loop inside a `@throws`-annotated function or a function with
-  `try`/`catch`.
+- Loop-level `continue` in a do-while body, or in a general `for` body
+  when an update clause exists.
+- Any loop at module level, inside a `@throws`-annotated function, or in
+  a function with `try`/`catch`.
+- `while`/`do-while`/general `for` inside a `@total` function (TH0068).
 
 For the still-rejected cases, idiomatic replacements are recursive helpers or
 higher-order array methods:
 
 ```typescript
-// while → recursion
+// still-rejected loop (e.g. module-level, or inside @throws/@total) → recursion
 function go(i: number): void {
   if (i >= arr.length) return;
   process(arr[i]);

--- a/docs/subset.md
+++ b/docs/subset.md
@@ -268,7 +268,7 @@ integer literal or `arr.length` for an array-typed parameter `arr` (a
 bound array (if any) is not reassigned in the body. Lowers to a Lean range
 loop (`for i in [0:B] do`) inside `Id.run do`.
 
-**`while` and `do`/`while`** ([#26](https://github.com/jessealama/thales/issues/26)):
+**`while` and `do`/`while`**:
 
 ```typescript
 function leftPad(str: string, len: number, ch: string): string {
@@ -289,7 +289,7 @@ mirroring the `@total`/`@throws` exclusivity. A do-while whose body has a
 loop-level `continue` stays rejected: TS `continue` jumps to the test,
 but Lean's `repeat ... until` re-enters the body without checking it.
 
-**Non-canonical C-style `for`** ([#26](https://github.com/jessealama/thales/issues/26)):
+**Non-canonical C-style `for`**:
 any `for (init; test; update)` where init is empty, a bare expression, or
 a single-identifier `let`/`const` declarator with an initializer.
 Desugars to `init; while (test) { body; update }`, so it inherits the

--- a/docs/test262.md
+++ b/docs/test262.md
@@ -124,6 +124,16 @@ attribution honesty, not new blockage. `parse-error` counts tests where
 thales hard-fails without a structured diagnostic (e.g. multi-declarator
 `var x, y;`).
 
+The #26 re-measure (while/do-while admitted, general C-style `for`
+desugared to `while` — all function-scoped) reproduces this table
+**byte-identically**, zero movement on TH0010 (765) included. That is the
+structurally expected outcome, not a measurement artifact: the slice
+tests are top-level statement scripts, and loop admission is (still)
+function-scoped, so every slice loop keeps drawing module-level TH0010.
+The widening #26 delivers is exercised by the conformance corpus
+(`loop-while-*`, `loop-do-while-*`, `loop-for-general-*`); test262
+movement on these slices is gated entirely on #49.
+
 New shim-attribution rows vs the pre-#24 baseline: TS2322 — #24's
 declared-type precision (unannotated/const bindings are no longer `any`)
 exposes a pre-existing truthy-narrowing gap at `harness/assert.ts:34`

--- a/scripts/run-examples.js
+++ b/scripts/run-examples.js
@@ -406,6 +406,18 @@ function collectCases(rootDir, mode) {
   return cases;
 }
 
+/** Directory membership IS the test specification: each bucket admits
+ *  exactly one pass label. A pass outcome with the wrong label (e.g. an
+ *  accept/ file that is merely subset-rejected) is a corpus violation, not
+ *  a pass — without this, a regression that demotes an accepted example to
+ *  subset-rejected would go unnoticed. */
+const expectedLabelByBucket = {
+  accept: 'accepted',
+  mirror: 'tsc-rejected',
+  reject: 'subset-rejected',
+  throws: 'both-throw',
+};
+
 function runCorpus(rootDir, opts = {}) {
   const cases = collectCases(rootDir, opts.selfTest ? 'subdir' : 'flat');
   let passes = 0;
@@ -417,6 +429,17 @@ function runCorpus(rootDir, opts = {}) {
       outcome = evaluateCase(c.inputPath);
     } catch (e) {
       outcome = { kind: 'fail', label: 'crash', detail: e.stack || e.message };
+    }
+    if (!opts.selfTest && outcome.kind === 'pass') {
+      const bucket = c.label.split('/')[0];
+      const expected = expectedLabelByBucket[bucket];
+      if (expected && outcome.label !== expected) {
+        outcome = {
+          kind: 'fail',
+          label: 'bucket-mismatch',
+          detail: `${bucket}/ requires outcome '${expected}', got '${outcome.label}'`,
+        };
+      }
     }
 
     if (opts.selfTest) {

--- a/scripts/run-examples.js
+++ b/scripts/run-examples.js
@@ -366,18 +366,31 @@ function evaluateCase(inputPath) {
 
 // ---- driver ----
 
-/** Enumerate corpus cases. For `tests/conformance/`, the immediate
- *  subdirectories `accept/`, `reject/`, and `throws/` are each scanned for
- *  `.ts` files; `future/` is skipped (parked fixtures). For
+/** Enumerate corpus cases. For `tests/conformance/`, each bucket
+ *  subdirectory in `corpusBuckets` is scanned for `.ts` files;
+ *  `future/` is skipped (parked fixtures). For
  *  `Test/Examples/fixtures/`, each subdirectory containing `input.ts` is a
  *  case (paired with `expected-outcome.txt`). Returns an array of
  *  {label, inputPath, expectedPath?} ordered by label.
  */
+/** Directory membership IS the test specification: each bucket admits
+ *  exactly one pass label. A pass outcome with the wrong label (e.g. an
+ *  accept/ file that is merely subset-rejected) is a corpus violation, not
+ *  a pass — without this, a regression that demotes an accepted example to
+ *  subset-rejected would go unnoticed. This single table drives both the
+ *  corpus walk and the outcome enforcement, so a bucket cannot be scanned
+ *  without its required label. */
+const corpusBuckets = {
+  accept: 'accepted',
+  mirror: 'tsc-rejected',
+  reject: 'subset-rejected',
+  throws: 'both-throw',
+};
+
 function collectCases(rootDir, mode) {
   const cases = [];
   if (mode === 'flat') {
-    const buckets = ['accept', 'mirror', 'reject', 'throws'];
-    for (const bucket of buckets) {
+    for (const bucket of Object.keys(corpusBuckets)) {
       const bucketDir = path.join(rootDir, bucket);
       if (!fs.existsSync(bucketDir)) continue;
       const files = fs.readdirSync(bucketDir).sort();
@@ -406,18 +419,6 @@ function collectCases(rootDir, mode) {
   return cases;
 }
 
-/** Directory membership IS the test specification: each bucket admits
- *  exactly one pass label. A pass outcome with the wrong label (e.g. an
- *  accept/ file that is merely subset-rejected) is a corpus violation, not
- *  a pass — without this, a regression that demotes an accepted example to
- *  subset-rejected would go unnoticed. */
-const expectedLabelByBucket = {
-  accept: 'accepted',
-  mirror: 'tsc-rejected',
-  reject: 'subset-rejected',
-  throws: 'both-throw',
-};
-
 function runCorpus(rootDir, opts = {}) {
   const cases = collectCases(rootDir, opts.selfTest ? 'subdir' : 'flat');
   let passes = 0;
@@ -432,8 +433,8 @@ function runCorpus(rootDir, opts = {}) {
     }
     if (!opts.selfTest && outcome.kind === 'pass') {
       const bucket = c.label.split('/')[0];
-      const expected = expectedLabelByBucket[bucket];
-      if (expected && outcome.label !== expected) {
+      const expected = corpusBuckets[bucket];
+      if (outcome.label !== expected) {
         outcome = {
           kind: 'fail',
           label: 'bucket-mismatch',

--- a/tests/conformance/accept/loop-do-while-runs-once.ts
+++ b/tests/conformance/accept/loop-do-while-runs-once.ts
@@ -1,0 +1,12 @@
+// #26: `do`/`while` lowers to Lean `repeat ... until !(test)`. The body
+// must run once even when the test is false on entry.
+function countdownSteps(n: number): number {
+  let steps = 0;
+  do {
+    steps += 1;
+    n -= 1;
+  } while (n > 0);
+  return steps;
+}
+console.log(countdownSteps(3));
+console.log(countdownSteps(-5));

--- a/tests/conformance/accept/loop-for-general-step.ts
+++ b/tests/conformance/accept/loop-for-general-step.ts
@@ -1,0 +1,11 @@
+// #26: a non-canonical C-style `for` (non-zero start, `>`, compound step)
+// lowers via while-desugaring: init, then `while test do { body; update }`.
+function sumDown(n: number): number {
+  let total = 0;
+  for (let i = n; i > 0; i -= 2) {
+    total += i;
+  }
+  return total;
+}
+console.log(sumDown(9));
+console.log(sumDown(0));

--- a/tests/conformance/accept/loop-while-break-continue.ts
+++ b/tests/conformance/accept/loop-while-break-continue.ts
@@ -1,0 +1,19 @@
+// #26: unlabeled break/continue inside `while` map 1:1 to Lean's break and
+// continue — Lean's `while` re-checks the condition on continue, matching TS.
+function sumOddsBelow(limit: number): number {
+  let sum = 0;
+  let n = 0;
+  while (true) {
+    n += 1;
+    if (n >= limit) {
+      break;
+    }
+    if (n % 2 === 0) {
+      continue;
+    }
+    sum += n;
+  }
+  return sum;
+}
+console.log(sumOddsBelow(10));
+console.log(sumOddsBelow(1));

--- a/tests/conformance/accept/loop-while-left-pad.ts
+++ b/tests/conformance/accept/loop-while-left-pad.ts
@@ -1,0 +1,11 @@
+// #26: `while` lowers to Lean do-notation `while`. The left-pad milestone
+// shape: condition re-reads mutated state each iteration.
+function leftPad(str: string, len: number, ch: string): string {
+  let pad = str;
+  while (pad.length < len) {
+    pad = ch + pad;
+  }
+  return pad;
+}
+console.log(leftPad('7', 3, '0'));
+console.log(leftPad('hello', 3, '*'));

--- a/tests/conformance/reject/0010-do-while-continue.ts
+++ b/tests/conformance/reject/0010-do-while-continue.ts
@@ -1,0 +1,14 @@
+// Subset-rejected example: do-while whose body has a loop-level `continue`
+// (TH0010). TS `continue` in a do-while jumps to the test; Lean's
+// `repeat ... until` re-enters the body without checking, so the lowering
+// would diverge where TS exits. The shape stays rejected.
+function f(n: number): number {
+  // @thales-expect-error TH0010
+  do {
+    if (n > 0) {
+      continue;
+    }
+  } while (n > 0);
+  return n;
+}
+console.log(f(0));

--- a/tests/conformance/reject/0010-for-loop.ts
+++ b/tests/conformance/reject/0010-for-loop.ts
@@ -1,4 +1,6 @@
-// Subset-rejected example: while loop (TH0010).
+// Subset-rejected example: module-level while loop (TH0010). Loops are
+// only admitted inside do-mode-lowerable declared functions (#26 admits
+// while/do-while there); at module level every loop stays rejected.
 // @thales-expect-error TH0010
 while (false) {
   console.log('unreachable');

--- a/tests/conformance/reject/0010-for-noncanonical.ts
+++ b/tests/conformance/reject/0010-for-noncanonical.ts
@@ -1,10 +1,15 @@
-// Subset-rejected example: non-canonical C-style for loop (TH0010).
-// tsc accepts; thales rejects because the admitted C-style for shape
-// requires `i++` as the update expression; `i += 2` is non-canonical.
+// Subset-rejected example: non-canonical C-style for whose body has a
+// loop-level `continue` (TH0010). The while-desugared lowering would skip
+// the update clause on `continue`, where TS runs it before re-testing —
+// so this shape stays rejected. (Without the `continue`, `i += 2` updates
+// have been admitted via the #26 while-desugar.)
 function f(): number {
   let total = 0;
   // @thales-expect-error TH0010
   for (let i = 1; i <= 5; i += 2) {
+    if (i === 3) {
+      continue;
+    }
     total += i;
   }
   return total;

--- a/tests/conformance/reject/0068-total-while-loop.ts
+++ b/tests/conformance/reject/0068-total-while-loop.ts
@@ -1,0 +1,15 @@
+// Subset-rejected example: `while` loop inside a `@total` function (TH0068).
+// tsc accepts; thales rejects because the loop's Lean lowering is backed by
+// a partial combinator that is opaque to the termination verifier — the
+// `@total` claim cannot be checked. Use a for-of loop or recursion, or drop
+// `@total`.
+/** @total */
+function drain(n: number): number {
+  let i = n;
+  // @thales-expect-error TH0068
+  while (i > 0) {
+    i -= 1;
+  }
+  return i;
+}
+console.log(drain(3));


### PR DESCRIPTION
Closes #26. Fourth feature of the subset-widening roadmap; depends on #24/#25 (merged).

## What's admitted now

- **`while (test) body`** — any test expression; lowers to Lean do-notation `while`. Lean's `while` re-checks the condition after `continue`, matching TS, so unlabeled `break`/`continue` map 1:1.
- **`do body while (test)`** — lowers to `repeat ... until !(test)`; the body runs at least once, as in TS. A **loop-level `continue` stays rejected** (TH0010): TS `continue` jumps to the test, but `repeat ... until` re-enters the body without checking it — the lowering would diverge where TS exits.
- **General C-style `for`** (closes the lowering left open in #25) — desugared at the AST level to `init; while (test) { body; update }`, reusing the while path. Loop-level `continue` with an update clause stays rejected (the desugared body would skip the update). The canonical `for (let i = 0; i < B; i++)` shape keeps its structural `[0:B]` range lowering and never falls back to the desugar, so the #25 operand boundaries (string-length bounds, bound mutation, var reassignment) are unchanged.

Loops remain function-scoped (module-level loops are #49) and excluded from `@throws`/try contexts, as in #25.

## `@total` × loops: new TH0068

Both lowerings are backed by a partial combinator, which the lake-side termination verification (TH0070) cannot see through — `@total` + `while` would verify vacuously. Per the issue's policy, the combination draws a clean diagnostic instead (TH0068, `totalHasUnverifiableLoop`), mirroring the `@total`/`@throws` exclusivity. `for-of`/canonical-for stay `@total`-friendly (pinned by `loop-total-forof.ts` and a new unit test).

## Runtime

The left-pad milestone fixture needs string concatenation, which had never worked (`a + b` on strings emitted `HAdd String String` with no instance — the pure path included). One runtime instance lands with the example, per convention: `HAdd String String String := ⟨String.append⟩`. Mixed string/number `+` deliberately keeps no instance — loud Lean-stage failure rather than a miscompile.

## Harness: bucket↔outcome enforcement (TDD red)

`run-examples.js` never checked a pass label against its bucket, so an accept/ fixture that thales subset-rejects passed as `ok (subset-rejected)` — the new fixtures couldn't fail first, and a regression demoting an accepted example would have gone unnoticed. Each bucket now requires its one pass label (accept→accepted, mirror→tsc-rejected, reject→subset-rejected, throws→both-throw). The four new accept fixtures were verified RED under this check (bucket-mismatch) before the feature landed, plus the TH0068 fixture (directive-check).

## Fixtures

- `accept/loop-while-left-pad.ts` — the issue's left-pad example, byte-matched through Lean
- `accept/loop-do-while-runs-once.ts` — body-runs-once semantics on a false-on-entry test
- `accept/loop-while-break-continue.ts` — `while (true)` with break/continue
- `accept/loop-for-general-step.ts` — non-canonical for (non-zero start, `>`, `i -= 2`)
- `reject/0068-total-while-loop.ts`, `reject/0010-do-while-continue.ts`
- `reject/0010-for-noncanonical.ts` repurposed to the still-rejected continue-with-update shape; `0010-for-loop.ts` recommented as the module-level guard

## Verification

`lake build` + `lake build ThalesTest` clean (LoopEscape/LoopSubsetCheck/LoopShape/LeanSyntaxDo tests extended to pin the new behavior); `format:check` clean; harness self-test 18/0; full conformance **120/0**. test262 re-measure reproduces the #25 table byte-identically — expected, not an artifact: the slice tests are top-level statement scripts, so TH0010 movement there is gated entirely on #49 (documented in `docs/test262.md`).