### PR TITLE
Reject definedness test on a non-identifier subject (TH0086, #63)

### DIFF
--- a/Thales/Emit/EscapeAnalysis.lean
+++ b/Thales/Emit/EscapeAnalysis.lean
@@ -224,6 +224,25 @@ def definednessTestSubject? : Expression → Option String
       else none
   | _ => none
 
+/-- True when `expr` is a definedness test (`=== / !== / == / !=` against
+    `null`/`undefined`) whose subject — the non-nullish operand — is not a bare
+    identifier (a call result, member access, computed index, …).
+    `definednessTestSubject?` handles the identifier case (folded or narrowed);
+    the emitter cannot narrow these, and would emit a literal `undefined` /
+    `.none`, so SubsetCheck rejects them (TH0086). -/
+def definednessTestHasNonIdentifierSubject : Expression → Bool
+  | .binaryExpr _ op l r =>
+      let nullishEqOp := match op with
+        | .seq | .sneq | .eq | .neq => true
+        | _ => false
+      if nullishEqOp then
+        let nonIdentSubject : Expression → Expression → Bool := fun subj other =>
+          isNullishOperand other && !isNullishOperand subj
+            && (match subj with | .identifier _ _ => false | _ => true)
+        nonIdentSubject l r || nonIdentSubject r l
+      else false
+  | _ => false
+
 /- Walk the function's OWN body: nested functions are not descended into —
    every identifier they mention lands in `capturedRefs` wholesale. -/
 mutual

--- a/Thales/Emit/SubsetCheck.lean
+++ b/Thales/Emit/SubsetCheck.lean
@@ -276,7 +276,15 @@ partial def checkExpr (ctx : MutCtx) (expr : Expression) : Array Diagnostic :=
           else #[]
         | none => #[]
       | none => #[]
-    th84 ++ checkExpr ctx left ++ checkExpr ctx right
+    -- TH0086: a definedness test whose subject is a non-identifier expression
+    -- (call, member access, computed index) cannot be narrowed by the emitter,
+    -- which would emit a literal `undefined`/`.none`. Independent of TH0084,
+    -- which only fires on identifier subjects.
+    let th86 : Array Diagnostic :=
+      if EscapeAnalysis.definednessTestHasNonIdentifierSubject expr then
+        #[mkThalesDiag .definednessTestNonIdentifierSubject b.loc]
+      else #[]
+    th84 ++ th86 ++ checkExpr ctx left ++ checkExpr ctx right
   | .logicalExpr _ _ left right =>
     checkExpr ctx left ++ checkExpr ctx right
   | .memberExpr _ obj prop _ _ =>

--- a/Thales/TypeCheck/Diagnostic.lean
+++ b/Thales/TypeCheck/Diagnostic.lean
@@ -111,6 +111,8 @@ inductive ThalesKind where
   | definednessTestUnrecordedBinding
   -- Array stdlib-method diagnostic (TH0085)
   | arrayMethodReceiverNotLowerable (methodName : String)
+  -- Definedness test on a non-identifier subject (TH0086)
+  | definednessTestNonIdentifierSubject
   -- Directive diagnostics (TH9000–TH9003)
   | directiveUnused
   | directiveCodeMismatch (expected : Nat) (actual : List Nat)
@@ -157,6 +159,7 @@ def ThalesKind.thCode : ThalesKind → Nat
   | .computedIndexNotArray => 83
   | .definednessTestUnrecordedBinding => 84
   | .arrayMethodReceiverNotLowerable _ => 85
+  | .definednessTestNonIdentifierSubject => 86
   | .directiveUnused => 9000
   | .directiveCodeMismatch .. => 9001
   | .emissionBlockedBySuppressedViolation => 9002
@@ -234,6 +237,8 @@ def ThalesKind.message : ThalesKind → String
     "Cannot determine whether this binding may be 'undefined'; annotate it or bind it from a recognized initializer before testing it"
   | .arrayMethodReceiverNotLowerable methodName =>
     s!"Array method '{methodName}' is only supported on a `number[]` or `string[]` receiver"
+  | .definednessTestNonIdentifierSubject =>
+    "A definedness test against 'undefined'/'null' is only supported when its subject is a variable; bind this expression to a variable first"
   | .directiveUnused => "Unused `@thales-expect-error` directive"
   | .directiveCodeMismatch expected actual =>
     let fmtCode (n : Nat) : String := s!"TH{padCode n}"

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -80,6 +80,7 @@ soundness check).
 | TH0083 | Subset       | Computed index access only supported on arrays         |
 | TH0084 | Subset       | Definedness test on a binding of undeterminable type   |
 | TH0085 | Subset       | Array method on a receiver of unlowerable element type |
+| TH0086 | Subset       | Definedness test on a non-identifier subject           |
 | TH9000 | Directive    | Unused `@thales-expect-error` directive                |
 | TH9001 | Directive    | Directive code mismatch                                |
 | TH9002 | Directive    | Cannot emit: subset violations suppressed              |
@@ -932,3 +933,34 @@ Fix: for a non-identifier receiver, assign the array to a typed local first
 (`const arr: number[] = getArr(); arr.join(',')`). A `boolean[]`/nested-array
 receiver has no equivalent lowering today. Generalizing the emitter's receiver
 type inference (issue #61) will let more of these compile.
+
+### TH0086 — Definedness test on a non-identifier subject
+
+**Message:** `A definedness test against 'undefined'/'null' is only supported when its subject is a variable; bind this expression to a variable first`
+
+A definedness test (`=== undefined`, `!== undefined`, and the `null` forms) is
+lowered only when its subject is a variable: the emitter narrows or folds the
+test based on the variable's recorded type. When the subject is any other
+expression — a function call, a member access, a computed index — the emitter
+cannot narrow it and would emit a literal `undefined` (an unknown Lean
+identifier) or a bare `.none`, so the test is rejected rather than miscompiled.
+`tsc` accepts these.
+
+Example (rejected):
+
+```typescript
+function g(): string {
+  return 'a';
+}
+function f(): string {
+  // @thales-expect-error TH0086
+  if (g() !== undefined) {
+    return g();
+  }
+  return 'n';
+}
+```
+
+Fix: bind the subject to a variable first
+(`const s = g(); if (s !== undefined) { … }`). Generalizing the emitter's RHS
+type inference (issue #61) will let more of these narrow directly.

--- a/tests/conformance/reject/0086-definedness-test-non-identifier-subject.ts
+++ b/tests/conformance/reject/0086-definedness-test-non-identifier-subject.ts
@@ -1,0 +1,15 @@
+// A definedness test against `undefined`/`null` is lowered only when its
+// subject is a variable; the emitter cannot narrow a call (or other
+// non-identifier) subject, so it is out of the Thales subset rather than
+// miscompiled. `tsc` accepts this.
+function g(): string {
+  return 'a';
+}
+function f(): string {
+  // @thales-expect-error TH0086
+  if (g() !== undefined) {
+    return g();
+  }
+  return 'n';
+}
+console.log(f());


### PR DESCRIPTION
A definedness test against `undefined`/`null` (`=== undefined`, `!== undefined`, and the `null` forms) whose subject is a non-identifier expression — a function call, a member access, a computed index — was accepted by `thales --no-emit` but emitted a literal `undefined` (an unknown Lean identifier) or a bare `.none`, failing to elaborate; this is an accept->uncompilable leak left by the TH0084 work, whose type-aware narrowing and folding key on identifier subjects only. Correctly lowering an arbitrary subject needs the generalized RHS type inference tracked in #61, so this takes the same route TH0084 takes for the identifier subjects it cannot resolve and rejects the non-identifier case with a new TH0086 rather than miscompiling it, adding the diagnostic, a docs entry, and a reject fixture; identifier subjects (including the `const y = xs[i]; y !== undefined` narrowing path) are unaffected. Closes #63.