### PR TITLE
Lower NaN/Infinity to Float constants (#66)

### DIFF
--- a/Thales/Emit/Lean.lean
+++ b/Thales/Emit/Lean.lean
@@ -667,7 +667,11 @@ partial def emitExprEnv (env : EmitEnv) : Expression → LExpr
   | .literal _ (.boolean b) _ => .bool b
   | .literal _ .null _       => .ctor "none" []
   | .literal _ (.regex _ _) _ => .var "(unsupported: regex literal)"
-  -- Identifier
+  -- Identifier. The JS numeric globals `NaN`/`Infinity` are `number`-typed but
+  -- have no bare Lean counterpart, so lower them to the runtime `Float`
+  -- constants (`-Infinity` lowers as the negation of `Infinity`).
+  | .identifier _ "NaN"      => .var "tsNaN"
+  | .identifier _ "Infinity" => .var "tsInfinity"
   | .identifier _ name => .var name
   -- Binary expressions — null-equality checks emit isNone/isSome on Option values
   -- `x === null` / `x === undefined` (and reverses, with `==` too) → x.isNone

--- a/Thales/TS/Runtime.lean
+++ b/Thales/TS/Runtime.lean
@@ -394,8 +394,16 @@ def jsMod (a b : Float) : Float :=
     form) fall through to Lean's `%f` formatting. -/
 def jsNumberToString (x : Float) : String :=
   if x.isNaN then "NaN"
+  else if x.isInf then (if x < 0.0 then "-Infinity" else "Infinity")
   else if x == 0.0 then "0"
   else stripTrailingZerosAfterDot (toString x)
+
+/-- JS global `NaN` as a Lean `Float` (the emitter lowers the `NaN` identifier
+    here so it is never a bare, unresolved name). -/
+def tsNaN : Float := 0.0 / 0.0
+
+/-- JS global `Infinity` as a Lean `Float`; `-Infinity` lowers to its negation. -/
+def tsInfinity : Float := 1.0 / 0.0
 
 /-- Typeclass for values printable by `console.log`. Instances implement the
     small subset of JS ToString semantics v1 actually exercises. -/

--- a/tests/conformance/accept/array-nan-divergence.ts
+++ b/tests/conformance/accept/array-nan-divergence.ts
@@ -1,0 +1,5 @@
+// indexOf uses strict ===, so it never matches NaN; includes uses
+// SameValueZero, so it does. (Unblocked by NaN now lowering to a Float value.)
+const xs: number[] = [NaN, 1];
+console.log(xs.indexOf(NaN));
+console.log(xs.includes(NaN));

--- a/tests/conformance/accept/nan-infinity.ts
+++ b/tests/conformance/accept/nan-infinity.ts
@@ -1,0 +1,6 @@
+// The JS numeric globals NaN/Infinity are number-typed and print as
+// themselves; -Infinity is their negation.
+const x: number = NaN;
+console.log(x);
+console.log(Infinity);
+console.log(-Infinity);


### PR DESCRIPTION
The JS numeric globals `NaN` and `Infinity` are `number`-typed and type-check, but the emitter lowered them to bare `NaN`/`Infinity` identifiers that do not exist in the emitted Lean, so a `tsc`-clean and `thales`-accepted program failed to compile — an accept->uncompilable bug; this lowers them to the runtime `Float` constants `tsNaN`/`tsInfinity` (`-Infinity` as the negation), teaches `jsNumberToString` to render infinities as `Infinity`/`-Infinity` to stay byte-identical to Node, and adds accept fixtures covering NaN/Infinity printing plus the `indexOf`/`includes` NaN divergence that was previously blocked on this fix. Closes #66.