### PR TITLE
Reject unlowered String.prototype methods (TH0087, #69)

### DIFF
--- a/Thales/TypeCheck/Diagnostic.lean
+++ b/Thales/TypeCheck/Diagnostic.lean
@@ -113,6 +113,8 @@ inductive ThalesKind where
   | arrayMethodReceiverNotLowerable (methodName : String)
   -- Definedness test on a non-identifier subject (TH0086)
   | definednessTestNonIdentifierSubject
+  -- Unsupported String.prototype method (TH0087)
+  | stringMethodNotSupported (methodName : String)
   -- Directive diagnostics (TH9000–TH9003)
   | directiveUnused
   | directiveCodeMismatch (expected : Nat) (actual : List Nat)
@@ -160,6 +162,7 @@ def ThalesKind.thCode : ThalesKind → Nat
   | .definednessTestUnrecordedBinding => 84
   | .arrayMethodReceiverNotLowerable _ => 85
   | .definednessTestNonIdentifierSubject => 86
+  | .stringMethodNotSupported _ => 87
   | .directiveUnused => 9000
   | .directiveCodeMismatch .. => 9001
   | .emissionBlockedBySuppressedViolation => 9002
@@ -239,6 +242,8 @@ def ThalesKind.message : ThalesKind → String
     s!"Array method '{methodName}' is only supported on a `number[]` or `string[]` receiver"
   | .definednessTestNonIdentifierSubject =>
     "A definedness test against 'undefined'/'null' is only supported when its subject is a variable; bind this expression to a variable first"
+  | .stringMethodNotSupported methodName =>
+    s!"String method '{methodName}' is not supported; the available string operations are 'startsWith', 'endsWith', and 'split'"
   | .directiveUnused => "Unused `@thales-expect-error` directive"
   | .directiveCodeMismatch expected actual =>
     let fmtCode (n : Nat) : String := s!"TH{padCode n}"

--- a/Thales/TypeCheck/Synth.lean
+++ b/Thales/TypeCheck/Synth.lean
@@ -82,6 +82,14 @@ private partial def lookupProperty (objType : TSType) (propName : String) (depth
     return builtinProperty objType propName
   | _ => return none
 
+/-- String members with a correct Lean lowering today. `length` is a property;
+    `startsWith`/`endsWith`/`split` lower to byte-identical Lean operations.
+    Every other declared `String.prototype` member is rejected (TH0087) — see
+    the member-access arm of `synthJSExpr`. -/
+def stringMethodSupported (name : String) : Bool :=
+  name == "length" || name == "startsWith" || name == "endsWith"
+    || name == "split"
+
 /-- Best-effort extraction of a "source name" for a JS expression, used in
     TH0081 diagnostics (`Value '<name>' of type 'number' is not assignable…`).
     Returns the identifier name for a bare identifier, the dotted path for a
@@ -231,7 +239,19 @@ partial def synthJSExpr (expr : Expression) (expected : Option TSType := none) :
     let objTyped ← synthJSExpr obj
     let resolved ← resolveTypeGeneric objTyped.type
     match ← lookupProperty resolved propName with
-    | some ty => return mk ty #[objTyped]
+    | some ty =>
+      -- TH0087: most `String.prototype` methods type-check (they are declared
+      -- in `Builtins.stringProperty`) but have no correct Lean lowering — the
+      -- emitter would produce a nonexistent `String.<m>` or a semantically
+      -- divergent one (e.g. `replace` replaces all, not the first match). Only
+      -- `length`/`startsWith`/`endsWith`/`split` are sound today; reject the
+      -- rest here, where the receiver type is fully known. `tsc` accepts them.
+      let unsupportedStringMethod := match resolved with
+        | .string | .stringLit _ => !stringMethodSupported propName
+        | _ => false
+      if unsupportedStringMethod then
+        emitDiagnostic (.thales (.stringMethodNotSupported propName)) base.loc
+      return mk ty #[objTyped]
     | none =>
       match resolved with
       | .any => return mk .any #[objTyped]

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -81,6 +81,7 @@ soundness check).
 | TH0084 | Subset       | Definedness test on a binding of undeterminable type   |
 | TH0085 | Subset       | Array method on a receiver of unlowerable element type |
 | TH0086 | Subset       | Definedness test on a non-identifier subject           |
+| TH0087 | Subset       | Unsupported `String.prototype` method                  |
 | TH9000 | Directive    | Unused `@thales-expect-error` directive                |
 | TH9001 | Directive    | Directive code mismatch                                |
 | TH9002 | Directive    | Cannot emit: subset violations suppressed              |
@@ -964,3 +965,28 @@ function f(): string {
 Fix: bind the subject to a variable first
 (`const s = g(); if (s !== undefined) { … }`). Generalizing the emitter's RHS
 type inference (issue #61) will let more of these narrow directly.
+
+### TH0087 — Unsupported `String.prototype` method
+
+**Message:** `String method '<name>' is not supported; the available string operations are 'startsWith', 'endsWith', and 'split'`
+
+Most `String.prototype` methods type-check — they are declared so that calling
+them is not a spurious `tsc`-style error — but the emitter has no correct Lean
+lowering for them. Some would emit a nonexistent `String.<m>` (e.g. `charAt`,
+`toUpperCase`, `slice`, `padStart`), and some have diverging semantics: JS
+`replace` replaces only the first match, whereas Lean's `String.replace`
+replaces every occurrence. Rather than miscompile (or silently produce wrong
+output), these are rejected. Only `length`, `startsWith`, `endsWith`, and
+`split` are supported today. `tsc` accepts the rejected methods.
+
+Example (rejected):
+
+```typescript
+const s: string = 'abcabc';
+// @thales-expect-error TH0087
+console.log(s.toUpperCase());
+```
+
+Fix: restructure to avoid the method, or use one of the supported operations.
+Sound lowerings (UTF-16-faithful where it matters) are future stdlib work
+(issue #28).

--- a/tests/conformance/reject/0087-unsupported-string-method.ts
+++ b/tests/conformance/reject/0087-unsupported-string-method.ts
@@ -1,0 +1,11 @@
+// Most String.prototype methods type-check (tsc accepts them) but have no
+// correct Lean lowering: many emit a nonexistent `String.<m>`, and some are
+// semantically wrong — e.g. JS `replace` replaces only the first match, while
+// Lean's `String.replace` replaces every one. They are out of the Thales
+// subset rather than miscompiled. Only `startsWith`, `endsWith`, and `split`
+// (plus the `length` property) are supported today.
+const s: string = 'abcabc';
+// @thales-expect-error TH0087
+console.log(s.toUpperCase());
+// @thales-expect-error TH0087
+console.log(s.replace('a', 'X'));


### PR DESCRIPTION
`Builtins.stringProperty` declares ~25 `String.prototype` members so that calling them is not a spurious `tsc`-style error, but the emitter has no correct lowering for most of them: about eleven (`charAt`, `charCodeAt`, `indexOf`, `includes`, `slice`, `substring`, `toUpperCase`, `toLowerCase`, `repeat`, `padStart`, `concat`, and more) emit a nonexistent `String.<m>` and fail to elaborate, and `replace` is worse — it silently diverges, because JS replaces only the first match while Lean's `String.replace` replaces every one — so a `tsc`-clean, `thales`-accepted program either does not compile or produces wrong output; this rejects every string method without a sound lowering with a new TH0087, emitted at member-access synthesis where the receiver type is fully known (so call results, member chains, and string literals are all covered, not just identifier receivers), keeping only the verified-correct `length`/`startsWith`/`endsWith`/`split`, and adds the diagnostic, a docs entry, and a reject fixture. Array `indexOf`/`includes` are unaffected; a non-identifier string receiver of `includes`/`indexOf` also still draws the pre-existing TH0085 alongside TH0087 (the TH0085 mislabel is tracked in #68), and sound UTF-16-faithful lowerings remain future stdlib work (#28). Closes #69.