### PR TITLE
Type-aware definedness tests: fold non-Option, reject unrecorded (TH0084)

### DIFF
--- a/Test/Emit/LeanEmitExprTest.lean
+++ b/Test/Emit/LeanEmitExprTest.lean
@@ -132,5 +132,15 @@ const result = apply((xs) => {
     ["match hit with", ".some hit"]
     ["if hit.isSome"]
 
+-- A definedness test on a recorded NON-Option binding (param `x : String`)
+-- is vacuous: it folds to `if true`/`if false`, never `x.isSome` (which
+-- does not exist on `String`).
+def testDefinednessFoldsOnNonOptionParam : IO Unit :=
+  expectEmitWithout
+    "function f(x: string): string { if (x !== undefined) { return x; } return \"none\"; }" "M"
+    ["def f", "if true then"]
+    ["isSome", "isNone"]
+
 #eval testIndexReadLowering
 #eval testUnknownBindingNarrowingMatch
+#eval testDefinednessFoldsOnNonOptionParam

--- a/Test/Emit/LeanEmitExprTest.lean
+++ b/Test/Emit/LeanEmitExprTest.lean
@@ -141,6 +141,17 @@ def testDefinednessFoldsOnNonOptionParam : IO Unit :=
     ["def f", "if true then"]
     ["isSome", "isNone"]
 
+-- An UN-annotated const with a literal initializer has a knowable
+-- non-Option type (`"a"` → string); its definedness test folds rather
+-- than emitting a `match` (which would project `.some`/`.none` off a
+-- non-Option value).
+def testDefinednessFoldsOnLiteralConst : IO Unit :=
+  expectEmitWithout
+    "function f(): string { const x = \"a\"; if (x !== undefined) { return x; } return \"b\"; }" "M"
+    ["def f", "if true then"]
+    ["isSome", "isNone", "match x"]
+
 #eval testIndexReadLowering
 #eval testUnknownBindingNarrowingMatch
 #eval testDefinednessFoldsOnNonOptionParam
+#eval testDefinednessFoldsOnLiteralConst

--- a/Test/Emit/MutationCheckTest.lean
+++ b/Test/Emit/MutationCheckTest.lean
@@ -108,6 +108,16 @@ def testUndefinedTestedMutationTH1 : IO Unit := expectCode
 def testPlainIdentSwitchTH1 : IO Unit := expectCode
   "function f(x: string): number { let n = 0; n = 1; switch (x) { case \"a\": return 1; case \"b\": return 2; } return n; }" 1
 
+-- A definedness test on a body-local whose type the emitter cannot record
+-- (concatenation initializer) is rejected with TH0084 — the emitter could
+-- neither fold (might be Option) nor narrow (might be non-Option) it.
+def testDefinednessUnrecordedRejected : IO Unit := expectCode
+  "function f(a: string, b: string): string { const x = a + b; if (x !== undefined) { return x; } return \"n\"; }" 84
+
+-- A recorded binding (literal const, param) is NOT rejected.
+def testDefinednessRecordedNotRejected : IO Unit := expectNoCode
+  "function f(x: string): string { const y = \"a\"; if (x !== undefined) { return y; } return \"n\"; }" 84
+
 #eval testReassignment
 #eval testCompoundAssignment
 #eval testIncrement
@@ -135,3 +145,5 @@ def testPlainIdentSwitchTH1 : IO Unit := expectCode
 #eval testNarrowedReadMutationAllowed
 #eval testUndefinedTestedMutationTH1
 #eval testPlainIdentSwitchTH1
+#eval testDefinednessUnrecordedRejected
+#eval testDefinednessRecordedNotRejected

--- a/Thales/Emit/EscapeAnalysis.lean
+++ b/Thales/Emit/EscapeAnalysis.lean
@@ -205,6 +205,25 @@ private def isNullishOperand : Expression → Bool
   | .identifier _ "undefined" => true
   | _ => false
 
+/-- The identifier subject of a definedness test (`x === null`,
+    `x !== undefined`, and `==`/`!=` variants, either operand order), or
+    `none`. Mirrors the shape `walkCond` records into `nullTested` and the
+    emitter's nullish-equality lowering; consumed by SubsetCheck's TH0084. -/
+def definednessTestSubject? : Expression → Option String
+  | .binaryExpr _ op l r =>
+      let nullishEqOp := match op with
+        | .seq | .sneq | .eq | .neq => true
+        | _ => false
+      if nullishEqOp then
+        let subjectOf : Expression → Expression → Option String := fun a b =>
+          match a with
+          | .identifier _ n =>
+              if isNullishOperand b && n != "undefined" then some n else none
+          | _ => none
+        subjectOf l r <|> subjectOf r l
+      else none
+  | _ => none
+
 /- Walk the function's OWN body: nested functions are not descended into —
    every identifier they mention lands in `capturedRefs` wholesale. -/
 mutual

--- a/Thales/Emit/EscapeAnalysis.lean
+++ b/Thales/Emit/EscapeAnalysis.lean
@@ -291,6 +291,10 @@ partial def walkStmt (acc : MutationInfo) : Statement → MutationInfo
             (match init with
              | some (.callExpr _ (.identifier _ _) _ _) => true
              | some (.memberExpr _ (.identifier _ _) _ true _) => true
+             | some (.literal _ (.string _) _)  => true
+             | some (.literal _ (.number _) _)  => true
+             | some (.literal _ (.bigint _) _)  => true
+             | some (.literal _ (.boolean _) _) => true
              | _ => false)
           let a := if recordable
             then { a with typedDecls := a.typedDecls.insert id.name }

--- a/Thales/Emit/Lean.lean
+++ b/Thales/Emit/Lean.lean
@@ -673,7 +673,11 @@ partial def emitExprEnv (env : EmitEnv) : Expression → LExpr
   | .binaryExpr _ .eq  (.identifier _ varName) (.identifier _ "undefined")
   | .binaryExpr _ .seq (.identifier _ "undefined") (.identifier _ varName)
   | .binaryExpr _ .eq  (.identifier _ "undefined") (.identifier _ varName) =>
-      .proj (.var varName) "isNone"
+      -- A definedness test on a recorded non-Option binding is vacuous:
+      -- `x === null`/`=== undefined` is always false. Fold so we never
+      -- emit `.isNone` on a non-Option value (which does not elaborate).
+      if knownNonOptionBinding env varName then .bool false
+      else .proj (.var varName) "isNone"
   -- `x !== null` / `x !== undefined` (and reverses, with `!=` too) → x.isSome
   | .binaryExpr _ .sneq (.identifier _ varName) (.literal _ .null _)
   | .binaryExpr _ .neq  (.identifier _ varName) (.literal _ .null _)
@@ -683,7 +687,10 @@ partial def emitExprEnv (env : EmitEnv) : Expression → LExpr
   | .binaryExpr _ .neq  (.identifier _ varName) (.identifier _ "undefined")
   | .binaryExpr _ .sneq (.identifier _ "undefined") (.identifier _ varName)
   | .binaryExpr _ .neq  (.identifier _ "undefined") (.identifier _ varName) =>
-      .proj (.var varName) "isSome"
+      -- `x !== null`/`!== undefined` is always true for a recorded
+      -- non-Option binding. Fold (see the `isNone` arm above).
+      if knownNonOptionBinding env varName then .bool true
+      else .proj (.var varName) "isSome"
   -- General binary expressions: when the op is arithmetic, relational, or
   -- equality, project `.val` off any refinement-typed identifier operands
   -- so the operation elaborates on plain `Float`. `%`, bitwise, and shift

--- a/Thales/Emit/Lean.lean
+++ b/Thales/Emit/Lean.lean
@@ -642,6 +642,12 @@ private def recordDeclBinding (env : EmitEnv) (name : String)
     | some (.callExpr _ (.identifier _ f) _ _) => env.funcRetTypes.get? f
     | some (.memberExpr _ (.identifier _ arrName) _ true _) =>
         (arrayElemTy? env arrName).map (fun et => TSType.option et)
+    -- Literal initializers carry a knowable non-Option primitive type
+    -- (the smallest slice of RHS inference; #61 generalizes the rest).
+    | some (.literal _ (.string _) _)  => some .string
+    | some (.literal _ (.number _) _)  => some .number
+    | some (.literal _ (.bigint _) _)  => some .bigint
+    | some (.literal _ (.boolean _) _) => some .boolean
     | _ => none
   match (typeAnnotation.map normalizeForEmit) <|> inferredTy with
   | some t => { env with bindingEnv := env.bindingEnv.insert name t }

--- a/Thales/Emit/SubsetCheck.lean
+++ b/Thales/Emit/SubsetCheck.lean
@@ -216,8 +216,25 @@ partial def checkExpr (ctx : MutCtx) (expr : Expression) : Array Diagnostic :=
     calleeDiags ++ (arguments.foldl (fun acc arg => acc ++ checkExpr ctx arg) #[])
   | .unaryExpr _ _ _ argument =>
     checkExpr ctx argument
-  | .binaryExpr _ _ left right =>
-    checkExpr ctx left ++ checkExpr ctx right
+  | .binaryExpr b _ left right =>
+    -- TH0084: a definedness test on a body-local whose type the emitter
+    -- cannot record (not a param, not in `typedDecls`) can be neither
+    -- folded nor narrowed, so reject rather than emit uncompilable Lean.
+    -- Params and top-level bindings are recordable, so they never reach here.
+    let th84 : Array Diagnostic :=
+      match ctx.info with
+      | some info =>
+        match EscapeAnalysis.definednessTestSubject? expr with
+        | some subj =>
+          let isBodyLocal := info.initializedLets.contains subj
+            || info.uninitializedLets.contains subj || info.consts.contains subj
+          let isRecordable := info.params.contains subj || info.typedDecls.contains subj
+          if isBodyLocal && !isRecordable then
+            #[mkThalesDiag .definednessTestUnrecordedBinding b.loc]
+          else #[]
+        | none => #[]
+      | none => #[]
+    th84 ++ checkExpr ctx left ++ checkExpr ctx right
   | .logicalExpr _ _ left right =>
     checkExpr ctx left ++ checkExpr ctx right
   | .memberExpr _ obj prop _ _ =>

--- a/Thales/TypeCheck/Diagnostic.lean
+++ b/Thales/TypeCheck/Diagnostic.lean
@@ -108,6 +108,7 @@ inductive ThalesKind where
   -- Computed-index diagnostics (TH0082–TH0083)
   | possiblyUndefinedOperand
   | computedIndexNotArray
+  | definednessTestUnrecordedBinding
   -- Directive diagnostics (TH9000–TH9003)
   | directiveUnused
   | directiveCodeMismatch (expected : Nat) (actual : List Nat)
@@ -152,6 +153,7 @@ def ThalesKind.thCode : ThalesKind → Nat
   | .refinementNeedsEvidence .. => 81
   | .possiblyUndefinedOperand => 82
   | .computedIndexNotArray => 83
+  | .definednessTestUnrecordedBinding => 84
   | .directiveUnused => 9000
   | .directiveCodeMismatch .. => 9001
   | .emissionBlockedBySuppressedViolation => 9002
@@ -225,6 +227,8 @@ def ThalesKind.message : ThalesKind → String
     "Operand may be 'undefined' or 'null'; narrow it first (e.g. bind it and test `!== undefined`)"
   | .computedIndexNotArray =>
     "Computed index access is only supported on array values"
+  | .definednessTestUnrecordedBinding =>
+    "Cannot determine whether this binding may be 'undefined'; annotate it or bind it from a recognized initializer before testing it"
   | .directiveUnused => "Unused `@thales-expect-error` directive"
   | .directiveCodeMismatch expected actual =>
     let fmtCode (n : Nat) : String := s!"TH{padCode n}"

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -42,47 +42,48 @@ soundness check).
 
 ## Summary
 
-| Code   | Category     | Short Message                                       |
-| ------ | ------------ | --------------------------------------------------- |
-| TH0001 | Mutation     | Cannot reassign variable                            |
-| TH0002 | Mutation     | Cannot assign to array element                      |
-| TH0003 | Mutation     | Cannot assign to object property                    |
-| TH0004 | Mutation     | Cannot call mutating method                         |
-| TH0005 | Mutation     | Cannot mutate variable captured by enclosing scope  |
-| TH0006 | Mutation     | Assignment only supported in statement position     |
-| TH0007 | Mutation     | Cannot mutate inside `@throws` or `try`/`catch`     |
-| TH0010 | Control flow | Loop not supported                                  |
-| TH0012 | Control flow | async/await not supported                           |
-| TH0020 | Types        | `any` not permitted                                 |
-| TH0021 | Types        | `unknown` not permitted in user code                |
-| TH0022 | Types        | Union must be discriminated                         |
-| TH0023 | Types        | Intersection types not supported                    |
-| TH0024 | Types        | keyof/conditional/mapped types not supported        |
-| TH0025 | Types        | null/undefined types not supported                  |
-| TH0026 | Types        | Condition must be boolean                           |
-| TH0030 | Declarations | `class` not supported                               |
-| TH0031 | Declarations | Inheritance (`extends`) not supported               |
-| TH0032 | Declarations | Shadowing declaration not supported                 |
-| TH0040 | Matching     | Non-exhaustive switch on discriminated union        |
-| TH0041 | Matching     | Switch shape not lowerable                          |
-| TH0050 | Recursion    | Cannot verify termination                           |
-| TH0066 | Totality     | `@total` and `@throws` declared together            |
-| TH0067 | Totality     | `@total` function has uncaught throw                |
-| TH0068 | Totality     | `@total` function contains an unverifiable loop     |
-| TH0070 | Totality     | `@total` asserted but Lean rejects termination      |
-| TH0060 | Exceptions   | Unannotated `throw`                                 |
-| TH0061 | Exceptions   | Unused `@throws` annotation                         |
-| TH0063 | Exceptions   | Thrown value must be a record type                  |
-| TH0064 | Exceptions   | Undeclared propagation                              |
-| TH0080 | Refinement   | Literal value out of range for refinement type      |
-| TH0081 | Refinement   | Value not assignable to refinement without evidence |
-| TH0082 | Subset       | Possibly-undefined operand; narrow before use       |
-| TH0083 | Subset       | Computed index access only supported on arrays      |
-| TH9000 | Directive    | Unused `@thales-expect-error` directive             |
-| TH9001 | Directive    | Directive code mismatch                             |
-| TH9002 | Directive    | Cannot emit: subset violations suppressed           |
-| TH9003 | Directive    | Malformed `@thales-expect-error` directive          |
-| TH9004 | Directive    | Emitted Lean code contains `sorry`                  |
+| Code   | Category     | Short Message                                        |
+| ------ | ------------ | ---------------------------------------------------- |
+| TH0001 | Mutation     | Cannot reassign variable                             |
+| TH0002 | Mutation     | Cannot assign to array element                       |
+| TH0003 | Mutation     | Cannot assign to object property                     |
+| TH0004 | Mutation     | Cannot call mutating method                          |
+| TH0005 | Mutation     | Cannot mutate variable captured by enclosing scope   |
+| TH0006 | Mutation     | Assignment only supported in statement position      |
+| TH0007 | Mutation     | Cannot mutate inside `@throws` or `try`/`catch`      |
+| TH0010 | Control flow | Loop not supported                                   |
+| TH0012 | Control flow | async/await not supported                            |
+| TH0020 | Types        | `any` not permitted                                  |
+| TH0021 | Types        | `unknown` not permitted in user code                 |
+| TH0022 | Types        | Union must be discriminated                          |
+| TH0023 | Types        | Intersection types not supported                     |
+| TH0024 | Types        | keyof/conditional/mapped types not supported         |
+| TH0025 | Types        | null/undefined types not supported                   |
+| TH0026 | Types        | Condition must be boolean                            |
+| TH0030 | Declarations | `class` not supported                                |
+| TH0031 | Declarations | Inheritance (`extends`) not supported                |
+| TH0032 | Declarations | Shadowing declaration not supported                  |
+| TH0040 | Matching     | Non-exhaustive switch on discriminated union         |
+| TH0041 | Matching     | Switch shape not lowerable                           |
+| TH0050 | Recursion    | Cannot verify termination                            |
+| TH0066 | Totality     | `@total` and `@throws` declared together             |
+| TH0067 | Totality     | `@total` function has uncaught throw                 |
+| TH0068 | Totality     | `@total` function contains an unverifiable loop      |
+| TH0070 | Totality     | `@total` asserted but Lean rejects termination       |
+| TH0060 | Exceptions   | Unannotated `throw`                                  |
+| TH0061 | Exceptions   | Unused `@throws` annotation                          |
+| TH0063 | Exceptions   | Thrown value must be a record type                   |
+| TH0064 | Exceptions   | Undeclared propagation                               |
+| TH0080 | Refinement   | Literal value out of range for refinement type       |
+| TH0081 | Refinement   | Value not assignable to refinement without evidence  |
+| TH0082 | Subset       | Possibly-undefined operand; narrow before use        |
+| TH0083 | Subset       | Computed index access only supported on arrays       |
+| TH0084 | Subset       | Definedness test on a binding of undeterminable type |
+| TH9000 | Directive    | Unused `@thales-expect-error` directive              |
+| TH9001 | Directive    | Directive code mismatch                              |
+| TH9002 | Directive    | Cannot emit: subset violations suppressed            |
+| TH9003 | Directive    | Malformed `@thales-expect-error` directive           |
+| TH9004 | Directive    | Emitted Lean code contains `sorry`                   |
 
 ## Future of this table
 
@@ -865,3 +866,33 @@ function firstChar(s: string): string | undefined {
 
 Fix: for strings, use the supported string methods; for objects, use dot
 access with a statically-known property name.
+
+### TH0084 — Definedness test on a binding of undeterminable type
+
+**Message:** `Cannot determine whether this binding may be 'undefined'; annotate it or bind it from a recognized initializer before testing it`
+
+Emitted when a definedness test (`x === null`, `x !== undefined`, and the
+`==`/`!=` variants) is applied to a body-local binding whose type the
+emitter cannot record — i.e. an unannotated `let`/`const` whose initializer
+is not a call, element read, or literal. The emitter cannot tell whether the
+binding is `Option`-typed, so it can neither narrow the test nor fold it
+away, and rejects rather than emit Lean that fails to elaborate. `tsc`
+accepts these. Parameters and annotated or literal-initialized bindings are
+recordable and are not rejected.
+
+Example (rejected):
+
+```typescript
+function f(a: string, b: string): string {
+  const x = a + b;
+  // @thales-expect-error TH0084
+  if (x !== undefined) {
+    return x;
+  }
+  return 'n';
+}
+```
+
+Fix: annotate the binding (`const x: string = a + b;`), or restructure so
+the tested value comes from a recognized initializer. Generalizing the
+emitter's RHS type inference (issue #61) will let more of these compile.

--- a/tests/conformance/accept/definedness-test-domode.ts
+++ b/tests/conformance/accept/definedness-test-domode.ts
@@ -1,0 +1,10 @@
+// Definedness test on a non-Option param inside a do-mode body (the local
+// `out` mutation forces `Id.run do`); the vacuous test folds in do-mode too.
+function f(x: string): string {
+  let out = '';
+  if (x !== undefined) {
+    out = x;
+  }
+  return out;
+}
+console.log(f('hi'));

--- a/tests/conformance/accept/definedness-test-literal-const.ts
+++ b/tests/conformance/accept/definedness-test-literal-const.ts
@@ -1,0 +1,10 @@
+// An un-annotated const with a literal initializer is known non-Option,
+// so its definedness test folds and compiles.
+function f(): string {
+  const x = 'a';
+  if (x !== undefined) {
+    return x;
+  }
+  return 'b';
+}
+console.log(f());

--- a/tests/conformance/accept/definedness-test-nonoption-param.ts
+++ b/tests/conformance/accept/definedness-test-nonoption-param.ts
@@ -1,0 +1,9 @@
+// A definedness test on a non-Option parameter is vacuous (the value is
+// always defined); it folds to the taken branch and compiles.
+function f(x: string): string {
+  if (x === null) {
+    return 'never';
+  }
+  return x;
+}
+console.log(f('hi'));

--- a/tests/conformance/reject/0084-definedness-untyped-binding.ts
+++ b/tests/conformance/reject/0084-definedness-untyped-binding.ts
@@ -1,0 +1,15 @@
+// Subset-rejected (TH0084): a definedness test on a body-local whose type
+// the emitter cannot record (a concatenation initializer — not an
+// annotation, call, element read, or literal). The emitter can neither
+// fold the test (the value might be Option) nor narrow it (it might be
+// non-Option), so the subset check rejects it. See #61 for generalizing
+// RHS type inference, which would let this compile.
+function f(a: string, b: string): string {
+  const x = a + b;
+  // @thales-expect-error TH0084
+  if (x !== undefined) {
+    return x;
+  }
+  return 'n';
+}
+console.log(f('x', 'y'));


### PR DESCRIPTION
Makes every accepted program containing a definedness test (`x === null`,
`x !== undefined`, and `==`/`!=` variants) on an **identifier** subject emit
Lean that elaborates and runs byte-identically, via a three-way type-aware
lowering:

- **Option binding** → narrow (unchanged, from #59).
- **Recorded non-Option binding** → fold the vacuous test to a constant
  (`if true`/`if false`), instead of emitting `.isSome`/`.isNone` on a
  non-Option value (which does not elaborate).
- **Unrecorded body-local binding** → reject with new subset diagnostic
  **TH0084** (the honest-oracle backstop): the emitter can neither fold nor
  narrow it, so it never reaches emission.

The emitter's binding-type inference is also extended to literal initializers
(`const x = 'a'` is now recorded non-Option), so more bindings fold instead of
falling through to a broken `match`.

This fixes gap 3 of #60 — the only live accept→uncompilable bug in that issue.
Gaps 1–2 are checker-narrowing and were rescoped to #38.

A definedness test on a **non-identifier** subject (e.g. `g() !== undefined`)
is still accepted and miscompiles — both the lowering and TH0084 key on
identifier subjects by design. Pre-existing, not a regression; filed as #63.

Closes #60.