### PR TITLE
Reject non-boolean conditions (TH0026)

### DIFF
--- a/Test/TypeCheck/ConditionBooleanTest.lean
+++ b/Test/TypeCheck/ConditionBooleanTest.lean
@@ -1,10 +1,8 @@
 /-
   Test/TypeCheck/ConditionBooleanTest.lean
-  Pins TH0026: condition positions (`if`/`while`/`do-while`/`for` tests,
-  the ternary) must synthesize boolean. JS truthiness has no Lean-side
-  coercion, so a non-boolean condition would emit a branch on a type Lean
-  cannot decide — rejection keeps the accept clause honest. tsc accepts
-  all of these programs; TH0026 is a subset boundary, not a tsc mirror.
+  Pins TH0026: condition positions and `!`/`&&`/`||` operands must be
+  boolean (see `requireBooleanCondition`). tsc accepts all of these
+  programs; TH0026 is a subset boundary, not a tsc mirror.
 -/
 import Thales.TypeCheck.Check
 import Thales.Parser.Native
@@ -44,6 +42,19 @@ def t_forNumberTest : IO Unit := expectTH0026
 def t_ternaryNumber : IO Unit := expectTH0026
   "function f(n: number): string { return n ? \"some\" : \"none\"; }"
 
+-- `!`/`&&`/`||` synthesize boolean-ish result types, so the condition-position
+-- check alone would let truthy operands through; the operand check fires.
+def t_notNumber : IO Unit := expectTH0026
+  "function f(n: number): number { if (!n) { return 1; } return 0; }"
+def t_andNumberLeft : IO Unit := expectTH0026
+  "function f(n: number, b: boolean): number { if (n && b) { return 1; } return 0; }"
+def t_orNumberRight : IO Unit := expectTH0026
+  "function p(n: number): boolean { return n > 0; } function g(n: number): number { if (p(n) || n) { return 1; } return 0; }"
+-- the operand rule applies outside condition positions too: `||` as a
+-- truthy default has no Lean-side meaning
+def t_orDefaultString : IO Unit := expectTH0026
+  "function pick(s: string): string { return s || \"fallback\"; }"
+
 -- ── boolean conditions stay clean ────────────────────────────────────────────
 
 def t_comparison : IO Unit := expectNoTH0026
@@ -59,6 +70,12 @@ def t_ternaryBoolean : IO Unit := expectNoTH0026
   "function f(n: number): string { return n > 0 ? \"pos\" : \"rest\"; }"
 def t_negatedBoolean : IO Unit := expectNoTH0026
   "function f(b: boolean): number { if (!b) { return 1; } return 0; }"
+def t_andBooleans : IO Unit := expectNoTH0026
+  "function f(b: boolean, c: boolean): number { if (b && c) { return 1; } return 0; }"
+def t_orBooleans : IO Unit := expectNoTH0026
+  "function f(b: boolean, c: boolean): number { if (b || c) { return 1; } return 0; }"
+def t_notComparison : IO Unit := expectNoTH0026
+  "function f(n: number): number { if (!(n > 0)) { return 1; } return 0; }"
 
 #eval t_ifNumber
 #eval t_ifString
@@ -66,9 +83,16 @@ def t_negatedBoolean : IO Unit := expectNoTH0026
 #eval t_doWhileNumber
 #eval t_forNumberTest
 #eval t_ternaryNumber
+#eval t_notNumber
+#eval t_andNumberLeft
+#eval t_orNumberRight
+#eval t_orDefaultString
 #eval t_comparison
 #eval t_booleanParam
 #eval t_whileTrue
 #eval t_canonicalFor
 #eval t_ternaryBoolean
 #eval t_negatedBoolean
+#eval t_andBooleans
+#eval t_orBooleans
+#eval t_notComparison

--- a/Test/TypeCheck/ConditionBooleanTest.lean
+++ b/Test/TypeCheck/ConditionBooleanTest.lean
@@ -1,0 +1,74 @@
+/-
+  Test/TypeCheck/ConditionBooleanTest.lean
+  Pins TH0026: condition positions (`if`/`while`/`do-while`/`for` tests,
+  the ternary) must synthesize boolean. JS truthiness has no Lean-side
+  coercion, so a non-boolean condition would emit a branch on a type Lean
+  cannot decide — rejection keeps the accept clause honest. tsc accepts
+  all of these programs; TH0026 is a subset boundary, not a tsc mirror.
+-/
+import Thales.TypeCheck.Check
+import Thales.Parser.Native
+
+open Thales.TypeCheck
+open Thales.Parser
+
+private def diagsOf (src : String) : IO (Array Diagnostic) := do
+  match parseTSSourceNative src with
+  | .error e => throw (IO.userError s!"parse error: {e}")
+  | .ok prog => return typeCheck prog
+
+private def expectTH0026 (src : String) : IO Unit := do
+  let diags ← diagsOf src
+  unless diags.any (·.thalesCode? == some 26) do
+    let formatted := (diags.map (·.format "t.ts")).toList
+    throw (IO.userError s!"expected TH0026, got: {formatted}")
+
+private def expectNoTH0026 (src : String) : IO Unit := do
+  let diags ← diagsOf src
+  if diags.any (·.thalesCode? == some 26) then
+    let formatted := (diags.map (·.format "t.ts")).toList
+    throw (IO.userError s!"expected no TH0026, got: {formatted}")
+
+-- ── non-boolean conditions draw TH0026 ──────────────────────────────────────
+
+def t_ifNumber : IO Unit := expectTH0026
+  "function f(n: number): number { if (n) { return 1; } return 0; }"
+def t_ifString : IO Unit := expectTH0026
+  "function f(s: string): number { if (s) { return 1; } return 0; }"
+def t_whileNumber : IO Unit := expectTH0026
+  "function f(n: number): number { let k = n; while (k) { k -= 1; } return k; }"
+def t_doWhileNumber : IO Unit := expectTH0026
+  "function f(n: number): number { let k = n; do { k -= 1; } while (k); return k; }"
+def t_forNumberTest : IO Unit := expectTH0026
+  "function f(n: number): number { let t = 0; for (let i = n; i; i -= 1) { t += i; } return t; }"
+def t_ternaryNumber : IO Unit := expectTH0026
+  "function f(n: number): string { return n ? \"some\" : \"none\"; }"
+
+-- ── boolean conditions stay clean ────────────────────────────────────────────
+
+def t_comparison : IO Unit := expectNoTH0026
+  "function f(n: number): number { if (n !== 0) { return 1; } return 0; }"
+def t_booleanParam : IO Unit := expectNoTH0026
+  "function f(b: boolean): number { if (b) { return 1; } return 0; }"
+-- literal `true` is a boolean subtype: `while (true)` stays admitted
+def t_whileTrue : IO Unit := expectNoTH0026
+  "function f(n: number): number { let k = n; while (true) { if (k <= 0) { break; } k -= 1; } return k; }"
+def t_canonicalFor : IO Unit := expectNoTH0026
+  "function f(n: number): number { let t = 0; for (let i = 0; i < 5; i++) { t += i; } return t; }"
+def t_ternaryBoolean : IO Unit := expectNoTH0026
+  "function f(n: number): string { return n > 0 ? \"pos\" : \"rest\"; }"
+def t_negatedBoolean : IO Unit := expectNoTH0026
+  "function f(b: boolean): number { if (!b) { return 1; } return 0; }"
+
+#eval t_ifNumber
+#eval t_ifString
+#eval t_whileNumber
+#eval t_doWhileNumber
+#eval t_forNumberTest
+#eval t_ternaryNumber
+#eval t_comparison
+#eval t_booleanParam
+#eval t_whileTrue
+#eval t_canonicalFor
+#eval t_ternaryBoolean
+#eval t_negatedBoolean

--- a/Thales/TypeCheck/Check.lean
+++ b/Thales/TypeCheck/Check.lean
@@ -395,8 +395,7 @@ partial def checkJSStatementRaw (stmt : Statement) : TypeCheckM Unit := do
   | .blockStmt _ body =>
     checkJSStatements body
   | .ifStmt _ test consequent alternate =>
-    let testTyped ← synthJSExpr test
-    requireBooleanCondition testTyped.type (exprLoc test)
+    let _ ← synthCondition test
     let ctx ← read
     let preBranchDA ← saveAssignmentState
     match Narrowing.extractGuard test with
@@ -426,8 +425,7 @@ partial def checkJSStatementRaw (stmt : Statement) : TypeCheckM Unit := do
       | none =>
         restoreAssignmentState (intersectAssigned thenDA preBranchDA)
   | .whileStmt _ test body =>
-    let testTyped ← synthJSExpr test
-    requireBooleanCondition testTyped.type (exprLoc test)
+    let _ ← synthCondition test
     let preLoopDA ← saveAssignmentState
     -- Widen variables assigned in the loop body back to declared types
     let assignedInLoop := collectAssignedVars body
@@ -446,8 +444,7 @@ partial def checkJSStatementRaw (stmt : Statement) : TypeCheckM Unit := do
     let assignedInLoop := collectAssignedVars body
     let widened ← widenAssignedVars assignedInLoop
     withScope widened (checkJSStatementRaw body)
-    let testTyped ← synthJSExpr test
-    requireBooleanCondition testTyped.type (exprLoc test)
+    let _ ← synthCondition test
     restoreAssignmentState preLoopDA
   | .forStmt _ init test update body =>
     -- Synth the init expression or bind the init declaration into scope for
@@ -462,9 +459,7 @@ partial def checkJSStatementRaw (stmt : Statement) : TypeCheckM Unit := do
       -- test and update are synthed outside the widening scope; they see the declared
       -- (pre-body) types, matching tsc's treatment of the loop header.
       match test with
-      | some e =>
-        let testTyped ← synthJSExpr e
-        requireBooleanCondition testTyped.type (exprLoc e)
+      | some e => let _ ← synthCondition e
       | none => pure ()
       match update with
       | some e => let _ ← synthJSExpr e
@@ -501,9 +496,7 @@ partial def checkJSStatementRaw (stmt : Statement) : TypeCheckM Unit := do
       -- test and update are synthed outside the widening scope; they see the declared
       -- (pre-body) types, matching tsc's treatment of the loop header.
       match test with
-      | some e =>
-        let testTyped ← synthJSExpr e
-        requireBooleanCondition testTyped.type (exprLoc e)
+      | some e => let _ ← synthCondition e
       | none => pure ()
       match update with
       | some e => let _ ← synthJSExpr e

--- a/Thales/TypeCheck/Check.lean
+++ b/Thales/TypeCheck/Check.lean
@@ -395,7 +395,8 @@ partial def checkJSStatementRaw (stmt : Statement) : TypeCheckM Unit := do
   | .blockStmt _ body =>
     checkJSStatements body
   | .ifStmt _ test consequent alternate =>
-    let _ ← synthJSExpr test
+    let testTyped ← synthJSExpr test
+    requireBooleanCondition testTyped.type (exprLoc test)
     let ctx ← read
     let preBranchDA ← saveAssignmentState
     match Narrowing.extractGuard test with
@@ -425,7 +426,8 @@ partial def checkJSStatementRaw (stmt : Statement) : TypeCheckM Unit := do
       | none =>
         restoreAssignmentState (intersectAssigned thenDA preBranchDA)
   | .whileStmt _ test body =>
-    let _ ← synthJSExpr test
+    let testTyped ← synthJSExpr test
+    requireBooleanCondition testTyped.type (exprLoc test)
     let preLoopDA ← saveAssignmentState
     -- Widen variables assigned in the loop body back to declared types
     let assignedInLoop := collectAssignedVars body
@@ -444,7 +446,8 @@ partial def checkJSStatementRaw (stmt : Statement) : TypeCheckM Unit := do
     let assignedInLoop := collectAssignedVars body
     let widened ← widenAssignedVars assignedInLoop
     withScope widened (checkJSStatementRaw body)
-    let _ ← synthJSExpr test
+    let testTyped ← synthJSExpr test
+    requireBooleanCondition testTyped.type (exprLoc test)
     restoreAssignmentState preLoopDA
   | .forStmt _ init test update body =>
     -- Synth the init expression or bind the init declaration into scope for
@@ -459,7 +462,9 @@ partial def checkJSStatementRaw (stmt : Statement) : TypeCheckM Unit := do
       -- test and update are synthed outside the widening scope; they see the declared
       -- (pre-body) types, matching tsc's treatment of the loop header.
       match test with
-      | some e => let _ ← synthJSExpr e
+      | some e =>
+        let testTyped ← synthJSExpr e
+        requireBooleanCondition testTyped.type (exprLoc e)
       | none => pure ()
       match update with
       | some e => let _ ← synthJSExpr e
@@ -480,7 +485,9 @@ partial def checkJSStatementRaw (stmt : Statement) : TypeCheckM Unit := do
         -- test and update are synthed outside the widening scope; they see the declared
         -- (pre-body) types, matching tsc's treatment of the loop header.
         match test with
-        | some e => let _ ← synthJSExpr e
+        | some e =>
+          let testTyped ← synthJSExpr e
+          requireBooleanCondition testTyped.type (exprLoc e)
         | none => pure ()
         match update with
         | some e => let _ ← synthJSExpr e
@@ -494,7 +501,9 @@ partial def checkJSStatementRaw (stmt : Statement) : TypeCheckM Unit := do
       -- test and update are synthed outside the widening scope; they see the declared
       -- (pre-body) types, matching tsc's treatment of the loop header.
       match test with
-      | some e => let _ ← synthJSExpr e
+      | some e =>
+        let testTyped ← synthJSExpr e
+        requireBooleanCondition testTyped.type (exprLoc e)
       | none => pure ()
       match update with
       | some e => let _ ← synthJSExpr e

--- a/Thales/TypeCheck/Diagnostic.lean
+++ b/Thales/TypeCheck/Diagnostic.lean
@@ -77,6 +77,11 @@ inductive ThalesKind where
   | intersectionNotSupported
   | typeLevelProgrammingNotSupported
   | nullUndefinedNotSupported
+  -- TH0026: condition positions (`if`/`while`/`do-while`/`for` tests, the
+  -- ternary) must be boolean. JS truthiness (`0`, `''`, `NaN`, `null`,
+  -- `undefined` are falsy) has no Lean-side coercion, so a non-boolean
+  -- condition would emit code that cannot compile.
+  | conditionNotBoolean (actualType : String)
   | classNotSupported
   | inheritanceNotSupported
   | switchNotExhaustive (missingKinds : List String)
@@ -96,7 +101,7 @@ inductive ThalesKind where
   | totalHasUncaughtThrow (source : ThrowSource)
   -- TH0068: while/do-while (and while-desugared `for`) lower to a
   -- partial-backed combinator the termination verifier cannot see through,
-  -- so they cannot substantiate a `@total` claim (#26).
+  -- so they cannot substantiate a `@total` claim.
   | totalHasUnverifiableLoop
   | totalityUnverified (leanError : String)
   -- Refinement-type diagnostics (TH0080–TH0081)
@@ -128,6 +133,7 @@ def ThalesKind.thCode : ThalesKind → Nat
   | .intersectionNotSupported => 23
   | .typeLevelProgrammingNotSupported => 24
   | .nullUndefinedNotSupported => 25
+  | .conditionNotBoolean _ => 26
   | .classNotSupported => 30
   | .inheritanceNotSupported => 31
   | .switchNotExhaustive _ => 40
@@ -173,6 +179,8 @@ def ThalesKind.message : ThalesKind → String
   | .intersectionNotSupported => "Intersection types are not supported"
   | .typeLevelProgrammingNotSupported => "keyof/conditional/mapped types are not supported"
   | .nullUndefinedNotSupported => "null/undefined types are not supported; use Option<T>"
+  | .conditionNotBoolean actualType =>
+    s!"Condition must be boolean, got '{actualType}'; truthiness is not mirrored — compare explicitly (e.g. `x !== 0`)"
   | .classNotSupported => "'class' is not supported"
   | .inheritanceNotSupported => "Inheritance ('extends') is not supported"
   | .switchNotExhaustive missingKinds =>

--- a/Thales/TypeCheck/Diagnostic.lean
+++ b/Thales/TypeCheck/Diagnostic.lean
@@ -77,10 +77,8 @@ inductive ThalesKind where
   | intersectionNotSupported
   | typeLevelProgrammingNotSupported
   | nullUndefinedNotSupported
-  -- TH0026: condition positions (`if`/`while`/`do-while`/`for` tests, the
-  -- ternary) must be boolean. JS truthiness (`0`, `''`, `NaN`, `null`,
-  -- `undefined` are falsy) has no Lean-side coercion, so a non-boolean
-  -- condition would emit code that cannot compile.
+  -- TH0026: condition positions and `!`/`&&`/`||` operands must be
+  -- boolean; `requireBooleanCondition` has the rationale.
   | conditionNotBoolean (actualType : String)
   | classNotSupported
   | inheritanceNotSupported

--- a/Thales/TypeCheck/Synth.lean
+++ b/Thales/TypeCheck/Synth.lean
@@ -100,6 +100,16 @@ partial def tsExprSourceName : TSExpression → String
   | .satisfiesExpr inner _ => tsExprSourceName inner
   | .nonNullAssert inner => tsExprSourceName inner
 
+/-- Condition positions (`if`/`while`/`do-while`/`for` tests, the ternary)
+    must synthesize boolean (TH0026). JS truthiness — `0`, `''`, `NaN`,
+    `null`, `undefined` are falsy — has no Lean-side coercion, so a
+    non-boolean condition would emit a branch on a type Lean cannot
+    decide, failing after acceptance. -/
+def requireBooleanCondition (ty : TSType) (loc : Option SourceLocation)
+    : TypeCheckM Unit := do
+  unless (← isSubtype ty .boolean) do
+    emitDiagnostic (.thales (.conditionNotBoolean (formatType ty))) loc
+
 /-- Check if a type contains any typeVar -/
 private partial def containsTypeVar : TSType → Bool
   | .typeVar .. => true
@@ -448,6 +458,7 @@ partial def synthJSExpr (expr : Expression) (expected : Option TSType := none) :
   -- Conditional (ternary)
   | .conditionalExpr _ test consequent alternate =>
     let testTyped ← synthJSExpr test
+    requireBooleanCondition testTyped.type (exprLoc test)
     let ctx ← read
     match Narrowing.extractGuard test with
     | some guard =>

--- a/Thales/TypeCheck/Synth.lean
+++ b/Thales/TypeCheck/Synth.lean
@@ -100,11 +100,11 @@ partial def tsExprSourceName : TSExpression → String
   | .satisfiesExpr inner _ => tsExprSourceName inner
   | .nonNullAssert inner => tsExprSourceName inner
 
-/-- Condition positions (`if`/`while`/`do-while`/`for` tests, the ternary)
-    must synthesize boolean (TH0026). JS truthiness — `0`, `''`, `NaN`,
-    `null`, `undefined` are falsy — has no Lean-side coercion, so a
-    non-boolean condition would emit a branch on a type Lean cannot
-    decide, failing after acceptance. -/
+/-- Require boolean in positions Lean will branch on: `if`/`while`/
+    `do-while`/`for` tests, the ternary test, and the operands of
+    `!`/`&&`/`||` (TH0026). JS truthiness — `0`, `''`, `NaN`, `null`,
+    `undefined` are falsy — has no Lean-side coercion, so a non-boolean
+    here would emit code the Lean stage cannot compile. -/
 def requireBooleanCondition (ty : TSType) (loc : Option SourceLocation)
     : TypeCheckM Unit := do
   unless (← isSubtype ty .boolean) do
@@ -401,22 +401,28 @@ partial def synthJSExpr (expr : Expression) (expected : Option TSType := none) :
     let ctx ← read
     match op with
     | .«and» =>
+      -- `&&` is Lean `&&`: both operands must be boolean (TH0026), not
+      -- merely the synthesized result.
+      requireBooleanCondition leftTyped.type (exprLoc left)
       match Narrowing.extractGuard left with
       | some guard =>
         let narrowed := Narrowing.applyGuard guard ctx.bindings
-        let rightTyped ← withScope (Narrowing.bindingsDiff narrowed ctx.bindings) (synthJSExpr right)
+        let rightTyped ← withScope (Narrowing.bindingsDiff narrowed ctx.bindings) (synthCondition right)
         return { expr := .js expr, type := rightTyped.type, children := #[leftTyped, rightTyped] }
       | none =>
-        let rightTyped ← synthJSExpr right
+        let rightTyped ← synthCondition right
         return { expr := .js expr, type := rightTyped.type, children := #[leftTyped, rightTyped] }
     | .«or» =>
+      -- `||` is Lean `||`: both operands must be boolean (TH0026). A truthy
+      -- default (`s || "fallback"`) is out of subset.
+      requireBooleanCondition leftTyped.type (exprLoc left)
       match Narrowing.extractGuard left with
       | some guard =>
         let narrowed := Narrowing.applyNegatedGuard guard ctx.bindings
-        let rightTyped ← withScope (Narrowing.bindingsDiff narrowed ctx.bindings) (synthJSExpr right)
+        let rightTyped ← withScope (Narrowing.bindingsDiff narrowed ctx.bindings) (synthCondition right)
         return { expr := .js expr, type := .union [leftTyped.type, rightTyped.type], children := #[leftTyped, rightTyped] }
       | none =>
-        let rightTyped ← synthJSExpr right
+        let rightTyped ← synthCondition right
         return { expr := .js expr, type := leftTyped.type, children := #[leftTyped, rightTyped] }
     | _ =>
       let rightTyped ← synthJSExpr right
@@ -457,8 +463,7 @@ partial def synthJSExpr (expr : Expression) (expected : Option TSType := none) :
 
   -- Conditional (ternary)
   | .conditionalExpr _ test consequent alternate =>
-    let testTyped ← synthJSExpr test
-    requireBooleanCondition testTyped.type (exprLoc test)
+    let testTyped ← synthCondition test
     let ctx ← read
     match Narrowing.extractGuard test with
     | some guard =>
@@ -540,7 +545,10 @@ partial def synthJSExpr (expr : Expression) (expected : Option TSType := none) :
   | .unaryExpr _ .neg _ _ => return mk .number #[]
   | .unaryExpr _ .pos _ _ => return mk .number #[]
   | .unaryExpr _ .bitnot _ _ => return mk .number #[]
-  | .unaryExpr _ .not _ _ => return mk .boolean #[]
+  | .unaryExpr _ .not _ arg =>
+    -- `!` is Lean `not`: the operand must already be boolean (TH0026).
+    let argTyped ← synthCondition arg
+    return mk .boolean #[argTyped]
 
   -- this
   | .thisExpr _ => return mk .any #[]
@@ -599,6 +607,13 @@ where
       | .withDefault id _ => some id.name
       | .rest id => some id.name
       | .pattern _ => none
+
+/-- Synthesize a condition-position expression and require it to be
+    boolean — the single entry point for TH0026 condition checks. -/
+partial def synthCondition (e : Expression) : TypeCheckM TypedExpression := do
+  let typed ← synthJSExpr e
+  requireBooleanCondition typed.type (exprLoc e)
+  return typed
 
 end
 

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -356,12 +356,14 @@ See `docs/subset.md` (Nullable types section) for the full translation rules.
 mirrored — compare explicitly (e.g. \`x !== 0\`)`
 
 Every condition position — `if`, `while`, `do`/`while`, the `for` test
-clause, and the ternary — must have type `boolean`. tsc accepts any type
-there and applies JS truthiness (`0`, `''`, `NaN`, `null`, `undefined`
-are falsy); Lean has no such coercion, so a non-boolean condition would
-emit a branch the Lean stage cannot compile. Rejecting keeps the accept
-clause of the conformance contract honest: everything thales accepts
-must compile and byte-match.
+clause, and the ternary — must have type `boolean`, and so must the
+operands of `!`, `&&`, and `||` (in the subset they are exactly Lean's
+boolean operators). tsc accepts any type in these positions and applies
+JS truthiness (`0`, `''`, `NaN`, `null`, `undefined` are falsy); Lean
+has no such coercion, so a non-boolean condition or operand would emit
+code the Lean stage cannot compile. Rejecting keeps the accept clause of
+the conformance contract honest: everything thales accepts must compile
+and byte-match.
 
 ```typescript
 function f(n: number): number {
@@ -373,9 +375,14 @@ function f(n: number): number {
 }
 ```
 
+The operand rule also rejects truthy shorthands like `if (!n)`,
+`if (n && b)`, and the default-value idiom `s || 'fallback'` (which
+additionally relies on `||` returning an operand rather than a boolean).
+
 **Fix:** compare explicitly — `n !== 0` (truthiness for numbers also
 excludes `NaN`; use `Number.isNaN` if that case matters), `s !== ""` for
-strings, or a boolean-returning predicate.
+strings, or a boolean-returning predicate. For defaults, use an explicit
+ternary: `s !== '' ? s : 'fallback'`.
 
 ---
 

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -59,6 +59,7 @@ soundness check).
 | TH0023 | Types        | Intersection types not supported                    |
 | TH0024 | Types        | keyof/conditional/mapped types not supported        |
 | TH0025 | Types        | null/undefined types not supported                  |
+| TH0026 | Types        | Condition must be boolean                           |
 | TH0030 | Declarations | `class` not supported                               |
 | TH0031 | Declarations | Inheritance (`extends`) not supported               |
 | TH0032 | Declarations | Shadowing declaration not supported                 |
@@ -216,8 +217,9 @@ do-mode-lowerable declared functions:
 - `for (let i = 0; i < B; i++)` — canonical C-style with `i++` update, bound
   `B` is a non-negative integer literal or an array-typed `arr.length`, bound
   array not reassigned in the body.
-- `while (test) body` — any test expression; lowered to Lean do-notation
-  `while`. Not allowed in `@total` functions — see TH0068.
+- `while (test) body` — any boolean test expression (conditions must be
+  boolean — see TH0026); lowered to Lean do-notation `while`. Not allowed
+  in `@total` functions — see TH0068.
 - `do body while (test)` — lowered to `repeat ... until !(test)`; the body
   runs at least once, as in TS. Same `@total` exclusion. A loop-level
   `continue` keeps a do-while rejected: TS `continue` jumps to the test,
@@ -345,6 +347,35 @@ If you have a `@thales-expect-error TH0025` directive in your source, remove
 it — the directive is now unused and will produce TH9000.
 
 See `docs/subset.md` (Nullable types section) for the full translation rules.
+
+---
+
+### TH0026 — condition must be boolean
+
+**Message:** `Condition must be boolean, got '<type>'; truthiness is not
+mirrored — compare explicitly (e.g. \`x !== 0\`)`
+
+Every condition position — `if`, `while`, `do`/`while`, the `for` test
+clause, and the ternary — must have type `boolean`. tsc accepts any type
+there and applies JS truthiness (`0`, `''`, `NaN`, `null`, `undefined`
+are falsy); Lean has no such coercion, so a non-boolean condition would
+emit a branch the Lean stage cannot compile. Rejecting keeps the accept
+clause of the conformance contract honest: everything thales accepts
+must compile and byte-match.
+
+```typescript
+function f(n: number): number {
+  if (n) {
+    // TH0026: Condition must be boolean, got 'number'
+    return 1;
+  }
+  return 0;
+}
+```
+
+**Fix:** compare explicitly — `n !== 0` (truthiness for numbers also
+excludes `NaN`; use `Number.isNaN` if that case matters), `s !== ""` for
+strings, or a boolean-returning predicate.
 
 ---
 

--- a/docs/subset.md
+++ b/docs/subset.md
@@ -280,7 +280,8 @@ function leftPad(str: string, len: number, ch: string): string {
 }
 ```
 
-Any test expression is accepted. `while` lowers to Lean do-notation
+Any boolean-typed test expression is accepted (conditions must be
+boolean — see TH0026). `while` lowers to Lean do-notation
 `while`; `do`/`while` lowers to `repeat ... until !(test)` (body runs at
 least once, as in TS). Both are backed by a partial combinator — fine for
 evaluation (the byte-match contract is unaffected), opaque to termination
@@ -577,6 +578,46 @@ interface ReadOnlyPoint {
 ```
 
 These constructs are type-level programs; translating them to Lean requires dependent types or macro metaprogramming. They are deferred to a future version with a type-level elaboration pass.
+
+---
+
+### TH0026 — Condition must be boolean
+
+**Category:** Types
+
+Every condition position — `if`, `while`, `do`/`while`, the `for` test
+clause, and the ternary — must have type `boolean`. tsc accepts any type
+in these positions and applies JS truthiness (`0`, `''`, `NaN`, `null`,
+`undefined` are falsy); Lean has no truthiness coercion, so a non-boolean
+condition would emit a branch the Lean stage cannot compile, violating
+the accept clause of the conformance contract.
+
+Rejected:
+
+```typescript
+function f(n: number): number {
+  if (n) {
+    // TH0026: Condition must be boolean, got 'number'
+    return 1;
+  }
+  return 0;
+}
+```
+
+Idiomatic replacement:
+
+```typescript
+function f(n: number): number {
+  if (n !== 0) {
+    return 1;
+  }
+  return 0;
+}
+```
+
+Mirroring truthiness with a runtime coercion (`truthy : Float → Bool`
+handling `NaN` and `-0`) is a possible future widening; rejection is the
+v1 boundary.
 
 ---
 

--- a/docs/subset.md
+++ b/docs/subset.md
@@ -586,11 +586,13 @@ These constructs are type-level programs; translating them to Lean requires depe
 **Category:** Types
 
 Every condition position — `if`, `while`, `do`/`while`, the `for` test
-clause, and the ternary — must have type `boolean`. tsc accepts any type
-in these positions and applies JS truthiness (`0`, `''`, `NaN`, `null`,
-`undefined` are falsy); Lean has no truthiness coercion, so a non-boolean
-condition would emit a branch the Lean stage cannot compile, violating
-the accept clause of the conformance contract.
+clause, and the ternary — must have type `boolean`, and so must the
+operands of `!`, `&&`, and `||`: in the subset these are exactly Lean's
+boolean operators. tsc accepts any type in these positions and applies
+JS truthiness (`0`, `''`, `NaN`, `null`, `undefined` are falsy); Lean
+has no truthiness coercion, so a non-boolean condition or operand would
+emit code the Lean stage cannot compile, violating the accept clause of
+the conformance contract.
 
 Rejected:
 
@@ -603,6 +605,13 @@ function f(n: number): number {
   return 0;
 }
 ```
+
+The operand rule also rejects `if (!n)`, `if (n && b)`, and the
+default-value idiom `s || 'fallback'` — the latter additionally relies
+on JS `||` returning an operand rather than a boolean, which Lean's `||`
+does not do. Use an explicit ternary for defaults
+(`s !== '' ? s : 'fallback'`). `??` on nullable types is unaffected; it
+lowers to `Option` handling, not truthiness.
 
 Idiomatic replacement:
 

--- a/docs/test262.md
+++ b/docs/test262.md
@@ -50,9 +50,10 @@ on demand).
 
 ## Baseline
 
-thales `06796af` (after #25 for-of/canonical-for widening; previous
-measure `4177bd1` after #24 and the #40–#45 hardening), test262
-`fc32f3e8`, 2026-06-11:
+thales `0067add` (after the #26 while/do-while widening and the TH0026
+non-boolean-condition rejection from #55; previous measures `06796af`
+after #25 and `4177bd1` after #24 and the #40–#45 hardening), test262
+`fc32f3e8`, 2026-06-12:
 
 ```
 Slice                                             Total  Skip   OoS  Pass  Fail  InSubset   Pass%
@@ -84,6 +85,7 @@ TH0001            1179    213        0
 TS2304            1179     92        0
 TH0030            1179     48        0
 TH0007            1179     18        0
+TH0026            1179     17        0
 TH0063            1179      2        0
 TH0021            1179      0        0
 TH0031            1179      0        0
@@ -133,6 +135,16 @@ function-scoped, so every slice loop keeps drawing module-level TH0010.
 The widening #26 delivers is exercised by the conformance corpus
 (`loop-while-*`, `loop-do-while-*`, `loop-for-general-*`); test262
 movement on these slices is gated entirely on #49.
+
+The TH0026 re-measure (non-boolean conditions rejected, #55) leaves
+every other count byte-identical and adds one attribution row: TH0026
+blocks the shim — the `harness/assert.ts:34` truthy narrowing documented
+below now draws a structured rejection instead of silently mistyping —
+and 17 test bodies that branch on truthy conditions. Totals and OoS are
+unchanged: all 17 were already blocked by other codes, so this is
+attribution honesty, not new blockage. (The new row pushes TH0004 —
+0 shim / 5 body — past the runner's top-20 display; the table above
+retains it from the baseline measure.)
 
 New shim-attribution rows vs the pre-#24 baseline: TS2322 — #24's
 declared-type precision (unannotated/const bindings are no longer `any`)

--- a/docs/test262.md
+++ b/docs/test262.md
@@ -50,10 +50,10 @@ on demand).
 
 ## Baseline
 
-thales `0067add` (after the #26 while/do-while widening and the TH0026
-non-boolean-condition rejection from #55; previous measures `06796af`
-after #25 and `4177bd1` after #24 and the #40–#45 hardening), test262
-`fc32f3e8`, 2026-06-12:
+Measured 2026-06-12, after the #26 while/do-while widening and the
+TH0026 non-boolean-condition rejection (#55); previous measures followed
+#24 (with the #40–#45 hardening) and #25. test262 is the pinned
+submodule snapshot.
 
 ```
 Slice                                             Total  Skip   OoS  Pass  Fail  InSubset   Pass%

--- a/docs/test262.md
+++ b/docs/test262.md
@@ -82,10 +82,10 @@ Top blocking diagnostics (tests blocked, by attribution):
 Code              Shim   Body  Unknown
 TS2339            1179    895        0
 TH0001            1179    213        0
-TS2304            1179     92        0
+TS2304            1179     98        0
 TH0030            1179     48        0
+TH0026            1179     26        0
 TH0007            1179     18        0
-TH0026            1179     17        0
 TH0063            1179      2        0
 TH0021            1179      0        0
 TH0031            1179      0        0
@@ -136,15 +136,18 @@ The widening #26 delivers is exercised by the conformance corpus
 (`loop-while-*`, `loop-do-while-*`, `loop-for-general-*`); test262
 movement on these slices is gated entirely on #49.
 
-The TH0026 re-measure (non-boolean conditions rejected, #55) leaves
-every other count byte-identical and adds one attribution row: TH0026
-blocks the shim — the `harness/assert.ts:34` truthy narrowing documented
-below now draws a structured rejection instead of silently mistyping —
-and 17 test bodies that branch on truthy conditions. Totals and OoS are
-unchanged: all 17 were already blocked by other codes, so this is
-attribution honesty, not new blockage. (The new row pushes TH0004 —
-0 shim / 5 body — past the runner's top-20 display; the table above
-retains it from the baseline measure.)
+The TH0026 re-measure (non-boolean conditions and `!`/`&&`/`||` operands
+rejected, #55) leaves totals and OoS byte-identical and adds one
+attribution row: TH0026 blocks the shim — the `harness/assert.ts:34`
+truthy narrowing documented below now draws a structured rejection
+instead of silently mistyping — and 26 test bodies (17 truthy condition
+positions, 9 more from truthy `!`/`&&`/`||` operands). All 26 were
+already blocked by other codes, so this is attribution honesty, not new
+blockage. The same change moves body TS2304 92 → 98: the checker
+previously did not synthesize the operand of `!` at all, so undeclared
+references inside a negation went unrecorded; they now surface. (The new
+row pushes TH0004 — 0 shim / 5 body — past the runner's top-20 display;
+the table above retains it from the baseline measure.)
 
 New shim-attribution rows vs the pre-#24 baseline: TS2322 — #24's
 declared-type precision (unannotated/const bindings are no longer `any`)

--- a/tests/conformance/reject/0026-truthy-and-operand.ts
+++ b/tests/conformance/reject/0026-truthy-and-operand.ts
@@ -1,0 +1,9 @@
+// Subset-rejected example: non-boolean left operand of `&&` (TH0026).
+function f(n: number, b: boolean): number {
+  // @thales-expect-error TH0026
+  if (n && b) {
+    return 1;
+  }
+  return 0;
+}
+console.log(f(2, true));

--- a/tests/conformance/reject/0026-truthy-if-condition.ts
+++ b/tests/conformance/reject/0026-truthy-if-condition.ts
@@ -1,8 +1,5 @@
 // Subset-rejected example: non-boolean `if` condition (TH0026).
-// tsc accepts; thales rejects because JS truthiness (`0`, `''`, `NaN`,
-// `null`, `undefined` are falsy) has no Lean-side coercion — the emitted
-// `if` would need a Decidable instance a Float cannot provide. Compare
-// explicitly instead (`n !== 0`).
+// JS truthiness has no Lean-side coercion; compare explicitly (`n !== 0`).
 function f(n: number): number {
   // @thales-expect-error TH0026
   if (n) {

--- a/tests/conformance/reject/0026-truthy-if-condition.ts
+++ b/tests/conformance/reject/0026-truthy-if-condition.ts
@@ -1,0 +1,13 @@
+// Subset-rejected example: non-boolean `if` condition (TH0026).
+// tsc accepts; thales rejects because JS truthiness (`0`, `''`, `NaN`,
+// `null`, `undefined` are falsy) has no Lean-side coercion — the emitted
+// `if` would need a Decidable instance a Float cannot provide. Compare
+// explicitly instead (`n !== 0`).
+function f(n: number): number {
+  // @thales-expect-error TH0026
+  if (n) {
+    return 1;
+  }
+  return 0;
+}
+console.log(f(2));

--- a/tests/conformance/reject/0026-truthy-not-operand.ts
+++ b/tests/conformance/reject/0026-truthy-not-operand.ts
@@ -1,0 +1,9 @@
+// Subset-rejected example: `!` on a non-boolean operand (TH0026).
+function f(n: number): number {
+  // @thales-expect-error TH0026
+  if (!n) {
+    return 1;
+  }
+  return 0;
+}
+console.log(f(0));

--- a/tests/conformance/reject/0026-truthy-or-default.ts
+++ b/tests/conformance/reject/0026-truthy-or-default.ts
@@ -1,0 +1,7 @@
+// Subset-rejected example: `||` as a truthy default outside a condition
+// position (TH0026) — the operands themselves must be boolean.
+function pick(s: string): string {
+  // @thales-expect-error TH0026
+  return s || 'fallback';
+}
+console.log(pick(''));

--- a/tests/conformance/reject/0026-truthy-or-operand.ts
+++ b/tests/conformance/reject/0026-truthy-or-operand.ts
@@ -1,0 +1,12 @@
+// Subset-rejected example: non-boolean right operand of `||` (TH0026).
+function isPos(n: number): boolean {
+  return n > 0;
+}
+function g(n: number): number {
+  // @thales-expect-error TH0026
+  if (isPos(n) || n) {
+    return 1;
+  }
+  return 0;
+}
+console.log(g(2));

--- a/tests/conformance/reject/0026-truthy-ternary.ts
+++ b/tests/conformance/reject/0026-truthy-ternary.ts
@@ -1,6 +1,4 @@
 // Subset-rejected example: non-boolean ternary condition (TH0026).
-// The ternary test is a condition position; a number operand relies on JS
-// truthiness (0 and NaN are falsy). Compare explicitly instead (`n !== 0`).
 function pick(n: number): string {
   // @thales-expect-error TH0026
   return n ? 'some' : 'none';

--- a/tests/conformance/reject/0026-truthy-ternary.ts
+++ b/tests/conformance/reject/0026-truthy-ternary.ts
@@ -1,0 +1,8 @@
+// Subset-rejected example: non-boolean ternary condition (TH0026).
+// The ternary test is a condition position; a number operand relies on JS
+// truthiness (0 and NaN are falsy). Compare explicitly instead (`n !== 0`).
+function pick(n: number): string {
+  // @thales-expect-error TH0026
+  return n ? 'some' : 'none';
+}
+console.log(pick(3));

--- a/tests/conformance/reject/0026-truthy-while-test.ts
+++ b/tests/conformance/reject/0026-truthy-while-test.ts
@@ -1,0 +1,15 @@
+// Subset-rejected example: non-boolean `while` test (TH0026).
+// Loop tests are condition positions like `if`: a number operand relies on
+// JS truthiness (0 and NaN are falsy), which has no Lean-side coercion.
+// Compare explicitly instead (`k !== 0` or `k > 0`).
+function countdown(n: number): number {
+  let k = n;
+  let steps = 0;
+  // @thales-expect-error TH0026
+  while (k) {
+    k -= 1;
+    steps += 1;
+  }
+  return steps;
+}
+console.log(countdown(3));

--- a/tests/conformance/reject/0026-truthy-while-test.ts
+++ b/tests/conformance/reject/0026-truthy-while-test.ts
@@ -1,6 +1,4 @@
 // Subset-rejected example: non-boolean `while` test (TH0026).
-// Loop tests are condition positions like `if`: a number operand relies on
-// JS truthiness (0 and NaN are falsy), which has no Lean-side coercion.
 // Compare explicitly instead (`k !== 0` or `k > 0`).
 function countdown(n: number): number {
   let k = n;


### PR DESCRIPTION
Closes #55.

## The hole

A condition position with a non-boolean operand was **accepted but emitted Lean that cannot compile**: `if (n)` on a `number` emits `if n then …` over a `Float`, which has no `Decidable` instance. tsc accepts the program (JS truthiness), so this violated the accept clause of the four-clause contract — the program could never reach the byte-match stage. Since the while/do-while widening, loop tests follow the same emission path as `if`, widening the reachable surface.

## The boundary

Per the issue's option 1, the v1 boundary is **rejection**: every condition position — `if`, `while`, `do`/`while`, the `for` test clause, and the ternary — must synthesize `boolean` (subtypes included: literal `true`/`false`, so `while (true)` stays admitted). The check lives in the type checker (`requireBooleanCondition`), which is the phase that knows the synthesized type.

A review pass on the first cut found the boundary leaked through the boolean-producing operators: `!`, `&&`, and `||` synthesize boolean-ish types from truthy operands, so `if (!n)`, `if (n && b)`, and `if (isPos(n) || n)` passed the condition check and still emitted non-compiling Lean (verified empirically). The rule is therefore enforced at the operand level too: **the operands of `!`/`&&`/`||` must be boolean** — in the subset they are exactly Lean's boolean operators. That also rejects the truthy default idiom (`s || 'fallback'`, which additionally relies on `||` returning an operand), and it fixed a latent defect: the `!` operand was previously never synthesized at all, so diagnostics inside negations were silently swallowed. `??` is unaffected (it lowers to `Option.getD`, not truthiness). All condition sites now route through a single `synthCondition` chokepoint.

Mirroring JS truthiness (`0`, `''`, `NaN`, `null`, `undefined` falsy) with a runtime coercion remains a possible future widening and would coordinate with the truthy-narrowing work (#38).

## TDD

The seven reject fixtures (`0026-truthy-{if-condition,while-test,ternary,not-operand,and-operand,or-operand,or-default}.ts`) were each verified RED before the corresponding check landed (directive-check: thales accepted, so the `@thales-expect-error TH0026` directives were unused). `Test/TypeCheck/ConditionBooleanTest.lean` pins ten rejecting shapes (if/while/do-while/for-test/ternary on number and string; `!`/`&&`/`||` truthy operands; `||` truthy default) and nine clean ones (comparisons, boolean params, `while (true)`, canonical for, boolean ternary, `!b`, `b && c`, `b || c`, `!(n > 0)`).

## test262

Re-measured after the operand widening: totals and OoS reproduce the previous table byte-identically. Attribution: **TH0026 shim 1179 / body 26** (17 truthy condition positions + 9 truthy operands; the shim hit is the already-documented `harness/assert.ts` truthy narrowing). Body **TS2304 92 → 98**: the `!` operand is now synthesized, so undeclared references inside negations surface. All affected bodies were already blocked by other codes — attribution honesty, not new blockage. Documented in `docs/test262.md`.

## Verification

`lake build` + `lake build ThalesTest` clean; harness self-test 18/0; conformance **127/0** (120 + the 7 new fixtures); `format:check` clean.

## Docs

`docs/errors.md` gains the TH0026 table row and section; `docs/subset.md` gains the TH0026 section (both cover the operand rule and the default-idiom rejection) and corrects the loop admission text ('any test expression' → 'any boolean test expression'). Also stripped a leftover issue-number reference in `Diagnostic.lean` that escaped the PR #54 sweep.
