### PR TITLE
Widen Array stdlib: fromIndex, some/every/findIndex/lastIndexOf

### DIFF
--- a/Test/Runtime/ArrayMethodsTest.lean
+++ b/Test/Runtime/ArrayMethodsTest.lean
@@ -62,6 +62,33 @@ def tIncludes : IO Unit := do
   expectBool "strs.includes(a,1)" (Array.includesStrFrom strs "a" 1.0) false
   expectBool "strs.includes(c,-1)" (Array.includesStrFrom strs "c" (-1.0)) true
 
+private def rep : Array Float := #[1.0, 2.0, 1.0, 2.0]
+private def strs4 : Array String := #["a", "b", "c", "b"]
+
+def tFindIndex : IO Unit := do
+  expectFloat "nums.findIndex(>1)" (Array.findIndexJS nums (· > 1.0)) 0.0
+  expectFloat "nums.findIndex(>5)" (Array.findIndexJS nums (· > 5.0)) (-1.0)
+  expectFloat "rep.findIndex(==2)" (Array.findIndexJS rep (· == 2.0)) 1.0
+  expectBool "nums.some(>1)" (nums.any (· > 1.0)) true
+  expectBool "nums.every(>1)" (nums.all (· > 1.0)) false
+  expectBool "nums.every(>0)" (nums.all (· > 0.0)) true
+
+def tLastIndexOf : IO Unit := do
+  expectFloat "rep.lastIndexOf(1)" (Array.lastIndexOfJS rep 1.0) 2.0
+  expectFloat "rep.lastIndexOf(2)" (Array.lastIndexOfJS rep 2.0) 3.0
+  expectFloat "rep.lastIndexOf(9)" (Array.lastIndexOfJS rep 9.0) (-1.0)
+  expectFloat "rep.lastIndexOf(1,1)" (Array.lastIndexOfFromJS rep 1.0 1.0) 0.0
+  expectFloat "rep.lastIndexOf(2,-1)" (Array.lastIndexOfFromJS rep 2.0 (-1.0)) 3.0
+  expectFloat "rep.lastIndexOf(2,-3)" (Array.lastIndexOfFromJS rep 2.0 (-3.0)) 1.0
+  expectFloat "rep.lastIndexOf(2,-5)" (Array.lastIndexOfFromJS rep 2.0 (-5.0)) (-1.0)
+  expectFloat "strs4.lastIndexOf(b)" (Array.lastIndexOfJS strs4 "b") 3.0
+  expectFloat "strs4.lastIndexOf(b,2)" (Array.lastIndexOfFromJS strs4 "b" 2.0) 1.0
+  expectFloat "strs4.lastIndexOf(z)" (Array.lastIndexOfJS strs4 "z") (-1.0)
+  -- empty array: no valid search window.
+  expectFloat "[].lastIndexOf(1)" (Array.lastIndexOfJS (#[] : Array Float) 1.0) (-1.0)
+
 #eval tJoin
 #eval tIndexOf
 #eval tIncludes
+#eval tFindIndex
+#eval tLastIndexOf

--- a/Test/Runtime/ArrayMethodsTest.lean
+++ b/Test/Runtime/ArrayMethodsTest.lean
@@ -38,6 +38,14 @@ def tIndexOf : IO Unit := do
   expectFloat "strs.indexOf(z)" (Array.indexOfJS strs "z") (-1.0)
   -- indexOf uses ===, so NaN never matches:
   expectFloat "[NaN].indexOf(NaN)" (Array.indexOfJS #[nan] nan) (-1.0)
+  -- #67: optional fromIndex (truncates toward zero, negative counts from end):
+  expectFloat "nums.indexOf(2,1)" (Array.indexOfFromJS nums 2.0 1.0) 2.0
+  expectFloat "nums.indexOf(3,1)" (Array.indexOfFromJS nums 3.0 1.0) (-1.0)
+  expectFloat "nums.indexOf(3,-100)" (Array.indexOfFromJS nums 3.0 (-100.0)) 0.0
+  expectFloat "nums.indexOf(2,5)" (Array.indexOfFromJS nums 2.0 5.0) (-1.0)
+  expectFloat "nums.indexOf(2,1.9)" (Array.indexOfFromJS nums 2.0 1.9) 2.0
+  expectFloat "strs.indexOf(c,1)" (Array.indexOfFromJS strs "c" 1.0) 2.0
+  expectFloat "strs.indexOf(a,1)" (Array.indexOfFromJS strs "a" 1.0) (-1.0)
 
 def tIncludes : IO Unit := do
   expectBool "nums.includes(3)" (Array.includesFloat nums 3.0) true
@@ -46,6 +54,13 @@ def tIncludes : IO Unit := do
   expectBool "[NaN].includes(NaN)" (Array.includesFloat #[nan] nan) true
   expectBool "strs.includes(a)" (Array.includesStr strs "a") true
   expectBool "strs.includes(z)" (Array.includesStr strs "z") false
+  -- #67: optional fromIndex:
+  expectBool "nums.includes(2,1)" (Array.includesFloatFrom nums 2.0 1.0) true
+  expectBool "nums.includes(3,1)" (Array.includesFloatFrom nums 3.0 1.0) false
+  expectBool "nums.includes(2,5)" (Array.includesFloatFrom nums 2.0 5.0) false
+  expectBool "[NaN].includes(NaN,-1)" (Array.includesFloatFrom #[nan] nan (-1.0)) true
+  expectBool "strs.includes(a,1)" (Array.includesStrFrom strs "a" 1.0) false
+  expectBool "strs.includes(c,-1)" (Array.includesStrFrom strs "c" (-1.0)) true
 
 #eval tJoin
 #eval tIndexOf

--- a/Thales/Emit/Lean.lean
+++ b/Thales/Emit/Lean.lean
@@ -806,6 +806,18 @@ partial def emitExprEnv (env : EmitEnv) : Expression → LExpr
               match secondArg? with
               | some b => .app (.var (helper ++ "From")) [.var recv, a, b]
               | none   => .app (.var helper) [.var recv, a]
+            -- lastIndexOf mirrors indexOf's optional-fromIndex routing.
+            let lastIndexOfExpr : LExpr → LExpr := fun a =>
+              match secondArg? with
+              | some b => .app (.var "Array.lastIndexOfFromJS") [.var recv, a, b]
+              | none   => .app (.var "Array.lastIndexOfJS") [.var recv, a]
+            -- some/every/findIndex take a predicate (the first argument) and
+            -- lower to the generic Lean primitives `Array.any`/`Array.all` and
+            -- the `Array.findIndexJS` helper. Element type is irrelevant to
+            -- these, but the receiver is still resolved to number[]/string[]
+            -- so unlowerable shapes are rejected (TH0085) rather than emitted.
+            let predExpr : String → LExpr → LExpr := fun helper cb =>
+              .app (.var helper) [.var recv, cb]
             match elemTy?, m with
             | some (.array .number), "join" =>
                 some (.app (.var "Array.joinJS") [.var recv, firstArg?.getD (.str ",")])
@@ -819,6 +831,22 @@ partial def emitExprEnv (env : EmitEnv) : Expression → LExpr
                 firstArg?.map (includesExpr "Array.includesFloat")
             | some (.array .string), "includes" =>
                 firstArg?.map (includesExpr "Array.includesStr")
+            | some (.array .number), "lastIndexOf" =>
+                firstArg?.map lastIndexOfExpr
+            | some (.array .string), "lastIndexOf" =>
+                firstArg?.map lastIndexOfExpr
+            | some (.array .number), "some" =>
+                firstArg?.map (predExpr "Array.any")
+            | some (.array .string), "some" =>
+                firstArg?.map (predExpr "Array.any")
+            | some (.array .number), "every" =>
+                firstArg?.map (predExpr "Array.all")
+            | some (.array .string), "every" =>
+                firstArg?.map (predExpr "Array.all")
+            | some (.array .number), "findIndex" =>
+                firstArg?.map (predExpr "Array.findIndexJS")
+            | some (.array .string), "findIndex" =>
+                firstArg?.map (predExpr "Array.findIndexJS")
             | _, _ => none
         | _ => none
       match arrayMethodOverride with

--- a/Thales/Emit/Lean.lean
+++ b/Thales/Emit/Lean.lean
@@ -791,19 +791,34 @@ partial def emitExprEnv (env : EmitEnv) : Expression → LExpr
             let firstArg? : Option LExpr := match args with
               | a :: _ => some (emitExprEnv env a)
               | [] => none
+            -- #67: indexOf/includes accept an optional `fromIndex`. When present
+            -- it routes to the `…From` runtime helper; otherwise the
+            -- single-argument helper. `join`'s second argument is not part of
+            -- the subset, so it ignores anything past the separator.
+            let secondArg? : Option LExpr := match args with
+              | _ :: b :: _ => some (emitExprEnv env b)
+              | _ => none
+            let indexOfExpr : LExpr → LExpr := fun a =>
+              match secondArg? with
+              | some b => .app (.var "Array.indexOfFromJS") [.var recv, a, b]
+              | none   => .app (.var "Array.indexOfJS") [.var recv, a]
+            let includesExpr : String → LExpr → LExpr := fun helper a =>
+              match secondArg? with
+              | some b => .app (.var (helper ++ "From")) [.var recv, a, b]
+              | none   => .app (.var helper) [.var recv, a]
             match elemTy?, m with
             | some (.array .number), "join" =>
                 some (.app (.var "Array.joinJS") [.var recv, firstArg?.getD (.str ",")])
             | some (.array .string), "join" =>
                 some (.app (.var "Array.joinJS") [.var recv, firstArg?.getD (.str ",")])
             | some (.array .number), "indexOf" =>
-                firstArg?.map (fun a => .app (.var "Array.indexOfJS") [.var recv, a])
+                firstArg?.map indexOfExpr
             | some (.array .string), "indexOf" =>
-                firstArg?.map (fun a => .app (.var "Array.indexOfJS") [.var recv, a])
+                firstArg?.map indexOfExpr
             | some (.array .number), "includes" =>
-                firstArg?.map (fun a => .app (.var "Array.includesFloat") [.var recv, a])
+                firstArg?.map (includesExpr "Array.includesFloat")
             | some (.array .string), "includes" =>
-                firstArg?.map (fun a => .app (.var "Array.includesStr") [.var recv, a])
+                firstArg?.map (includesExpr "Array.includesStr")
             | _, _ => none
         | _ => none
       match arrayMethodOverride with

--- a/Thales/Emit/SubsetCheck.lean
+++ b/Thales/Emit/SubsetCheck.lean
@@ -239,7 +239,9 @@ partial def checkExpr (ctx : MutCtx) (expr : Expression) : Array Diagnostic :=
         -- Receivers SubsetCheck cannot resolve here (string methods, arrays
         -- whose type is only inferred from an initializer) are left to the
         -- existing path and tracked under separate issues.
-        else if propName == "join" || propName == "indexOf" || propName == "includes" then
+        else if propName == "join" || propName == "indexOf" || propName == "includes"
+            || propName == "lastIndexOf" || propName == "some" || propName == "every"
+            || propName == "findIndex" then
           match obj with
           | .identifier _ recv =>
               match (ctx.recvEnv.get? recv).map (resolveType ctx.aliasEnv) with

--- a/Thales/TS/Runtime.lean
+++ b/Thales/TS/Runtime.lean
@@ -484,6 +484,46 @@ def Array.includesStrFrom (xs : Array String) (x : String) (fromIndex : Float) :
 def Array.includesStr (xs : Array String) (x : String) : Bool :=
   Array.includesStrFrom xs x 0.0
 
+/-- `Array.prototype.findIndex(p)`: index of the first element satisfying `p`,
+    else `-1`, as a JS number (`Float`). -/
+def Array.findIndexJS {α : Type} (xs : Array α) (p : α → Bool) : Float :=
+  match xs.toList.findIdx? p with
+  | some i => i.toFloat
+  | none   => -1.0
+
+/-- The inclusive upper search bound `k` for `lastIndexOf(x, fromIndex)` over an
+    array of length `len`: `NaN → 0`; truncate toward zero; non-negative values
+    clamp to `len-1`; a negative `fromIndex` counts back from the end
+    (`len + n`). `none` when the search window is empty (`len = 0` or the
+    negative offset lands before index 0). -/
+def Array.lastStartJS (len : Nat) (fromIndex : Float) : Option Nat :=
+  if len == 0 then none
+  else if fromIndex.isNaN then some 0
+  else if fromIndex ≥ 0.0 then
+    if fromIndex ≥ len.toFloat then some (len - 1)
+    else some (min fromIndex.toUInt64.toNat (len - 1))
+  else
+    let magN := (-fromIndex).toUInt64.toNat
+    if magN > len then none else some (len - magN)
+
+/-- `Array.prototype.lastIndexOf(x, fromIndex)`: highest index `≤ fromIndex`
+    whose element `=== x`, else `-1`. Same `===`/`Float` `BEq` semantics as
+    `indexOf`. -/
+def Array.lastIndexOfFromJS {α : Type} [BEq α] (xs : Array α) (x : α) (fromIndex : Float) : Float :=
+  match Array.lastStartJS xs.size fromIndex with
+  | none   => -1.0
+  | some k =>
+    -- search the prefix `0..k` from the top: reverse it, find the first match,
+    -- and map the reversed position `j` back to the original index `k - j`.
+    match ((xs.toList.take (k + 1)).reverse).findIdx? (· == x) with
+    | some j => (k - j).toFloat
+    | none   => -1.0
+
+/-- `Array.prototype.lastIndexOf(x)`: the single-argument form (search from the
+    last element). -/
+def Array.lastIndexOfJS {α : Type} [BEq α] (xs : Array α) (x : α) : Float :=
+  Array.lastIndexOfFromJS xs x (xs.size.toFloat - 1.0)
+
 /-- Emitted counterpart of JS `console.log(x)`. Prints `x` using
     `JSShow.jsShow` so the Lean path's stdout matches the VM's without any
     post-processing by the conformance harness. -/

--- a/Thales/TS/Runtime.lean
+++ b/Thales/TS/Runtime.lean
@@ -437,23 +437,52 @@ instance : JSShow Bool   := ⟨fun b => if b then "true" else "false"⟩
 def Array.joinJS {α : Type} [JSShow α] (xs : Array α) (sep : String) : String :=
   String.intercalate sep (xs.toList.map JSShow.jsShow)
 
-/-- `Array.prototype.indexOf`: first index whose element `=== x`, else `-1`, as
-    a JS number (`Float`). Lean `Float` `BEq` is IEEE (`NaN ≠ NaN`, `+0 = -0`),
-    matching JS strict equality; `String` `BEq` matches too. -/
-def Array.indexOfJS {α : Type} [BEq α] (xs : Array α) (x : α) : Float :=
-  match xs.findIdx? (· == x) with
-  | some i => i.toFloat
+/-- JS `ToIntegerOrInfinity` clamped to a search start offset `k`
+    (`0 ≤ k ≤ len`) for the `indexOf`/`includes` `fromIndex` argument over an
+    array of length `len`. `NaN → 0`; the value truncates toward zero; a
+    negative `fromIndex` counts back from the end (`max(len + n, 0)`); a value
+    at or beyond `len` starts past the end (empty search). -/
+def Array.startIndexJS (len : Nat) (fromIndex : Float) : Nat :=
+  if fromIndex.isNaN then 0
+  else if fromIndex < 0.0 then
+    let mag := -fromIndex
+    if mag ≥ len.toFloat then 0 else len - mag.toUInt64.toNat
+  else
+    if fromIndex ≥ len.toFloat then len else fromIndex.toUInt64.toNat
+
+/-- `Array.prototype.indexOf(x, fromIndex)`: first index `≥ fromIndex` whose
+    element `=== x`, else `-1`, as a JS number (`Float`). Lean `Float` `BEq` is
+    IEEE (`NaN ≠ NaN`, `+0 = -0`), matching JS strict equality; `String` `BEq`
+    matches too. -/
+def Array.indexOfFromJS {α : Type} [BEq α] (xs : Array α) (x : α) (fromIndex : Float) : Float :=
+  let k := Array.startIndexJS xs.size fromIndex
+  match (xs.toList.drop k).findIdx? (· == x) with
+  | some i => (k + i).toFloat
   | none   => -1.0
 
-/-- `Array.prototype.includes` for numbers: SameValueZero, so `NaN` matches
-    `NaN` (unlike `indexOf`) and `+0`/`-0` match. -/
-def Array.includesFloat (xs : Array Float) (x : Float) : Bool :=
-  if x.isNaN then xs.any (·.isNaN) else xs.any (· == x)
+/-- `Array.prototype.indexOf(x)`: the single-argument form (search from 0). -/
+def Array.indexOfJS {α : Type} [BEq α] (xs : Array α) (x : α) : Float :=
+  Array.indexOfFromJS xs x 0.0
 
-/-- `Array.prototype.includes` for strings: structural equality (no NaN
-    subtlety). -/
+/-- `Array.prototype.includes(x, fromIndex)` for numbers: SameValueZero from
+    `fromIndex`, so `NaN` matches `NaN` (unlike `indexOf`) and `+0`/`-0`
+    match. -/
+def Array.includesFloatFrom (xs : Array Float) (x : Float) (fromIndex : Float) : Bool :=
+  let tail := xs.toList.drop (Array.startIndexJS xs.size fromIndex)
+  if x.isNaN then tail.any (·.isNaN) else tail.any (· == x)
+
+/-- `Array.prototype.includes(x)` for numbers: the single-argument form. -/
+def Array.includesFloat (xs : Array Float) (x : Float) : Bool :=
+  Array.includesFloatFrom xs x 0.0
+
+/-- `Array.prototype.includes(x, fromIndex)` for strings: structural equality
+    (no NaN subtlety), searching from `fromIndex`. -/
+def Array.includesStrFrom (xs : Array String) (x : String) (fromIndex : Float) : Bool :=
+  (xs.toList.drop (Array.startIndexJS xs.size fromIndex)).any (· == x)
+
+/-- `Array.prototype.includes(x)` for strings: the single-argument form. -/
 def Array.includesStr (xs : Array String) (x : String) : Bool :=
-  xs.any (· == x)
+  Array.includesStrFrom xs x 0.0
 
 /-- Emitted counterpart of JS `console.log(x)`. Prints `x` using
     `JSShow.jsShow` so the Lean path's stdout matches the VM's without any

--- a/Thales/TypeCheck/Builtins.lean
+++ b/Thales/TypeCheck/Builtins.lean
@@ -207,8 +207,10 @@ where
     -- lowers these for `number[]`/`string[]` identifier receivers; other
     -- receivers are rejected by TH0085 (SubsetCheck) per the strict-subset rule.
     | "join" => some (fnTypeOpt [("separator", .string, true)] .string)
-    | "indexOf" => some (fnType [("searchElement", elem)] .number)
-    | "includes" => some (fnType [("searchElement", elem)] .boolean)
+    | "indexOf" =>
+      some (fnTypeOpt [("searchElement", elem, false), ("fromIndex", .number, true)] .number)
+    | "includes" =>
+      some (fnTypeOpt [("searchElement", elem, false), ("fromIndex", .number, true)] .boolean)
     | _ => none
 
 /-- Create the initial type context with built-in bindings -/

--- a/Thales/TypeCheck/Builtins.lean
+++ b/Thales/TypeCheck/Builtins.lean
@@ -211,6 +211,32 @@ where
       some (fnTypeOpt [("searchElement", elem, false), ("fromIndex", .number, true)] .number)
     | "includes" =>
       some (fnTypeOpt [("searchElement", elem, false), ("fromIndex", .number, true)] .boolean)
+    -- lastIndexOf mirrors indexOf, searching from the end.
+    | "lastIndexOf" =>
+      some (fnTypeOpt [("searchElement", elem, false), ("fromIndex", .number, true)] .number)
+    -- Predicate methods (callback shape mirrors `filter`'s): `some`/`every`
+    -- return boolean, `findIndex` returns the matching index (or -1).
+    | "some" =>
+      some (fnType
+        [("predicate", .function
+          [.mk "value" elem false false,
+           .mk "index" (.refinement .natural) false false]
+          .boolean)]
+        .boolean)
+    | "every" =>
+      some (fnType
+        [("predicate", .function
+          [.mk "value" elem false false,
+           .mk "index" (.refinement .natural) false false]
+          .boolean)]
+        .boolean)
+    | "findIndex" =>
+      some (fnType
+        [("predicate", .function
+          [.mk "value" elem false false,
+           .mk "index" (.refinement .natural) false false]
+          .boolean)]
+        .number)
     | _ => none
 
 /-- Create the initial type context with built-in bindings -/

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -904,11 +904,11 @@ emitter's RHS type inference (issue #61) will let more of these compile.
 
 **Message:** `Array method '<name>' is only supported on a \`number[]\` or \`string[]\` receiver`
 
-`join`, `indexOf`, and `includes` are lowered only when the receiver is an
-identifier the emitter can statically resolve to `number[]` or `string[]` (a
-module-level const, a typed parameter, or a body-local typed declarator). Two
-receiver shapes are out of subset and rejected rather than miscompiled — `tsc`
-accepts both:
+`join`, `indexOf`, `includes`, `lastIndexOf`, `some`, `every`, and `findIndex`
+are lowered only when the receiver is an identifier the emitter can statically
+resolve to `number[]` or `string[]` (a module-level const, a typed parameter, or
+a body-local typed declarator). Two receiver shapes are out of subset and
+rejected rather than miscompiled — `tsc` accepts both:
 
 - a non-identifier receiver (a function-call result, a member-access chain, …),
   whose element type cannot be resolved at emit time; and

--- a/tests/conformance/accept/array-indexof-includes-fromindex.ts
+++ b/tests/conformance/accept/array-indexof-includes-fromindex.ts
@@ -1,0 +1,18 @@
+// #67: indexOf/includes accept an optional `fromIndex` second argument.
+const xs: number[] = [1, 2, 1, 2];
+console.log(xs.indexOf(2, 1)); // 1
+console.log(xs.indexOf(1, 1)); // 2
+console.log(xs.indexOf(2, -1)); // 3
+console.log(xs.indexOf(1, -2)); // 2
+console.log(xs.indexOf(1, -100)); // 0
+console.log(xs.indexOf(2, 5)); // -1
+console.log(xs.indexOf(2, 1.9)); // 1 (fromIndex truncates toward zero)
+console.log(xs.includes(2, 1)); // true
+console.log(xs.includes(1, -2)); // true
+console.log(xs.includes(2, 5)); // false
+
+const ss: string[] = ['a', 'b', 'c'];
+console.log(ss.indexOf('c', 1)); // 2
+console.log(ss.indexOf('a', 1)); // -1
+console.log(ss.includes('a', 1)); // false
+console.log(ss.includes('c', -1)); // true

--- a/tests/conformance/accept/array-some-every-findindex-lastindexof.ts
+++ b/tests/conformance/accept/array-some-every-findindex-lastindexof.ts
@@ -1,0 +1,25 @@
+// Read-only Array methods: some/every/findIndex (predicate) and
+// lastIndexOf (search from the end, optional fromIndex).
+const xs: number[] = [3, 1, 2];
+console.log(xs.some((x) => x > 1)); // true
+console.log(xs.every((x) => x > 1)); // false
+console.log(xs.every((x) => x > 0)); // true
+console.log(xs.findIndex((x) => x > 1)); // 0
+console.log(xs.findIndex((x) => x > 5)); // -1
+
+const rep: number[] = [1, 2, 1, 2];
+console.log(rep.findIndex((x) => x === 2)); // 1
+console.log(rep.lastIndexOf(1)); // 2
+console.log(rep.lastIndexOf(2)); // 3
+console.log(rep.lastIndexOf(9)); // -1
+console.log(rep.lastIndexOf(1, 1)); // 0
+console.log(rep.lastIndexOf(2, -1)); // 3
+console.log(rep.lastIndexOf(2, -3)); // 1
+console.log(rep.lastIndexOf(2, -5)); // -1
+
+const ss: string[] = ['a', 'b', 'c', 'b'];
+console.log(ss.some((s) => s === 'c')); // true
+console.log(ss.findIndex((s) => s === 'b')); // 1
+console.log(ss.lastIndexOf('b')); // 3
+console.log(ss.lastIndexOf('b', 2)); // 1
+console.log(ss.lastIndexOf('z')); // -1


### PR DESCRIPTION
Fixes the spurious `TS2554` from #67 by declaring the optional `fromIndex` argument on `indexOf`/`includes` and honoring it end to end: the emitter routes the two-argument form to new fromIndex-aware runtime helpers built on a shared `startIndexJS` that implements JS `ToIntegerOrInfinity` clamping (NaN to 0, truncate toward zero, negative counts back from the end). The single-argument helpers become thin wrappers, so existing emission is unchanged.

The same investigation showed that every undeclared-but-real Array method leaks a spurious `TS2339` ("Property does not exist"), the same contract violation in a different form. So this also declares and lowers `some`/`every` (to the generic `Array.any`/`Array.all`), `findIndex` (`Array.findIndexJS`), and `lastIndexOf` (`Array.lastIndexOfJS`/`lastIndexOfFromJS`, searching from the end with the same optional-fromIndex routing). Unlowerable receivers — other element types, non-identifier receivers — are rejected by TH0085 rather than miscompiled, matching the existing join/indexOf/includes treatment. New `accept/` examples pin byte-identical runtime output and the runtime helpers are pinned against Node's results. Follow-up read-only methods (`at`/`find`/`slice`) are tracked in #77 and the mutating methods in #78.