### PR TITLE
Omit ill-typed trailing return after non-completing while(true) (#64)

### DIFF
--- a/Thales/Emit/Lean.lean
+++ b/Thales/Emit/Lean.lean
@@ -1516,7 +1516,7 @@ def emitFuncDecl (aliasEnv : Std.HashMap String TSType) (name : String) (typePar
       -- A body that can fall off the end (void function) needs an explicit
       -- unit return; appending one after an always-returning body would be
       -- dead code at the wrong type.
-      let core := if doStmtsTerminate core then core else core ++ [.ret (.var "()")]
+      let core := finalizeDoBody core
       .idRunDo core
     else
       emitBodyEnv env stmts

--- a/Thales/Emit/LeanSyntax.lean
+++ b/Thales/Emit/LeanSyntax.lean
@@ -118,6 +118,37 @@ partial def doStmtsTerminate (stmts : List LDoStmt) : Bool :=
   -- no trailing return, so all three stay conservatively non-terminating.
   | some _ => false
 
+/-- Whether `stmts` contains a `break` that targets the *current* loop level —
+    not one nested inside another loop, which captures its own `break`.
+    Descends through `if`/`match` arms only. -/
+partial def hasOwnBreakDo (stmts : List LDoStmt) : Bool :=
+  stmts.any fun s => match s with
+    | .breakDo => true
+    | .ifDo _ thn els => hasOwnBreakDo thn || hasOwnBreakDo els
+    | .matchDo _ arms => arms.any fun (_, ss) => hasOwnBreakDo ss
+    | _ => false
+
+/-- A `while (true)` loop with no `break` for this loop: it never completes
+    normally, so control after it is unreachable. (The `do … while (true)`
+    form lowers to `repeat … until`, which must be the last `do` element and
+    so cannot take a trailing tail — that case is tracked separately.) -/
+def loopNeverCompletes : LDoStmt → Bool
+  | .whileDo (.bool true) body => !hasOwnBreakDo body
+  | _ => false
+
+/-- Append the synthetic tail an `Id.run do` body needs so the block has a
+    value on every path. Nothing when it already `return`s everywhere; an
+    unreachable (correctly-typed) tail after a never-completing loop — whose
+    Lean type would otherwise be `PUnit`, mismatching a non-unit return type;
+    or `return ()` for a plain void fall-through. -/
+def finalizeDoBody (stmts : List LDoStmt) : List LDoStmt :=
+  if doStmtsTerminate stmts then stmts
+  else match stmts.getLast? with
+    | some s =>
+        if loopNeverCompletes s then stmts ++ [.ret (.var "unreachable!")]
+        else stmts ++ [.ret (.var "()")]
+    | none => stmts ++ [.ret (.var "()")]
+
 /-- Top-level declaration. -/
 inductive LDecl where
   | def_ (name : String)

--- a/tests/conformance/accept/while-true-returns.ts
+++ b/tests/conformance/accept/while-true-returns.ts
@@ -1,0 +1,14 @@
+// `while (true)` that returns on every interior path never completes, so tsc
+// requires no return after it. The emitter must not append a trailing
+// `return ()` at the function's (non-unit) return type.
+function f(n: number): number {
+  while (true) {
+    if (n > 0) {
+      return n;
+    }
+    return 0;
+  }
+}
+
+console.log(f(5));
+console.log(f(-3));


### PR DESCRIPTION
A function whose body ends in a `while (true)` that returns on every interior path is accepted by both `tsc` (its control-flow analysis knows the loop never completes) and `thales --no-emit`, but the do-mode body emitter unconditionally appended a trailing `return ()` after the loop, which is ill-typed at a non-unit return type and fails to elaborate — an accept->uncompilable bug; this recognizes a `while (true)` with no `break` targeting it as non-completing and appends an `unreachable!` tail (correctly typed, never executed) rather than `return ()`, centralizing the trailing-tail choice in a new `finalizeDoBody` helper, and adds an accept fixture. The sibling `do … while (true)` form lowers to `repeat … until`, which cannot take a trailing element and so needs a different lowering; it is filed separately as #72. Closes #64.