### PR TITLE
Array join/indexOf/includes for number[] and string[] (#28)

### DIFF
--- a/Test/Runtime/ArrayMethodsTest.lean
+++ b/Test/Runtime/ArrayMethodsTest.lean
@@ -1,0 +1,52 @@
+/-
+  Test/Runtime/ArrayMethodsTest.lean
+  Pins the Array stdlib helpers (#28): `joinJS`, `indexOfJS`, `includesFloat`,
+  `includesStr`. Every expected value is Node's result for the same call.
+  Note the indexOf/includes NaN divergence: `===` vs SameValueZero.
+-/
+import Thales.TS.Runtime
+
+open Thales.TS
+
+private def expectStr (label : String) (got expected : String) : IO Unit := do
+  unless got == expected do
+    throw (IO.userError s!"{label}: got {repr got}, expected {repr expected}")
+
+private def expectFloat (label : String) (got expected : Float) : IO Unit := do
+  unless got == expected do
+    throw (IO.userError s!"{label}: got {got}, expected {expected}")
+
+private def expectBool (label : String) (got expected : Bool) : IO Unit := do
+  unless got == expected do
+    throw (IO.userError s!"{label}: got {got}, expected {expected}")
+
+private def nums : Array Float := #[3.0, 1.0, 2.0]
+private def strs : Array String := #["a", "b", "c"]
+private def nan : Float := 0.0 / 0.0
+
+def tJoin : IO Unit := do
+  expectStr "nums.join(\",\")" (Array.joinJS nums ",") "3,1,2"
+  expectStr "nums.join(\" - \")" (Array.joinJS nums " - ") "3 - 1 - 2"
+  expectStr "strs.join(\"\")" (Array.joinJS strs "") "abc"
+  expectStr "strs.join(\",\")" (Array.joinJS strs ",") "a,b,c"
+  expectStr "empty.join(\",\")" (Array.joinJS (#[] : Array Float) ",") ""
+
+def tIndexOf : IO Unit := do
+  expectFloat "nums.indexOf(2)" (Array.indexOfJS nums 2.0) 2.0
+  expectFloat "nums.indexOf(9)" (Array.indexOfJS nums 9.0) (-1.0)
+  expectFloat "strs.indexOf(b)" (Array.indexOfJS strs "b") 1.0
+  expectFloat "strs.indexOf(z)" (Array.indexOfJS strs "z") (-1.0)
+  -- indexOf uses ===, so NaN never matches:
+  expectFloat "[NaN].indexOf(NaN)" (Array.indexOfJS #[nan] nan) (-1.0)
+
+def tIncludes : IO Unit := do
+  expectBool "nums.includes(3)" (Array.includesFloat nums 3.0) true
+  expectBool "nums.includes(9)" (Array.includesFloat nums 9.0) false
+  -- includes uses SameValueZero, so NaN matches NaN:
+  expectBool "[NaN].includes(NaN)" (Array.includesFloat #[nan] nan) true
+  expectBool "strs.includes(a)" (Array.includesStr strs "a") true
+  expectBool "strs.includes(z)" (Array.includesStr strs "z") false
+
+#eval tJoin
+#eval tIndexOf
+#eval tIncludes

--- a/Thales/Emit/Lean.lean
+++ b/Thales/Emit/Lean.lean
@@ -760,6 +760,36 @@ partial def emitExprEnv (env : EmitEnv) : Expression → LExpr
           .app (.proj (emitExprEnv env obj) "foldl")
             [emitExprEnv env cb, emitExprEnv env initArg]
       | _, _ =>
+      -- #28: array-method overrides. `xs.join/indexOf/includes(...)` on an
+      -- identifier receiver recorded as `number[]`/`string[]`. Non-identifier
+      -- receivers are rejected earlier by TH0085, so they never reach here;
+      -- unsupported element types fall through to the generic emission below
+      -- (a Lean compile error if ever exercised — never a silent miscompile).
+      let arrayMethodOverride : Option LExpr :=
+        match callee with
+        | .memberExpr _ (.identifier _ recv) (.identifier _ m) false _ =>
+            let elemTy? := env.bindingEnv.get? recv
+            let firstArg? : Option LExpr := match args with
+              | a :: _ => some (emitExprEnv env a)
+              | [] => none
+            match elemTy?, m with
+            | some (.array .number), "join" =>
+                some (.app (.var "Array.joinJS") [.var recv, firstArg?.getD (.str ",")])
+            | some (.array .string), "join" =>
+                some (.app (.var "Array.joinJS") [.var recv, firstArg?.getD (.str ",")])
+            | some (.array .number), "indexOf" =>
+                firstArg?.map (fun a => .app (.var "Array.indexOfJS") [.var recv, a])
+            | some (.array .string), "indexOf" =>
+                firstArg?.map (fun a => .app (.var "Array.indexOfJS") [.var recv, a])
+            | some (.array .number), "includes" =>
+                firstArg?.map (fun a => .app (.var "Array.includesFloat") [.var recv, a])
+            | some (.array .string), "includes" =>
+                firstArg?.map (fun a => .app (.var "Array.includesStr") [.var recv, a])
+            | _, _ => none
+        | _ => none
+      match arrayMethodOverride with
+      | some e => e
+      | none =>
       let calleeFnName : Option String := match callee with
         | .identifier _ name => some name
         | _ => none

--- a/Thales/Emit/SubsetCheck.lean
+++ b/Thales/Emit/SubsetCheck.lean
@@ -60,6 +60,12 @@ structure MutCtx where
   /-- Binding environment for the enclosing function's typed parameters;
       used to check that for-of RHS resolves to an array type. -/
   bindingEnv : Std.HashMap String TSType := {}
+  /-- Annotation-derived types of identifiers in scope (module-level consts,
+      typed parameters, body-local typed declarators), used solely to resolve
+      an array-method receiver's element type for TH0085. Kept separate from
+      `bindingEnv` on purpose: `bindingEnv` feeds the intentionally
+      conservative (params-only) loop-admission check, which must not widen. -/
+  recvEnv : Std.HashMap String TSType := {}
 
 /-- Parameter names of a JS-level function/arrow (typed params live on
     `annotatedFuncDecl` and are handled separately). -/
@@ -129,6 +135,20 @@ private def identIsArray (ctx : MutCtx) (name : String) : Bool :=
       | .array _ => true
       | _ => false
   | none => false
+
+/-- Record a statement's body-local typed declarators into `recvEnv` so a
+    later array-method call on them can resolve the element type (TH0085).
+    Only explicit annotations are tracked; resolving inferred/initializer-shape
+    types is the emitter's job and is tracked separately. -/
+private def recordRecvDecls (ctx : MutCtx) (s : Statement) : MutCtx :=
+  match s with
+  | .variableDecl (VariableDeclaration.mk _ decls _) =>
+      decls.foldl (fun ctx decl =>
+        match decl with
+        | VariableDeclarator.mk _ (.identifier idn) _ (some ty) =>
+            { ctx with recvEnv := ctx.recvEnv.insert idn.name ty }
+        | _ => ctx) ctx
+  | _ => ctx
 
 /-- Route a statement-position mutation of identifier `name`.
     Returns the rejection diagnostics; `#[]` means the mutation is allowed.
@@ -210,14 +230,28 @@ partial def checkExpr (ctx : MutCtx) (expr : Expression) : Array Diagnostic :=
         if mutatingMethodNames.elem propName then
           #[mkThalesDiag (.cannotCallMutatingMethod propName) loc]
             ++ checkExpr ctx obj
-        -- TH0085: join/indexOf/includes lower only for an identifier receiver
-        -- recorded as number[]/string[]; any other receiver (call, member
-        -- chain, etc.) cannot be statically typed by the emitter, so reject
-        -- rather than emit uncompilable Lean.
-        else if (propName == "join" || propName == "indexOf" || propName == "includes")
-            && !(match obj with | .identifier _ _ => true | _ => false) then
-          #[mkThalesDiag (.arrayMethodReceiverNotLowerable propName) loc]
-            ++ checkExpr ctx obj
+        -- TH0085: join/indexOf/includes lower only when the emitter can
+        -- statically resolve the receiver to `number[]`/`string[]`. Reject the
+        -- two receiver shapes that would otherwise emit uncompilable Lean:
+        --   (a) a non-identifier receiver (call result, member chain, …);
+        --   (b) an identifier whose declared element type is an array of some
+        --       other type (`boolean[]`, `number[][]`, an object array, …).
+        -- Receivers SubsetCheck cannot resolve here (string methods, arrays
+        -- whose type is only inferred from an initializer) are left to the
+        -- existing path and tracked under separate issues.
+        else if propName == "join" || propName == "indexOf" || propName == "includes" then
+          match obj with
+          | .identifier _ recv =>
+              match (ctx.recvEnv.get? recv).map (resolveType ctx.aliasEnv) with
+              | some (.array .number) => checkExpr ctx callee
+              | some (.array .string) => checkExpr ctx callee
+              | some (.array _) =>
+                  #[mkThalesDiag (.arrayMethodReceiverNotLowerable propName) loc]
+                    ++ checkExpr ctx obj
+              | _ => checkExpr ctx callee
+          | _ =>
+              #[mkThalesDiag (.arrayMethodReceiverNotLowerable propName) loc]
+                ++ checkExpr ctx obj
         else
           checkExpr ctx callee
       | _ => checkExpr ctx callee
@@ -328,7 +362,11 @@ partial def checkStmt (ctx : MutCtx) (stmt : Statement) : Array Diagnostic :=
       routeIdentMutation ctx b.loc name false true
     | _ => checkExpr ctx expr
   | .blockStmt _ body =>
-    body.foldl (fun acc s => acc ++ checkStmt ctx s) #[]
+    -- Thread `recvEnv` so a body-local typed array declarator is visible to a
+    -- later array-method call on it (TH0085); declarations stay scoped to the
+    -- block because the accumulator resets per `checkStmt` recursion.
+    (body.foldl (fun (st : Array Diagnostic × MutCtx) s =>
+      (st.1 ++ checkStmt st.2 s, recordRecvDecls st.2 s)) (#[], ctx)).1
   | .ifStmt _ test consequent alternate =>
     checkExpr ctx test
       ++ checkStmt ctx consequent
@@ -839,6 +877,15 @@ private def buildAliasEnv (body : List TSStatement) : Std.HashMap String TSType 
     | .declareStmt _ (.typeAliasDecl _ name _ ty) => env.insert name ty
     | _ => env) {}
 
+/-- Module-level annotation-derived bindings (top-level typed `const`/`let`),
+    seeded into `recvEnv` for the array-method receiver check (TH0085). -/
+private def buildTopRecvEnv (body : List TSStatement) : Std.HashMap String TSType :=
+  body.foldl (fun env ts =>
+    match ts with
+    | .annotatedVarDecl _ _ name (some ann) _ => env.insert name ann.type
+    | .declareStmt _ (.annotatedVarDecl _ _ name (some ann) _) => env.insert name ann.type
+    | _ => env) {}
+
 /-- Build a binding environment from annotated function parameters. -/
 private def buildParamEnv
     (params : List (String × Option TypeAnnotation × Bool × Bool))
@@ -849,10 +896,12 @@ private def buildParamEnv
     | none => env) {}
 
 /-- Check a TS-level statement for mutation violations.
-    `aliasEnv` is threaded in for for-of array-type resolution. -/
-def checkTSStmt (aliasEnv : Std.HashMap String TSType) (ts : TSStatement) : Array Diagnostic :=
+    `aliasEnv` is threaded in for for-of array-type resolution; `topRecvEnv`
+    carries module-level annotation types for the TH0085 receiver check. -/
+def checkTSStmt (aliasEnv : Std.HashMap String TSType)
+    (topRecvEnv : Std.HashMap String TSType) (ts : TSStatement) : Array Diagnostic :=
   match ts with
-  | .js s => checkStmt {} s ++ shadowStmts {} [s]
+  | .js s => checkStmt { aliasEnv := aliasEnv, recvEnv := topRecvEnv } s ++ shadowStmts {} [s]
   | .annotatedVarDecl b _ _ typeAnn initOpt =>
     checkAnn b.loc typeAnn
       ++ (match initOpt with
@@ -861,13 +910,16 @@ def checkTSStmt (aliasEnv : Std.HashMap String TSType) (ts : TSStatement) : Arra
   -- TH0012: async annotated function declarations — emit diagnostic, still recurse body.
   -- TH0060 is no longer SubsetCheck's responsibility, so no suppression filter is needed.
   | .annotatedFuncDecl b _ _ params returnType body _ async throwsAnn isTotal =>
+    let paramEnv := buildParamEnv params
     let ctx : MutCtx :=
       { info := some (EscapeAnalysis.analyze (params.map (·.1)) body),
         noMutZone := throwsAnn != .absent,
         allowEligible := true,
         inTotalFn := isTotal,
         aliasEnv := aliasEnv,
-        bindingEnv := buildParamEnv params }
+        bindingEnv := paramEnv,
+        -- Typed params override module-level bindings of the same name.
+        recvEnv := paramEnv.fold (fun m k v => m.insert k v) topRecvEnv }
     let paramTypeDiags := params.foldl (fun acc (_, ann, _, _) =>
       acc ++ checkAnn b.loc ann) #[]
     let bodyDiags := checkStmt ctx body
@@ -885,7 +937,7 @@ def checkTSStmt (aliasEnv : Std.HashMap String TSType) (ts : TSStatement) : Arra
           acc ++ pd ++ checkType b.loc ret) #[]
   | .typeAliasDecl b _ _ ty => checkType b.loc ty
   | .enumDecl _ _ _ _ => #[]
-  | .declareStmt _ inner => checkTSStmt aliasEnv inner
+  | .declareStmt _ inner => checkTSStmt aliasEnv topRecvEnv inner
   | .importDecl _ _ _ => #[]
 
 /-- Check a TS-level statement for switch lowerability and exhaustiveness
@@ -908,8 +960,9 @@ def checkTSStmtSwitch (aliasEnv : Std.HashMap String TSType) (ts : TSStatement)
     without directive post-processing). -/
 def subsetCheckRaw (prog : TSProgram) : Array Diagnostic :=
   let aliasEnv := buildAliasEnv prog.body
+  let topRecvEnv := buildTopRecvEnv prog.body
   prog.body.foldl (fun acc ts =>
-    acc ++ checkTSStmt aliasEnv ts ++ checkTSStmtSwitch aliasEnv ts) #[]
+    acc ++ checkTSStmt aliasEnv topRecvEnv ts ++ checkTSStmtSwitch aliasEnv ts) #[]
 
 /-- Subset check with `@thales-expect-error` directives applied.
     Suppresses TH diagnostics on lines covered by matching directives and

--- a/Thales/Emit/SubsetCheck.lean
+++ b/Thales/Emit/SubsetCheck.lean
@@ -210,6 +210,14 @@ partial def checkExpr (ctx : MutCtx) (expr : Expression) : Array Diagnostic :=
         if mutatingMethodNames.elem propName then
           #[mkThalesDiag (.cannotCallMutatingMethod propName) loc]
             ++ checkExpr ctx obj
+        -- TH0085: join/indexOf/includes lower only for an identifier receiver
+        -- recorded as number[]/string[]; any other receiver (call, member
+        -- chain, etc.) cannot be statically typed by the emitter, so reject
+        -- rather than emit uncompilable Lean.
+        else if (propName == "join" || propName == "indexOf" || propName == "includes")
+            && !(match obj with | .identifier _ _ => true | _ => false) then
+          #[mkThalesDiag (.arrayMethodReceiverNotLowerable propName) loc]
+            ++ checkExpr ctx obj
         else
           checkExpr ctx callee
       | _ => checkExpr ctx callee

--- a/Thales/TS/Runtime.lean
+++ b/Thales/TS/Runtime.lean
@@ -418,6 +418,35 @@ instance : JSShow Nat    := ⟨toString⟩
 instance : JSShow String := ⟨id⟩
 instance : JSShow Bool   := ⟨fun b => if b then "true" else "false"⟩
 
+/-! ### Array stdlib methods (#28)
+
+`join`/`indexOf`/`includes` for `number[]` (`Array Float`) and `string[]`
+(`Array String`). The emitter dispatches on the receiver's element type. -/
+
+/-- `Array.prototype.join`: stringify each element via `JSShow` and join with
+    `sep`. Empty array → `""`. JS number→string goes through `jsNumberToString`,
+    so output is byte-identical to Node. -/
+def Array.joinJS {α : Type} [JSShow α] (xs : Array α) (sep : String) : String :=
+  String.intercalate sep (xs.toList.map JSShow.jsShow)
+
+/-- `Array.prototype.indexOf`: first index whose element `=== x`, else `-1`, as
+    a JS number (`Float`). Lean `Float` `BEq` is IEEE (`NaN ≠ NaN`, `+0 = -0`),
+    matching JS strict equality; `String` `BEq` matches too. -/
+def Array.indexOfJS {α : Type} [BEq α] (xs : Array α) (x : α) : Float :=
+  match xs.findIdx? (· == x) with
+  | some i => i.toFloat
+  | none   => -1.0
+
+/-- `Array.prototype.includes` for numbers: SameValueZero, so `NaN` matches
+    `NaN` (unlike `indexOf`) and `+0`/`-0` match. -/
+def Array.includesFloat (xs : Array Float) (x : Float) : Bool :=
+  if x.isNaN then xs.any (·.isNaN) else xs.any (· == x)
+
+/-- `Array.prototype.includes` for strings: structural equality (no NaN
+    subtlety). -/
+def Array.includesStr (xs : Array String) (x : String) : Bool :=
+  xs.any (· == x)
+
 /-- Emitted counterpart of JS `console.log(x)`. Prints `x` using
     `JSShow.jsShow` so the Lean path's stdout matches the VM's without any
     post-processing by the conformance harness. -/

--- a/Thales/TypeCheck/Builtins.lean
+++ b/Thales/TypeCheck/Builtins.lean
@@ -203,6 +203,12 @@ where
           .any),
          ("init", .any)]
         .any)
+    -- #28: join/indexOf/includes. `elem` is the element type. The emitter
+    -- lowers these for `number[]`/`string[]` identifier receivers; other
+    -- receivers are rejected by TH0085 (SubsetCheck) per the strict-subset rule.
+    | "join" => some (fnTypeOpt [("separator", .string, true)] .string)
+    | "indexOf" => some (fnType [("searchElement", elem)] .number)
+    | "includes" => some (fnType [("searchElement", elem)] .boolean)
     | _ => none
 
 /-- Create the initial type context with built-in bindings -/

--- a/Thales/TypeCheck/Diagnostic.lean
+++ b/Thales/TypeCheck/Diagnostic.lean
@@ -233,7 +233,7 @@ def ThalesKind.message : ThalesKind → String
   | .definednessTestUnrecordedBinding =>
     "Cannot determine whether this binding may be 'undefined'; annotate it or bind it from a recognized initializer before testing it"
   | .arrayMethodReceiverNotLowerable methodName =>
-    s!"Array method '{methodName}' is only supported on a `number[]` or `string[]` variable; this receiver's element type cannot be determined statically"
+    s!"Array method '{methodName}' is only supported on a `number[]` or `string[]` receiver"
   | .directiveUnused => "Unused `@thales-expect-error` directive"
   | .directiveCodeMismatch expected actual =>
     let fmtCode (n : Nat) : String := s!"TH{padCode n}"

--- a/Thales/TypeCheck/Diagnostic.lean
+++ b/Thales/TypeCheck/Diagnostic.lean
@@ -109,6 +109,8 @@ inductive ThalesKind where
   | possiblyUndefinedOperand
   | computedIndexNotArray
   | definednessTestUnrecordedBinding
+  -- Array stdlib-method diagnostic (TH0085)
+  | arrayMethodReceiverNotLowerable (methodName : String)
   -- Directive diagnostics (TH9000–TH9003)
   | directiveUnused
   | directiveCodeMismatch (expected : Nat) (actual : List Nat)
@@ -154,6 +156,7 @@ def ThalesKind.thCode : ThalesKind → Nat
   | .possiblyUndefinedOperand => 82
   | .computedIndexNotArray => 83
   | .definednessTestUnrecordedBinding => 84
+  | .arrayMethodReceiverNotLowerable _ => 85
   | .directiveUnused => 9000
   | .directiveCodeMismatch .. => 9001
   | .emissionBlockedBySuppressedViolation => 9002
@@ -229,6 +232,8 @@ def ThalesKind.message : ThalesKind → String
     "Computed index access is only supported on array values"
   | .definednessTestUnrecordedBinding =>
     "Cannot determine whether this binding may be 'undefined'; annotate it or bind it from a recognized initializer before testing it"
+  | .arrayMethodReceiverNotLowerable methodName =>
+    s!"Array method '{methodName}' is only supported on a `number[]` or `string[]` variable; this receiver's element type cannot be determined statically"
   | .directiveUnused => "Unused `@thales-expect-error` directive"
   | .directiveCodeMismatch expected actual =>
     let fmtCode (n : Nat) : String := s!"TH{padCode n}"

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -900,15 +900,21 @@ emitter's RHS type inference (issue #61) will let more of these compile.
 
 ### TH0085 — Array method on an unlowerable receiver
 
-**Message:** `Array method '<name>' is only supported on a \`number[]\` or \`string[]\` variable; this receiver's element type cannot be determined statically`
+**Message:** `Array method '<name>' is only supported on a \`number[]\` or \`string[]\` receiver`
 
-`join`, `indexOf`, and `includes` are lowered only when the receiver is a
-variable statically known to be `number[]` or `string[]`. A receiver that is a
-function call, a member-access chain, or any other non-identifier expression
-cannot have its element type resolved at emit time, so it is rejected rather
-than miscompiled. `tsc` accepts these.
+`join`, `indexOf`, and `includes` are lowered only when the receiver is an
+identifier the emitter can statically resolve to `number[]` or `string[]` (a
+module-level const, a typed parameter, or a body-local typed declarator). Two
+receiver shapes are out of subset and rejected rather than miscompiled — `tsc`
+accepts both:
 
-Example (rejected):
+- a non-identifier receiver (a function-call result, a member-access chain, …),
+  whose element type cannot be resolved at emit time; and
+- an identifier whose declared element type is an array of any other type — a
+  `boolean[]`, a nested `number[][]`, an object array — for which no runtime
+  lowering exists.
+
+Examples (rejected):
 
 ```typescript
 function getArr(): number[] {
@@ -916,8 +922,13 @@ function getArr(): number[] {
 }
 // @thales-expect-error TH0085
 console.log(getArr().join(','));
+
+const flags: boolean[] = [true, false];
+// @thales-expect-error TH0085
+console.log(flags.includes(true));
 ```
 
-Fix: assign the array to a typed local first
-(`const arr: number[] = getArr(); arr.join(',')`). Generalizing the emitter's
-receiver type inference (issue #61) will let more of these compile.
+Fix: for a non-identifier receiver, assign the array to a typed local first
+(`const arr: number[] = getArr(); arr.join(',')`). A `boolean[]`/nested-array
+receiver has no equivalent lowering today. Generalizing the emitter's receiver
+type inference (issue #61) will let more of these compile.

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -42,48 +42,49 @@ soundness check).
 
 ## Summary
 
-| Code   | Category     | Short Message                                        |
-| ------ | ------------ | ---------------------------------------------------- |
-| TH0001 | Mutation     | Cannot reassign variable                             |
-| TH0002 | Mutation     | Cannot assign to array element                       |
-| TH0003 | Mutation     | Cannot assign to object property                     |
-| TH0004 | Mutation     | Cannot call mutating method                          |
-| TH0005 | Mutation     | Cannot mutate variable captured by enclosing scope   |
-| TH0006 | Mutation     | Assignment only supported in statement position      |
-| TH0007 | Mutation     | Cannot mutate inside `@throws` or `try`/`catch`      |
-| TH0010 | Control flow | Loop not supported                                   |
-| TH0012 | Control flow | async/await not supported                            |
-| TH0020 | Types        | `any` not permitted                                  |
-| TH0021 | Types        | `unknown` not permitted in user code                 |
-| TH0022 | Types        | Union must be discriminated                          |
-| TH0023 | Types        | Intersection types not supported                     |
-| TH0024 | Types        | keyof/conditional/mapped types not supported         |
-| TH0025 | Types        | null/undefined types not supported                   |
-| TH0026 | Types        | Condition must be boolean                            |
-| TH0030 | Declarations | `class` not supported                                |
-| TH0031 | Declarations | Inheritance (`extends`) not supported                |
-| TH0032 | Declarations | Shadowing declaration not supported                  |
-| TH0040 | Matching     | Non-exhaustive switch on discriminated union         |
-| TH0041 | Matching     | Switch shape not lowerable                           |
-| TH0050 | Recursion    | Cannot verify termination                            |
-| TH0066 | Totality     | `@total` and `@throws` declared together             |
-| TH0067 | Totality     | `@total` function has uncaught throw                 |
-| TH0068 | Totality     | `@total` function contains an unverifiable loop      |
-| TH0070 | Totality     | `@total` asserted but Lean rejects termination       |
-| TH0060 | Exceptions   | Unannotated `throw`                                  |
-| TH0061 | Exceptions   | Unused `@throws` annotation                          |
-| TH0063 | Exceptions   | Thrown value must be a record type                   |
-| TH0064 | Exceptions   | Undeclared propagation                               |
-| TH0080 | Refinement   | Literal value out of range for refinement type       |
-| TH0081 | Refinement   | Value not assignable to refinement without evidence  |
-| TH0082 | Subset       | Possibly-undefined operand; narrow before use        |
-| TH0083 | Subset       | Computed index access only supported on arrays       |
-| TH0084 | Subset       | Definedness test on a binding of undeterminable type |
-| TH9000 | Directive    | Unused `@thales-expect-error` directive              |
-| TH9001 | Directive    | Directive code mismatch                              |
-| TH9002 | Directive    | Cannot emit: subset violations suppressed            |
-| TH9003 | Directive    | Malformed `@thales-expect-error` directive           |
-| TH9004 | Directive    | Emitted Lean code contains `sorry`                   |
+| Code   | Category     | Short Message                                          |
+| ------ | ------------ | ------------------------------------------------------ |
+| TH0001 | Mutation     | Cannot reassign variable                               |
+| TH0002 | Mutation     | Cannot assign to array element                         |
+| TH0003 | Mutation     | Cannot assign to object property                       |
+| TH0004 | Mutation     | Cannot call mutating method                            |
+| TH0005 | Mutation     | Cannot mutate variable captured by enclosing scope     |
+| TH0006 | Mutation     | Assignment only supported in statement position        |
+| TH0007 | Mutation     | Cannot mutate inside `@throws` or `try`/`catch`        |
+| TH0010 | Control flow | Loop not supported                                     |
+| TH0012 | Control flow | async/await not supported                              |
+| TH0020 | Types        | `any` not permitted                                    |
+| TH0021 | Types        | `unknown` not permitted in user code                   |
+| TH0022 | Types        | Union must be discriminated                            |
+| TH0023 | Types        | Intersection types not supported                       |
+| TH0024 | Types        | keyof/conditional/mapped types not supported           |
+| TH0025 | Types        | null/undefined types not supported                     |
+| TH0026 | Types        | Condition must be boolean                              |
+| TH0030 | Declarations | `class` not supported                                  |
+| TH0031 | Declarations | Inheritance (`extends`) not supported                  |
+| TH0032 | Declarations | Shadowing declaration not supported                    |
+| TH0040 | Matching     | Non-exhaustive switch on discriminated union           |
+| TH0041 | Matching     | Switch shape not lowerable                             |
+| TH0050 | Recursion    | Cannot verify termination                              |
+| TH0066 | Totality     | `@total` and `@throws` declared together               |
+| TH0067 | Totality     | `@total` function has uncaught throw                   |
+| TH0068 | Totality     | `@total` function contains an unverifiable loop        |
+| TH0070 | Totality     | `@total` asserted but Lean rejects termination         |
+| TH0060 | Exceptions   | Unannotated `throw`                                    |
+| TH0061 | Exceptions   | Unused `@throws` annotation                            |
+| TH0063 | Exceptions   | Thrown value must be a record type                     |
+| TH0064 | Exceptions   | Undeclared propagation                                 |
+| TH0080 | Refinement   | Literal value out of range for refinement type         |
+| TH0081 | Refinement   | Value not assignable to refinement without evidence    |
+| TH0082 | Subset       | Possibly-undefined operand; narrow before use          |
+| TH0083 | Subset       | Computed index access only supported on arrays         |
+| TH0084 | Subset       | Definedness test on a binding of undeterminable type   |
+| TH0085 | Subset       | Array method on a receiver of unlowerable element type |
+| TH9000 | Directive    | Unused `@thales-expect-error` directive                |
+| TH9001 | Directive    | Directive code mismatch                                |
+| TH9002 | Directive    | Cannot emit: subset violations suppressed              |
+| TH9003 | Directive    | Malformed `@thales-expect-error` directive             |
+| TH9004 | Directive    | Emitted Lean code contains `sorry`                     |
 
 ## Future of this table
 
@@ -896,3 +897,27 @@ function f(a: string, b: string): string {
 Fix: annotate the binding (`const x: string = a + b;`), or restructure so
 the tested value comes from a recognized initializer. Generalizing the
 emitter's RHS type inference (issue #61) will let more of these compile.
+
+### TH0085 — Array method on an unlowerable receiver
+
+**Message:** `Array method '<name>' is only supported on a \`number[]\` or \`string[]\` variable; this receiver's element type cannot be determined statically`
+
+`join`, `indexOf`, and `includes` are lowered only when the receiver is a
+variable statically known to be `number[]` or `string[]`. A receiver that is a
+function call, a member-access chain, or any other non-identifier expression
+cannot have its element type resolved at emit time, so it is rejected rather
+than miscompiled. `tsc` accepts these.
+
+Example (rejected):
+
+```typescript
+function getArr(): number[] {
+  return [3, 1, 2];
+}
+// @thales-expect-error TH0085
+console.log(getArr().join(','));
+```
+
+Fix: assign the array to a typed local first
+(`const arr: number[] = getArr(); arr.join(',')`). Generalizing the emitter's
+receiver type inference (issue #61) will let more of these compile.

--- a/scripts/run-examples.js
+++ b/scripts/run-examples.js
@@ -2,6 +2,14 @@
 // scripts/run-examples.js
 // Drives the Thales-TS ↔ TypeScript conformance harness.
 //
+// Usage:
+//   node scripts/run-examples.js                 # full conformance corpus
+//   node scripts/run-examples.js <substr>        # only cases whose label
+//   node scripts/run-examples.js --filter <sub>  #   matches <substr> (e.g.
+//                                                #   `array-join`)
+//   node scripts/run-examples.js --self-test     # harness self-test fixtures
+//                                                #   (combinable with a filter)
+//
 // Environment assumptions (CI pins these; local runs may differ):
 //   NODE_VERSION 24.x, LC_ALL=C.UTF-8, TZ=UTC, lean-toolchain from repo.
 
@@ -420,7 +428,11 @@ function collectCases(rootDir, mode) {
 }
 
 function runCorpus(rootDir, opts = {}) {
-  const cases = collectCases(rootDir, opts.selfTest ? 'subdir' : 'flat');
+  let cases = collectCases(rootDir, opts.selfTest ? 'subdir' : 'flat');
+  if (opts.filter) {
+    const needle = opts.filter.toLowerCase();
+    cases = cases.filter((c) => c.label.toLowerCase().includes(needle));
+  }
   let passes = 0;
   let fails = 0;
   for (const c of cases) {
@@ -509,6 +521,22 @@ function runDirectHarnessChecks() {
 const args = process.argv.slice(2);
 const selfTest = args.includes('--self-test');
 
+// Optional single-example filter: a substring matched case-insensitively
+// against each case label (e.g. `accept/array-join.ts`, or just `array-join`).
+// Supply it as `--filter <substr>` / `--filter=<substr>` or as a bare
+// positional argument, to iterate on one example without the whole suite.
+function parseFilter(argv) {
+  const idx = argv.findIndex(
+    (a) => a === '--filter' || a.startsWith('--filter='),
+  );
+  if (idx !== -1) {
+    const a = argv[idx];
+    return a.includes('=') ? a.slice(a.indexOf('=') + 1) : argv[idx + 1];
+  }
+  return argv.find((a) => !a.startsWith('-'));
+}
+const filter = parseFilter(args);
+
 const problems = preflight();
 if (problems.length > 0) {
   console.error('Preflight failed:');
@@ -522,18 +550,37 @@ if (selfTest) {
     console.log(`(no fixtures directory yet at ${fixturesDir})`);
     process.exit(0);
   }
-  const { passes, fails } = runCorpus(fixturesDir, { selfTest: true });
+  const { passes, fails } = runCorpus(fixturesDir, { selfTest: true, filter });
+  if (filter && passes + fails === 0) {
+    console.error(`No fixtures matched filter '${filter}'.`);
+    process.exit(2);
+  }
   console.log(`\n${passes} passed, ${fails} failed`);
   process.exit(fails > 0 ? 1 : 0);
 }
 
-const directFail = runDirectHarnessChecks();
-if (directFail) {
-  console.error('Direct harness check failed:\n  ' + directFail);
-  process.exit(1);
+// The direct harness checks aren't tied to a single example; skip them when
+// the run is narrowed to one.
+if (!filter) {
+  const directFail = runDirectHarnessChecks();
+  if (directFail) {
+    console.error('Direct harness check failed:\n  ' + directFail);
+    process.exit(1);
+  }
 }
 
-console.log('Running conformance corpus...\n');
-const { passes, fails } = runCorpus(conformanceDir, { selfTest: false });
+console.log(
+  filter
+    ? `Running conformance corpus (filter: ${filter})...\n`
+    : 'Running conformance corpus...\n',
+);
+const { passes, fails } = runCorpus(conformanceDir, {
+  selfTest: false,
+  filter,
+});
+if (filter && passes + fails === 0) {
+  console.error(`No examples matched filter '${filter}'.`);
+  process.exit(2);
+}
 console.log(`\n${passes} passed, ${fails} failed`);
 process.exit(fails > 0 ? 1 : 0);

--- a/tests/conformance/accept/array-indexof-includes.ts
+++ b/tests/conformance/accept/array-indexof-includes.ts
@@ -1,0 +1,11 @@
+const xs: number[] = [3, 1, 2];
+console.log(xs.indexOf(2));
+console.log(xs.indexOf(9));
+console.log(xs.includes(3));
+console.log(xs.includes(9));
+
+const ss: string[] = ['a', 'b'];
+console.log(ss.indexOf('b'));
+console.log(ss.indexOf('z'));
+console.log(ss.includes('a'));
+console.log(ss.includes('z'));

--- a/tests/conformance/accept/array-join.ts
+++ b/tests/conformance/accept/array-join.ts
@@ -1,0 +1,11 @@
+const xs: number[] = [3, 1, 2];
+console.log(xs.join(','));
+console.log(xs.join());
+console.log(xs.join(' - '));
+
+const ss: string[] = ['a', 'b', 'c'];
+console.log(ss.join(''));
+console.log(ss.join(','));
+
+const empty: number[] = [];
+console.log(empty.join(','));

--- a/tests/conformance/accept/array-method-receivers.ts
+++ b/tests/conformance/accept/array-method-receivers.ts
@@ -1,0 +1,14 @@
+// join/indexOf/includes lower for any receiver the emitter can statically
+// resolve to number[]/string[], not just a module-level const: a body-local
+// typed declarator and a typed parameter both work.
+function joinLabels(): string {
+  const labels: string[] = ['lo', 'hi'];
+  return labels.join('/');
+}
+
+function indexIn(xs: number[]): number {
+  return xs.indexOf(2);
+}
+
+console.log(joinLabels());
+console.log(indexIn([3, 1, 2]));

--- a/tests/conformance/reject/0085-array-method-bad-element-type.ts
+++ b/tests/conformance/reject/0085-array-method-bad-element-type.ts
@@ -1,0 +1,11 @@
+// `join`/`indexOf`/`includes` type-check on any array under `tsc`, but Thales
+// lowers them only for `number[]`/`string[]` receivers. An identifier whose
+// element type is anything else (a `boolean[]`, a nested `number[][]`, …) is
+// out of the Thales subset: emitting it would produce uncompilable Lean.
+const bs: boolean[] = [true, false];
+// @thales-expect-error TH0085
+console.log(bs.includes(true));
+
+const xss: number[][] = [[1], [2]];
+// @thales-expect-error TH0085
+console.log(xss.join(','));

--- a/tests/conformance/reject/0085-array-method-untyped-receiver.ts
+++ b/tests/conformance/reject/0085-array-method-untyped-receiver.ts
@@ -1,0 +1,7 @@
+// A function-call receiver type-checks under `tsc`, but the emitter cannot
+// statically resolve its element type, so join is out of the Thales subset.
+function getArr(): number[] {
+  return [3, 1, 2];
+}
+// @thales-expect-error TH0085
+console.log(getArr().join(','));


### PR DESCRIPTION
`Array.prototype.join`, `indexOf`, and `includes` now type-check, emit, and run byte-identically for `number[]` and `string[]` receivers — closing the contract bug where `tsc`-clean calls drew spurious `TS2339`.

Lowering mirrors the existing `.length` receiver dispatch: identifier receivers recorded as `number[]`/`string[]` lower to polymorphic runtime helpers (`joinJS`/`indexOfJS`/`includesFloat`/`includesStr`). `indexOf` uses strict `===`; `includes` uses SameValueZero, so they diverge on `NaN` — hence the dedicated `includesFloat`. Receivers the emitter cannot statically type (function-call or chained receivers) are rejected with a new **TH0085** rather than miscompiled.

Conformance corpus 139 → 142. Still open under #28: the `String.prototype.padStart`/`padEnd` 2-arg fill form and the `Number.*` audit.

Separately discovered while writing tests: the `NaN` literal type-checks but emits an unknown Lean identifier (accept→uncompilable, pre-existing) — filed as #66.