### PR TITLE
ESM import/export of values and types (#18)

### DIFF
--- a/Test/Examples/fixtures/modules-accept/README.md
+++ b/Test/Examples/fixtures/modules-accept/README.md
@@ -1,0 +1,2 @@
+Multi-file fixture: a named `import` of an exported function from a sibling
+module type-checks, emits, and runs byte-identically (entry = input.ts).

--- a/Test/Examples/fixtures/modules-accept/a.ts
+++ b/Test/Examples/fixtures/modules-accept/a.ts
@@ -1,0 +1,3 @@
+export function inc(x: bigint): bigint {
+  return x + 1n;
+}

--- a/Test/Examples/fixtures/modules-accept/expected-outcome.txt
+++ b/Test/Examples/fixtures/modules-accept/expected-outcome.txt
@@ -1,0 +1,1 @@
+pass:accepted

--- a/Test/Examples/fixtures/modules-accept/input.ts
+++ b/Test/Examples/fixtures/modules-accept/input.ts
@@ -1,0 +1,2 @@
+import { inc } from './a';
+console.log(inc(41n));

--- a/Test/Parser/ExportImportParseTest.lean
+++ b/Test/Parser/ExportImportParseTest.lean
@@ -1,0 +1,60 @@
+import Thales.Parser.Native
+
+/-!
+Parser round-trip for the ESM module forms widened in #18: a named import with
+an `as` alias, an inline `export` on a declaration, a plain declaration, and a
+trailing `export { … }`. Asserts the new `importDecl`/`exportDecl`/
+`exportNamedDecl` shapes preserve specifiers, the import form, and aliases.
+
+The Pratt parser is built from `partial def`s, so it does not reduce under
+`#guard`; assertions run via `#eval` (executed at `lake build ThalesTest`),
+throwing on mismatch.
+-/
+
+namespace Thales.Parser.ExportImportParse.Test
+
+open Thales Thales.TypeCheck
+
+private def src : String :=
+  "import { makeFoo as build } from './a';\n" ++
+  "export function f(): bigint { return 1n; }\n" ++
+  "function g(): bigint { return 2n; }\n" ++
+  "export { g };\n"
+
+private def specPairs (specs : List ModuleSpecifier) : List (String × String) :=
+  specs.map fun s => (s.imported, s.localName)
+
+#eval show IO Unit from do
+  match parseTSSourceNative src with
+  | .error e => throw (IO.userError s!"parse failed: {e}")
+  | .ok prog =>
+    match prog.body with
+    | [s0, s1, s2, s3] =>
+      -- stmt 0: named import with alias `makeFoo as build`
+      match s0 with
+      | .importDecl _ source specs form typeOnly =>
+        unless source == "./a" && form == .named && typeOnly == false
+            && specPairs specs == [("makeFoo", "build")] do
+          throw (IO.userError s!"stmt0 import mismatch: {source} {repr (specPairs specs)}")
+      | _ => throw (IO.userError "stmt0 is not a named importDecl")
+      -- stmt 1: inline export wrapping `function f`
+      match s1 with
+      | .exportDecl _ (.annotatedFuncDecl _ name ..) =>
+        unless name == "f" do throw (IO.userError s!"stmt1 export name: {name}")
+      | _ => throw (IO.userError "stmt1 is not exportDecl of a function")
+      -- stmt 2: plain (unexported) `function g`
+      match s2 with
+      | .annotatedFuncDecl _ name .. =>
+        unless name == "g" do throw (IO.userError s!"stmt2 func name: {name}")
+      | _ => throw (IO.userError "stmt2 is not a plain annotatedFuncDecl")
+      -- stmt 3: trailing `export { g }`
+      match s3 with
+      | .exportNamedDecl _ specs =>
+        unless specPairs specs == [("g", "g")] do
+          throw (IO.userError s!"stmt3 export specs: {repr (specPairs specs)}")
+      | _ => throw (IO.userError "stmt3 is not exportNamedDecl")
+      IO.println "ExportImportParseTest: OK"
+    | other =>
+      throw (IO.userError s!"expected 4 statements, got {other.length}")
+
+end Thales.Parser.ExportImportParse.Test

--- a/Thales/Emit/Lean.lean
+++ b/Thales/Emit/Lean.lean
@@ -1626,7 +1626,7 @@ private def pathToLeanModule (path : String) : String :=
 /-- Translate relative TS imports into Lean module names; bare specifiers are skipped. -/
 private def collectImports (body : List TSStatement) : List String :=
   body.filterMap fun
-    | .importDecl _ source _ =>
+    | .importDecl _ source _ _ _ =>
         if source.startsWith "./" || source.startsWith "../" then
           let m := pathToLeanModule source
           if m.isEmpty then none else some m

--- a/Thales/Emit/Lean.lean
+++ b/Thales/Emit/Lean.lean
@@ -1633,6 +1633,20 @@ private def collectImports (body : List TSStatement) : List String :=
         else none
     | _ => none
 
+/-- Produce a selective `open` clause per relative named import, so imported
+    names are usable unqualified. v1 (no aliasing) opens the names verbatim:
+    `import { inc } from './a'` → `A (inc)`, rendered by `renderModule` as
+    `open A (inc)`. Import aliasing (`renaming`) is added in a later phase. -/
+private def collectOpens (body : List TSStatement) : List String :=
+  body.filterMap fun
+    | .importDecl _ source specs .named _ =>
+        if (source.startsWith "./" || source.startsWith "../") && !specs.isEmpty then
+          let m := pathToLeanModule source
+          if m.isEmpty then none
+          else some s!"{m} ({String.intercalate " " (specs.map (·.imported))})"
+        else none
+    | _ => none
+
 /-- Build a map from function name → throws list from annotated function declarations. -/
 private def buildFuncThrowsEnv (body : List TSStatement) : Std.HashMap String (List String) :=
   body.foldl (fun env ts =>
@@ -1695,6 +1709,23 @@ private def resolveAliases (body : List TSStatement) : Std.HashMap String TSType
         env.insert name resolved
     | _ => env) {}
 
+/-- The declared name of a top-level statement, for export/privacy bookkeeping. -/
+private def declName : TSStatement → Option String
+  | .annotatedFuncDecl _ n .. => some n
+  | .annotatedVarDecl _ _ n .. => some n
+  | .interfaceDecl _ n .. => some n
+  | .typeAliasDecl _ n .. => some n
+  | .enumDecl _ n .. => some n
+  | _ => none
+
+/-- The name an emitted decl binds, for privacy marking (`eval_`/`instance_` bind none). -/
+private def ldeclName : LDecl → Option String
+  | .def_ n .. => some n
+  | .struct n .. => some n
+  | .inductive_ n .. => some n
+  | .abbrev_ n .. => some n
+  | _ => none
+
 /-- Walk the program and produce a Lean module string. -/
 def emit (prog : TSProgram) (moduleName : String) : String :=
   let resolvedAliases := resolveAliases prog.body
@@ -1734,7 +1765,22 @@ def emit (prog : TSProgram) (moduleName : String) : String :=
   -- can be seeded distinctly per item (two top-level `if`s would otherwise
   -- both start at `h0` and collide). `16` leaves generous headroom for the
   -- number of `dite` binders any single top-level statement could introduce.
-  let decls : List LDecl := prog.body.zipIdx.flatMap fun (ts, idx) =>
+  -- Names that are publicly exported (inline `export <decl>` or trailing
+  -- `export { … }`). When a module has any exports, every other top-level decl
+  -- is emitted `private` so it cannot leak into an importer via `import A`.
+  let exportedNames : List String := prog.body.foldl (fun acc s => match s with
+    | .exportDecl _ inner => acc ++ (declName inner).toList
+    | .exportNamedDecl _ specs => acc ++ specs.map (·.imported)
+    | _ => acc) []
+  let hasExports : Bool := prog.body.any fun s => match s with
+    | .exportDecl _ _ | .exportNamedDecl _ _ => true
+    | _ => false
+  -- Unwrap `export <decl>` to its inner declaration so the existing arms emit it
+  -- unchanged; `exportNamedDecl`/`exportUnsupported` carry no decl (catch-all).
+  let bodyForEmit : List TSStatement := prog.body.map fun s => match s with
+    | .exportDecl _ inner => inner
+    | other => other
+  let decls : List LDecl := bodyForEmit.zipIdx.flatMap fun (ts, idx) =>
     match ts with
     | .typeAliasDecl _ name tps ty =>
         let bodyTy := resolvedAliases.getD name ty
@@ -1891,12 +1937,19 @@ def emit (prog : TSProgram) (moduleName : String) : String :=
         let ifEnv : EmitEnv := { topEnv with diteBinderCounter := idx * 16 }
         [.eval_ (emitIfIO ifEnv cond thn elsOpt [])]
     | _ => []
+  -- Mark non-exported named decls `private` (only in modules that export).
+  let decls : List LDecl :=
+    if hasExports then
+      decls.map fun d => match ldeclName d with
+        | some n => if exportedNames.contains n then d else .private_ d
+        | none => d
+    else decls
   let body : LDecl :=
     if moduleName.isEmpty then .namespace_ "Input" decls
     else .namespace_ moduleName decls
   renderModule {
     imports := "Thales.TS.Runtime" :: tsImports
-    opens := ["Thales.TS"]
+    opens := "Thales.TS" :: collectOpens prog.body
     decls := [body]
   }
 

--- a/Thales/Emit/Lean.lean
+++ b/Thales/Emit/Lean.lean
@@ -1633,19 +1633,31 @@ private def collectImports (body : List TSStatement) : List String :=
         else none
     | _ => none
 
-/-- Produce a selective `open` clause per relative named import, so imported
-    names are usable unqualified. v1 (no aliasing) opens the names verbatim:
-    `import { inc } from './a'` → `A (inc)`, rendered by `renderModule` as
-    `open A (inc)`. Import aliasing (`renaming`) is added in a later phase. -/
+/-- Produce selective `open` clauses per relative named import, so imported
+    names are usable unqualified. Specifiers split by whether they alias:
+    `import { inc, makeFoo as build } from './a'` →
+    `A (inc)` and `A renaming makeFoo → build`, rendered as two `open` lines.
+    A single combined `open` cannot mix plain and renaming, so they stay separate. -/
 private def collectOpens (body : List TSStatement) : List String :=
-  body.filterMap fun
+  body.flatMap fun
     | .importDecl _ source specs .named _ =>
         if (source.startsWith "./" || source.startsWith "../") && !specs.isEmpty then
           let m := pathToLeanModule source
-          if m.isEmpty then none
-          else some s!"{m} ({String.intercalate " " (specs.map (·.imported))})"
-        else none
-    | _ => none
+          if m.isEmpty then []
+          else
+            let plain := specs.filter fun sp => sp.imported == sp.localName
+            let renamed := specs.filter fun sp => sp.imported != sp.localName
+            let plainOpen : List String :=
+              if plain.isEmpty then []
+              else [s!"{m} ({String.intercalate " " (plain.map (·.imported))})"]
+            let renameOpen : List String :=
+              if renamed.isEmpty then []
+              else
+                let pairs := renamed.map fun sp => s!"{sp.imported} → {sp.localName}"
+                [s!"{m} renaming {String.intercalate ", " pairs}"]
+            plainOpen ++ renameOpen
+        else []
+    | _ => []
 
 /-- Build a map from function name → throws list from annotated function declarations. -/
 private def buildFuncThrowsEnv (body : List TSStatement) : Std.HashMap String (List String) :=
@@ -1768,9 +1780,12 @@ def emit (prog : TSProgram) (moduleName : String) : String :=
   -- Names that are publicly exported (inline `export <decl>` or trailing
   -- `export { … }`). When a module has any exports, every other top-level decl
   -- is emitted `private` so it cannot leak into an importer via `import A`.
+  -- For trailing `export { local as public }`, the PUBLIC name (`localName`) is
+  -- the export; the local decl (`imported`) stays private and gets a public
+  -- alias `def public := local` (below). For `export { g }` the two coincide.
   let exportedNames : List String := prog.body.foldl (fun acc s => match s with
     | .exportDecl _ inner => acc ++ (declName inner).toList
-    | .exportNamedDecl _ specs => acc ++ specs.map (·.imported)
+    | .exportNamedDecl _ specs => acc ++ specs.map (·.localName)
     | _ => acc) []
   let hasExports : Bool := prog.body.any fun s => match s with
     | .exportDecl _ _ | .exportNamedDecl _ _ => true
@@ -1937,6 +1952,17 @@ def emit (prog : TSProgram) (moduleName : String) : String :=
         let ifEnv : EmitEnv := { topEnv with diteBinderCounter := idx * 16 }
         [.eval_ (emitIfIO ifEnv cond thn elsOpt [])]
     | _ => []
+  -- For each trailing `export { local as public }` (local ≠ public), emit a
+  -- public alias `def public := local`, appended after the originals so the
+  -- referenced local decl is already in scope.
+  let exportAliasDecls : List LDecl := prog.body.flatMap fun s => match s with
+    | .exportNamedDecl _ specs =>
+        specs.filterMap fun sp =>
+          if sp.imported != sp.localName then
+            some (.def_ sp.localName [] [] .inferred (.var sp.imported))
+          else none
+    | _ => []
+  let decls : List LDecl := decls ++ exportAliasDecls
   -- Mark non-exported named decls `private` (only in modules that export).
   let decls : List LDecl :=
     if hasExports then

--- a/Thales/Emit/LeanSyntax.lean
+++ b/Thales/Emit/LeanSyntax.lean
@@ -173,6 +173,9 @@ inductive LDecl where
   | instance_ (classApp : LType)
               (fieldName : String)
               (body : LExpr)
+  -- `private <inner>` — restricts a module-level decl to its own file, so a
+  -- non-exported declaration does not leak into an importing module's scope.
+  | private_ (inner : LDecl)
   deriving Inhabited
 
 /-- A pretty-printed Lean module. -/
@@ -391,6 +394,8 @@ partial def renderDecl : LDecl → String
       s!"#eval {renderExpr expr}"
   | .instance_ classApp fieldName body =>
       s!"instance : {renderType classApp} where\n  {fieldName} := {renderExpr body}"
+  | .private_ inner =>
+      "private " ++ renderDecl inner
 
 /-- Render a complete Lean module to a source string. -/
 def renderModule (m : LModule) : String :=

--- a/Thales/Emit/SubsetCheck.lean
+++ b/Thales/Emit/SubsetCheck.lean
@@ -948,10 +948,18 @@ def checkTSStmt (aliasEnv : Std.HashMap String TSType)
   | .typeAliasDecl b _ _ ty => checkType b.loc ty
   | .enumDecl _ _ _ _ => #[]
   | .declareStmt _ inner => checkTSStmt aliasEnv topRecvEnv inner
-  | .importDecl _ _ _ _ _ => #[]
+  | .importDecl b _ _ form _ =>
+    match form with
+    | .named => #[]
+    | .defaultImport => #[mkThalesDiag (.unsupportedImportForm "default import") b.loc]
+    | .namespaceImport => #[mkThalesDiag (.unsupportedImportForm "import * as ns") b.loc]
+    | .sideEffect => #[mkThalesDiag (.unsupportedImportForm "side-effect import") b.loc]
   | .exportDecl _ inner => checkTSStmt aliasEnv topRecvEnv inner
   | .exportNamedDecl _ _ => #[]
-  | .exportUnsupported _ _ => #[]
+  | .exportUnsupported b form =>
+    match form with
+    | .defaultExport => #[mkThalesDiag (.unsupportedExportForm "export default") b.loc]
+    | .reexport => #[mkThalesDiag (.unsupportedExportForm "re-export") b.loc]
 
 /-- Check a TS-level statement for switch lowerability and exhaustiveness
     (TH0041/TH0040). Requires a SwitchEnv with type alias and binding

--- a/Thales/Emit/SubsetCheck.lean
+++ b/Thales/Emit/SubsetCheck.lean
@@ -948,7 +948,10 @@ def checkTSStmt (aliasEnv : Std.HashMap String TSType)
   | .typeAliasDecl b _ _ ty => checkType b.loc ty
   | .enumDecl _ _ _ _ => #[]
   | .declareStmt _ inner => checkTSStmt aliasEnv topRecvEnv inner
-  | .importDecl _ _ _ => #[]
+  | .importDecl _ _ _ _ _ => #[]
+  | .exportDecl _ inner => checkTSStmt aliasEnv topRecvEnv inner
+  | .exportNamedDecl _ _ => #[]
+  | .exportUnsupported _ _ => #[]
 
 /-- Check a TS-level statement for switch lowerability and exhaustiveness
     (TH0041/TH0040). Requires a SwitchEnv with type alias and binding

--- a/Thales/Main.lean
+++ b/Thales/Main.lean
@@ -82,29 +82,6 @@ private def resolveSiblingPath (importerFile : String) (spec : String) : Option 
     some (dirnameOf importerFile ++ "/" ++ spec ++ ".ts")  -- literal join; v1 fixtures are same-dir
   else none
 
-/-- Seed a type context with one imported module's exported surface: bind the
-    explicitly-imported value names under their local alias, and merge ALL of the
-    module's exported types so imported signatures that reference them resolve. -/
-private def addExportsToCtx (ctx : TypeContext) (imp : List ModuleSpecifier)
-    (exp : ModuleExports) : TypeContext := Id.run do
-  let mut c := ctx
-  -- bind explicitly-imported value names under their local alias
-  for sp in imp do
-    match exp.values.find? (·.1 == sp.imported) with
-    | some (_, ty) => c := { c with bindings := c.bindings.insert sp.localName ty }
-    | none => pure ()   -- not exported: TS2305 handled in Phase 5
-  -- merge ALL exported types so imported signatures referencing them resolve
-  for (n, idef) in exp.interfaces do c := { c with interfaces := c.interfaces.insert n idef }
-  for (n, adef) in exp.aliases do c := { c with typeAliases := c.typeAliases.insert n adef }
-  -- also bind imported type names (interface/alias) under their alias when imported
-  for sp in imp do
-    match exp.interfaces.find? (·.1 == sp.imported) with
-    | some (_, idef) => c := { c with interfaces := c.interfaces.insert sp.localName idef }
-    | none => match exp.aliases.find? (·.1 == sp.imported) with
-      | some (_, adef) => c := { c with typeAliases := c.typeAliases.insert sp.localName adef }
-      | none => pure ()
-  return c
-
 /-- Recursively load the sibling-import closure of `path`, collecting each
     module's exported surface into `loaded`. `inProgress` is the chain of files
     currently being resolved; re-entering one signals an import cycle (Lean's
@@ -133,6 +110,51 @@ private partial def loadModule (path : String) (inProgress : List String)
         | none => pure ()
       | _ => pure ()
     return (ld.insert path (collectModuleExports prog), cyc)
+
+/-- Resolve the entry module's relative sibling imports: recursively harvest each
+    imported module's exported signatures (detecting cycles → TH0090), seed an
+    augmented `TypeContext` (from `builtinContext`) with the harvested exports, and
+    emit TS2305/TS2307 for missing members/modules. Returns the seeded context and
+    the resolver diagnostics; the entry's own type check runs against the former. -/
+private def resolveEntryImports (filename : String) (prog : TSProgram) :
+    IO (TypeContext × Array Diagnostic) := do
+  let mut ctx := builtinContext
+  let mut diags : Array Diagnostic := #[]
+  let mut loaded : Std.HashMap String ModuleExports := {}
+  for stmt in prog.body do
+    match stmt with
+    | .importDecl base source specs .named _ =>
+      match resolveSiblingPath filename source with
+      | none => pure ()
+      | some sibPath =>
+        if (← System.FilePath.pathExists sibPath) then
+          let (ld, cyc) ← loadModule sibPath [filename] loaded
+          loaded := ld
+          match cyc with
+          | some chain =>
+            diags := diags.push { kind := .thales (.importCycle chain), location := base.loc }
+          | none => pure ()
+          -- Seed even when a cycle was found: the sibling was still parsed,
+          -- so binding its exports avoids a spurious TS2304 for the import.
+          match ld[sibPath]? with
+          | some exp =>
+            -- TS2305: a named import of a member the module does not export.
+            for sp in specs do
+              unless exp.member? sp.imported do
+                diags := diags.push
+                  { kind := .noExportedMember source sp.imported, location := base.loc }
+                -- Error recovery: bind the missing name as `any` (as tsc does)
+                -- so its use sites don't cascade into a spurious TS2304.
+                ctx := { ctx with bindings := ctx.bindings.insert sp.localName .any }
+            ctx := exp.seedContext ctx specs
+          | none => pure ()
+        else
+          -- TS2307: a relative specifier that resolves to no sibling file.
+          diags := diags.push { kind := .moduleNotFound source, location := base.loc }
+          for sp in specs do
+            ctx := { ctx with bindings := ctx.bindings.insert sp.localName .any }
+    | _ => pure ()
+  return (ctx, diags)
 
 /-- Collect names and locations of `@total`-annotated functions from a program body. -/
 private def totalFuncEntries (prog : TSProgram)
@@ -242,50 +264,9 @@ def main (args : List String) : IO UInt32 := do
       IO.eprintln s!"Parse error: {e}"
       return 1
     | .ok tsProg =>
-      -- Resolve relative sibling imports: recursively harvest each imported
-      -- module's exported signatures (detecting import cycles → TH0090) and seed
-      -- an augmented type context for the entry's type check.
-      let mut ctx := builtinContext
-      let mut resolverDiags : Array Diagnostic := #[]
-      let mut loaded : Std.HashMap String ModuleExports := {}
-      for stmt in tsProg.body do
-        match stmt with
-        | .importDecl base source specs .named _ =>
-          match resolveSiblingPath filename source with
-          | none => pure ()
-          | some sibPath =>
-            if (← System.FilePath.pathExists sibPath) then
-              let (ld, cyc) ← loadModule sibPath [filename] loaded
-              loaded := ld
-              match cyc with
-              | some chain =>
-                resolverDiags := resolverDiags.push
-                  { kind := .thales (.importCycle chain), location := base.loc }
-              | none => pure ()
-              -- Seed even when a cycle was found: the sibling was still parsed,
-              -- so binding its exports avoids a spurious TS2304 for the import.
-              match ld[sibPath]? with
-              | some exp =>
-                -- TS2305: a named import of a member the module does not export.
-                for sp in specs do
-                  let known := exp.values.any (·.1 == sp.imported)
-                    || exp.interfaces.any (·.1 == sp.imported)
-                    || exp.aliases.any (·.1 == sp.imported)
-                  unless known do
-                    resolverDiags := resolverDiags.push
-                      { kind := .noExportedMember source sp.imported, location := base.loc }
-                    -- Error recovery: bind the missing name as `any` (as tsc does)
-                    -- so its use sites don't cascade into a spurious TS2304.
-                    ctx := { ctx with bindings := ctx.bindings.insert sp.localName .any }
-                ctx := addExportsToCtx ctx specs exp
-              | none => pure ()
-            else
-              -- TS2307: a relative specifier that resolves to no sibling file.
-              resolverDiags := resolverDiags.push
-                { kind := .moduleNotFound source, location := base.loc }
-              for sp in specs do
-                ctx := { ctx with bindings := ctx.bindings.insert sp.localName .any }
-        | _ => pure ()
+      -- Resolve relative sibling imports into an augmented type context (and
+      -- TS2305/TS2307/TH0090 diagnostics) for the entry's type check.
+      let (ctx, resolverDiags) ← resolveEntryImports filename tsProg
       let tsDiags := resolverDiags ++ typeCheck tsProg ctx
       let propDiags := throwsAnnotationCheck tsProg
       let throwsListDiags := throwsTypeListCheck tsProg

--- a/Thales/Main.lean
+++ b/Thales/Main.lean
@@ -1,6 +1,7 @@
 import Thales.Parser.Native
 import Thales.TypeCheck.Check
 import Thales.TypeCheck.TSAST
+import Thales.TypeCheck.ModuleExports
 import Thales.TypeCheck.Diagnostic
 import Thales.Emit.SubsetCheck
 import Thales.Emit.DirectiveApply
@@ -69,6 +70,40 @@ private def dirnameOf (path : String) : String :=
   let parts := path.splitOn "/"
   let dirParts := parts.dropLast
   if dirParts.isEmpty then "." else String.intercalate "/" dirParts
+
+/-- Resolve a relative module specifier against the importing file's directory.
+    Returns the sibling `.ts` path, or `none` for bare/non-relative specifiers
+    (e.g. `@thales/prelude`, handled inside the checker). v1 fixtures use
+    same-directory `./x` specifiers. -/
+private def resolveSiblingPath (importerFile : String) (spec : String) : Option String :=
+  if spec.startsWith "./" then
+    some (dirnameOf importerFile ++ "/" ++ spec.drop 2 ++ ".ts")
+  else if spec.startsWith "../" then
+    some (dirnameOf importerFile ++ "/" ++ spec ++ ".ts")  -- literal join; v1 fixtures are same-dir
+  else none
+
+/-- Seed a type context with one imported module's exported surface: bind the
+    explicitly-imported value names under their local alias, and merge ALL of the
+    module's exported types so imported signatures that reference them resolve. -/
+private def addExportsToCtx (ctx : TypeContext) (imp : List ModuleSpecifier)
+    (exp : ModuleExports) : TypeContext := Id.run do
+  let mut c := ctx
+  -- bind explicitly-imported value names under their local alias
+  for sp in imp do
+    match exp.values.find? (·.1 == sp.imported) with
+    | some (_, ty) => c := { c with bindings := c.bindings.insert sp.localName ty }
+    | none => pure ()   -- not exported: TS2305 handled in Phase 5
+  -- merge ALL exported types so imported signatures referencing them resolve
+  for (n, idef) in exp.interfaces do c := { c with interfaces := c.interfaces.insert n idef }
+  for (n, adef) in exp.aliases do c := { c with typeAliases := c.typeAliases.insert n adef }
+  -- also bind imported type names (interface/alias) under their alias when imported
+  for sp in imp do
+    match exp.interfaces.find? (·.1 == sp.imported) with
+    | some (_, idef) => c := { c with interfaces := c.interfaces.insert sp.localName idef }
+    | none => match exp.aliases.find? (·.1 == sp.imported) with
+      | some (_, adef) => c := { c with typeAliases := c.typeAliases.insert sp.localName adef }
+      | none => pure ()
+  return c
 
 /-- Collect names and locations of `@total`-annotated functions from a program body. -/
 private def totalFuncEntries (prog : TSProgram)
@@ -178,7 +213,22 @@ def main (args : List String) : IO UInt32 := do
       IO.eprintln s!"Parse error: {e}"
       return 1
     | .ok tsProg =>
-      let tsDiags := typeCheck tsProg
+      -- Resolve relative sibling imports: harvest each imported module's
+      -- exported signatures and seed an augmented type context. (TS2305/TS2307
+      -- and cycle detection land in Phase 5.)
+      let mut ctx := builtinContext
+      for stmt in tsProg.body do
+        match stmt with
+        | .importDecl _ source specs .named _ =>
+          match resolveSiblingPath filename source with
+          | none => pure ()
+          | some sibPath =>
+            if (← System.FilePath.pathExists sibPath) then
+              match (← Thales.Parser.parseTSFileNative sibPath) with
+              | .error _ => pure ()
+              | .ok sibProg => ctx := addExportsToCtx ctx specs (collectModuleExports sibProg)
+        | _ => pure ()
+      let tsDiags := typeCheck tsProg ctx
       let propDiags := throwsAnnotationCheck tsProg
       let throwsListDiags := throwsTypeListCheck tsProg
       let totalDiags := totalAnnotationCheck tsProg

--- a/Thales/Main.lean
+++ b/Thales/Main.lean
@@ -105,6 +105,35 @@ private def addExportsToCtx (ctx : TypeContext) (imp : List ModuleSpecifier)
       | none => pure ()
   return c
 
+/-- Recursively load the sibling-import closure of `path`, collecting each
+    module's exported surface into `loaded`. `inProgress` is the chain of files
+    currently being resolved; re-entering one signals an import cycle (Lean's
+    module graph must be acyclic), returned as the offending `a → b → a` chain. -/
+private partial def loadModule (path : String) (inProgress : List String)
+    (loaded : Std.HashMap String ModuleExports) :
+    IO (Std.HashMap String ModuleExports × Option String) := do
+  if inProgress.contains path then
+    return (loaded, some (String.intercalate " → " (inProgress ++ [path])))
+  if loaded.contains path then
+    return (loaded, none)
+  match (← Thales.Parser.parseTSFileNative path) with
+  | .error _ => return (loaded, none)   -- parse/not-found surfaces at the import site
+  | .ok prog =>
+    let mut ld := loaded
+    let mut cyc : Option String := none
+    for stmt in prog.body do
+      match stmt with
+      | .importDecl _ source _ .named _ =>
+        match resolveSiblingPath path source with
+        | some sib =>
+          if (← System.FilePath.pathExists sib) then
+            let (ld', c) ← loadModule sib (inProgress ++ [path]) ld
+            ld := ld'
+            cyc := cyc <|> c
+        | none => pure ()
+      | _ => pure ()
+    return (ld.insert path (collectModuleExports prog), cyc)
+
 /-- Collect names and locations of `@total`-annotated functions from a program body. -/
 private def totalFuncEntries (prog : TSProgram)
     : List (String × Option Thales.AST.SourceLocation) :=
@@ -213,22 +242,51 @@ def main (args : List String) : IO UInt32 := do
       IO.eprintln s!"Parse error: {e}"
       return 1
     | .ok tsProg =>
-      -- Resolve relative sibling imports: harvest each imported module's
-      -- exported signatures and seed an augmented type context. (TS2305/TS2307
-      -- and cycle detection land in Phase 5.)
+      -- Resolve relative sibling imports: recursively harvest each imported
+      -- module's exported signatures (detecting import cycles → TH0090) and seed
+      -- an augmented type context for the entry's type check.
       let mut ctx := builtinContext
+      let mut resolverDiags : Array Diagnostic := #[]
+      let mut loaded : Std.HashMap String ModuleExports := {}
       for stmt in tsProg.body do
         match stmt with
-        | .importDecl _ source specs .named _ =>
+        | .importDecl base source specs .named _ =>
           match resolveSiblingPath filename source with
           | none => pure ()
           | some sibPath =>
             if (← System.FilePath.pathExists sibPath) then
-              match (← Thales.Parser.parseTSFileNative sibPath) with
-              | .error _ => pure ()
-              | .ok sibProg => ctx := addExportsToCtx ctx specs (collectModuleExports sibProg)
+              let (ld, cyc) ← loadModule sibPath [filename] loaded
+              loaded := ld
+              match cyc with
+              | some chain =>
+                resolverDiags := resolverDiags.push
+                  { kind := .thales (.importCycle chain), location := base.loc }
+              | none => pure ()
+              -- Seed even when a cycle was found: the sibling was still parsed,
+              -- so binding its exports avoids a spurious TS2304 for the import.
+              match ld[sibPath]? with
+              | some exp =>
+                -- TS2305: a named import of a member the module does not export.
+                for sp in specs do
+                  let known := exp.values.any (·.1 == sp.imported)
+                    || exp.interfaces.any (·.1 == sp.imported)
+                    || exp.aliases.any (·.1 == sp.imported)
+                  unless known do
+                    resolverDiags := resolverDiags.push
+                      { kind := .noExportedMember source sp.imported, location := base.loc }
+                    -- Error recovery: bind the missing name as `any` (as tsc does)
+                    -- so its use sites don't cascade into a spurious TS2304.
+                    ctx := { ctx with bindings := ctx.bindings.insert sp.localName .any }
+                ctx := addExportsToCtx ctx specs exp
+              | none => pure ()
+            else
+              -- TS2307: a relative specifier that resolves to no sibling file.
+              resolverDiags := resolverDiags.push
+                { kind := .moduleNotFound source, location := base.loc }
+              for sp in specs do
+                ctx := { ctx with bindings := ctx.bindings.insert sp.localName .any }
         | _ => pure ()
-      let tsDiags := typeCheck tsProg ctx
+      let tsDiags := resolverDiags ++ typeCheck tsProg ctx
       let propDiags := throwsAnnotationCheck tsProg
       let throwsListDiags := throwsTypeListCheck tsProg
       let totalDiags := totalAnnotationCheck tsProg

--- a/Thales/Parser/Pratt.lean
+++ b/Thales/Parser/Pratt.lean
@@ -3435,6 +3435,32 @@ private partial def skipToSemicolonOrEnd (p : ParserState) : ParseResult ParserS
   if ps.check .semicolon then ps ← ps.advance
   return ps
 
+/-- Parse a brace-enclosed specifier list `{ a, b as c }`, starting at the `{`,
+    and consuming the closing `}`. Each entry becomes `⟨imported, local⟩` where
+    `local` is the `as` alias when present and the bare name otherwise. Shared by
+    named imports and trailing named exports — for `export { local as public }`
+    the same shape carries `imported = local`, `localName = public`. `what` names
+    the construct for the closing-brace error. -/
+private partial def parseBraceSpecifierList (p : ParserState) (what : String) :
+    ParseResult (ParserState × List ModuleSpecifier) := do
+  let mut ps ← p.advance  -- skip '{'
+  let mut specs : List ModuleSpecifier := []
+  while !ps.check .rbrace && !ps.atEnd do
+    match ps.current.kind with
+    | .identifier n =>
+      ps ← ps.advance
+      let mut localName := n
+      if ps.check .as_ then
+        ps ← ps.advance  -- skip 'as'
+        match ps.current.kind with
+        | .identifier a => localName := a; ps ← ps.advance
+        | _ => pure ()
+      specs := specs ++ [{ imported := n, localName := localName }]
+      if ps.check .comma then ps ← ps.advance
+    | _ => ps ← ps.advance  -- skip unexpected tokens
+  ps ← ps.expect .rbrace s!"Expected '}}' in {what}"
+  return (ps, specs)
+
 /-- Parse an ES module import declaration. Handles all four forms, recording the
     written form and per-specifier aliases:
       import { a, b as c } from 'specifier';   (named)
@@ -3461,25 +3487,8 @@ partial def parseTSImportDecl (p : ParserState) : ParseResult (ParserState × TS
     return (p3, .importDecl base source [] .sideEffect false)
   -- Named import: import { a, b as c } from 'specifier';
   | .lbrace =>
-    let mut ps := p1
-    ps ← ps.advance  -- skip '{'
-    let mut specs : List ModuleSpecifier := []
-    -- Parse comma-separated list of specifiers until '}'
-    while !ps.check .rbrace && !ps.atEnd do
-      match ps.current.kind with
-      | .identifier n =>
-        ps ← ps.advance
-        let mut localName := n
-        -- Optional 'as' alias: imported as localName
-        if ps.check .as_ then
-          ps ← ps.advance  -- skip 'as'
-          match ps.current.kind with
-          | .identifier a => localName := a; ps ← ps.advance
-          | _ => pure ()
-        specs := specs ++ [{ imported := n, localName := localName }]
-        if ps.check .comma then ps ← ps.advance
-      | _ => ps ← ps.advance  -- skip unexpected tokens
-    ps ← ps.expect .rbrace "Expected '}' in import specifiers"
+    let (p2, specs) ← parseBraceSpecifierList p1 "import specifiers"
+    let mut ps := p2
     -- Expect 'from'
     match ps.current.kind with
     | .identifier "from" =>
@@ -3558,25 +3567,7 @@ partial def parseTSExportDecl (p : ParserState) : ParseResult (ParserState × TS
     return (p2, .exportUnsupported base .reexport)
   | .lbrace =>
     -- export { a, b as c };  OR  export { a } from '…';  (the latter is a re-export)
-    let mut ps := p1
-    ps ← ps.advance  -- skip '{'
-    let mut specs : List ModuleSpecifier := []
-    while !ps.check .rbrace && !ps.atEnd do
-      match ps.current.kind with
-      | .identifier n =>
-        ps ← ps.advance
-        let mut exportedName := n
-        if ps.check .as_ then
-          ps ← ps.advance
-          match ps.current.kind with
-          | .identifier a => exportedName := a; ps ← ps.advance
-          | _ => pure ()
-        -- For `export { local as exported }`, `imported` holds the local name,
-        -- `localName` holds the exported (public) name.
-        specs := specs ++ [{ imported := n, localName := exportedName }]
-        if ps.check .comma then ps ← ps.advance
-      | _ => ps ← ps.advance
-    ps ← ps.expect .rbrace "Expected '}' in export specifiers"
+    let (ps, specs) ← parseBraceSpecifierList p1 "export specifiers"
     match ps.current.kind with
     | .identifier "from" =>          -- re-export: export { … } from '…'
       let ps2 ← skipToSemicolonOrEnd ps

--- a/Thales/Parser/Pratt.lean
+++ b/Thales/Parser/Pratt.lean
@@ -3427,39 +3427,56 @@ partial def parseTSEnumDecl (p : ParserState) (isConst : Bool) :
 private def skipSemicolon (p : ParserState) : ParseResult ParserState :=
   if p.check .semicolon then p.advance else return p
 
-/-- Parse an ES module import declaration. Handles all four forms:
-      import { A, B } from 'specifier';
-      import DefaultName from 'specifier';
-      import * as NS from 'specifier';
-      import 'specifier';   (side-effect)
-    Returns `.importDecl source specifiers`. -/
+/-- Advance until a semicolon or EOF, consuming the semicolon if present. -/
+private partial def skipToSemicolonOrEnd (p : ParserState) : ParseResult ParserState := do
+  let mut ps := p
+  while !ps.check .semicolon && !ps.atEnd do
+    ps ← ps.advance
+  if ps.check .semicolon then ps ← ps.advance
+  return ps
+
+/-- Parse an ES module import declaration. Handles all four forms, recording the
+    written form and per-specifier aliases:
+      import { a, b as c } from 'specifier';   (named)
+      import DefaultName from 'specifier';      (default)
+      import * as NS from 'specifier';          (namespace)
+      import 'specifier';                       (side-effect)
+    `import type { … }` sets `typeOnly`. -/
 partial def parseTSImportDecl (p : ParserState) : ParseResult (ParserState × TSStatement) := do
+  let startPos := p.current.pos
   -- Current token is the identifier "import"; advance past it.
-  let p1 ← p.advance
+  let p0 ← p.advance
+  -- Detect `import type { … }`. `type` lexes as the `.type` keyword; treat it as
+  -- type-only. (`import type from '…'` — `type` as a default binding — is out of
+  -- subset and not distinguished here.)
+  let typeOnly := p0.current.kind == .type
+  let p1 ← if typeOnly then p0.advance else pure p0
+  let base := makeBase startPos startPos
   -- Determine which form we have by looking at the next token.
   match p1.current.kind with
   -- Side-effect import: import 'specifier';
   | .string source =>
     let p2 ← p1.advance
     let p3 ← skipSemicolon p2
-    return (p3, .importDecl {} source [])
-  -- Named import: import { A, B } from 'specifier';
+    return (p3, .importDecl base source [] .sideEffect false)
+  -- Named import: import { a, b as c } from 'specifier';
   | .lbrace =>
     let mut ps := p1
     ps ← ps.advance  -- skip '{'
-    let mut names : List String := []
+    let mut specs : List ModuleSpecifier := []
     -- Parse comma-separated list of specifiers until '}'
     while !ps.check .rbrace && !ps.atEnd do
       match ps.current.kind with
       | .identifier n =>
-        names := names ++ [n]
         ps ← ps.advance
-        -- Skip optional 'as' alias: identifier as localName
+        let mut localName := n
+        -- Optional 'as' alias: imported as localName
         if ps.check .as_ then
           ps ← ps.advance  -- skip 'as'
           match ps.current.kind with
-          | .identifier _ => ps ← ps.advance  -- skip alias (local name not needed for emit)
+          | .identifier a => localName := a; ps ← ps.advance
           | _ => pure ()
+        specs := specs ++ [{ imported := n, localName := localName }]
         if ps.check .comma then ps ← ps.advance
       | _ => ps ← ps.advance  -- skip unexpected tokens
     ps ← ps.expect .rbrace "Expected '}' in import specifiers"
@@ -3471,7 +3488,7 @@ partial def parseTSImportDecl (p : ParserState) : ParseResult (ParserState × TS
       | .string source =>
         ps ← ps.advance
         ps ← skipSemicolon ps
-        return (ps, .importDecl {} source names)
+        return (ps, .importDecl base source specs .named typeOnly)
       | _ => throw "Expected string literal after 'from' in import"
     | _ => throw "Expected 'from' after import specifiers"
   -- Namespace import: import * as NS from 'specifier';
@@ -3492,7 +3509,8 @@ partial def parseTSImportDecl (p : ParserState) : ParseResult (ParserState × TS
         | .string source =>
           ps ← ps.advance
           ps ← skipSemicolon ps
-          return (ps, .importDecl {} source [nsName])
+          return (ps, .importDecl base source
+            [{ imported := nsName, localName := nsName }] .namespaceImport typeOnly)
         | _ => throw "Expected string literal after 'from' in namespace import"
       | _ => throw "Expected 'from' after 'import * as NS'"
     | _ => throw "Expected 'as' after '*' in import"
@@ -3507,13 +3525,65 @@ partial def parseTSImportDecl (p : ParserState) : ParseResult (ParserState × TS
       | .string source =>
         ps ← ps.advance
         ps ← skipSemicolon ps
-        return (ps, .importDecl {} source [defName])
+        return (ps, .importDecl base source
+          [{ imported := defName, localName := defName }] .defaultImport typeOnly)
       | _ => throw "Expected string literal after 'from' in default import"
     | _ => throw "Expected 'from' after default import name"
   | _ =>
     -- Unknown form: skip to semicolon / end
     let p2 ← skipSemicolon p1
-    return (p2, .importDecl {} "" [])
+    return (p2, .importDecl base "" [] .sideEffect false)
+
+mutual
+
+/-- Parse an ES module export declaration:
+      export function f … / export const … / export type … / export interface …  (inline)
+      export { a, b as c };                                                       (named)
+      export default … / export … from '…' / export *                            (unsupported → routed for rejection)
+-/
+partial def parseTSExportDecl (p : ParserState) : ParseResult (ParserState × TSStatement) := do
+  let startPos := p.current.pos
+  let p1 ← p.advance  -- skip 'export'
+  let base := makeBase startPos startPos
+  match p1.current.kind with
+  | .«default» =>            -- export default …  (consume to end of statement)
+    let p2 ← skipToSemicolonOrEnd p1
+    return (p2, .exportUnsupported base .defaultExport)
+  | .star =>                 -- export * …  (re-export)
+    let p2 ← skipToSemicolonOrEnd p1
+    return (p2, .exportUnsupported base .reexport)
+  | .lbrace =>
+    -- export { a, b as c };  OR  export { a } from '…';  (the latter is a re-export)
+    let mut ps := p1
+    ps ← ps.advance  -- skip '{'
+    let mut specs : List ModuleSpecifier := []
+    while !ps.check .rbrace && !ps.atEnd do
+      match ps.current.kind with
+      | .identifier n =>
+        ps ← ps.advance
+        let mut exportedName := n
+        if ps.check .as_ then
+          ps ← ps.advance
+          match ps.current.kind with
+          | .identifier a => exportedName := a; ps ← ps.advance
+          | _ => pure ()
+        -- For `export { local as exported }`, `imported` holds the local name,
+        -- `localName` holds the exported (public) name.
+        specs := specs ++ [{ imported := n, localName := exportedName }]
+        if ps.check .comma then ps ← ps.advance
+      | _ => ps ← ps.advance
+    ps ← ps.expect .rbrace "Expected '}' in export specifiers"
+    match ps.current.kind with
+    | .identifier "from" =>          -- re-export: export { … } from '…'
+      let ps2 ← skipToSemicolonOrEnd ps
+      return (ps2, .exportUnsupported base .reexport)
+    | _ =>
+      let ps2 ← skipSemicolon ps
+      return (ps2, .exportNamedDecl base specs)
+  | _ =>
+    -- Inline export on a declaration: parse the inner statement and wrap it.
+    let (p2, inner) ← parseTSStatement p1
+    return (p2, .exportDecl base inner)
 
 /-- Parse a single TS statement -/
 partial def parseTSStatement (p : ParserState) : ParseResult (ParserState × TSStatement) := do
@@ -3542,7 +3612,9 @@ partial def parseTSStatement (p : ParserState) : ParseResult (ParserState × TSS
     let (p2, inner) ← parseTSStatement p1
     return (p2, .declareStmt {} inner)
   | .identifier n =>
-    if n == "import" then
+    if n == "export" then
+      parseTSExportDecl p
+    else if n == "import" then
       parseTSImportDecl p
     -- `abstract class Foo ...` — skip the `abstract` modifier and parse the class
     else if n == "abstract" then
@@ -3563,6 +3635,8 @@ partial def parseTSStatement (p : ParserState) : ParseResult (ParserState × TSS
   | _ =>
     let (p1, stmt) ← parseStatement p
     return (p1, .js stmt)
+
+end
 
 /-- Parse a TS program (list of TS statements) -/
 partial def parseTSProgram (p : ParserState) : ParseResult (ParserState × TSProgram) := do

--- a/Thales/Parser/Pratt.lean
+++ b/Thales/Parser/Pratt.lean
@@ -3546,9 +3546,13 @@ partial def parseTSExportDecl (p : ParserState) : ParseResult (ParserState × TS
   let p1 ← p.advance  -- skip 'export'
   let base := makeBase startPos startPos
   match p1.current.kind with
-  | .«default» =>            -- export default …  (consume to end of statement)
-    let p2 ← skipToSemicolonOrEnd p1
-    return (p2, .exportUnsupported base .defaultExport)
+  | .«default» =>            -- export default <decl-or-expr>
+    -- Parse the default-exported declaration/expression with the full parser so
+    -- a function/class body (with internal semicolons) is consumed correctly,
+    -- then discard it — the form is rejected wholesale (TH0089).
+    let p2 ← p1.advance      -- skip 'default'
+    let (p3, _) ← parseTSStatement p2
+    return (p3, .exportUnsupported base .defaultExport)
   | .star =>                 -- export * …  (re-export)
     let p2 ← skipToSemicolonOrEnd p1
     return (p2, .exportUnsupported base .reexport)

--- a/Thales/TypeCheck/Check.lean
+++ b/Thales/TypeCheck/Check.lean
@@ -344,7 +344,7 @@ partial def checkStatement (stmt : TSStatement) (rest : List TSStatement) : Type
       let ty := match typeAnn with | some ann => ann.type | none => .any
       withScope [(vname, ty)] (checkStatements rest)
     | _ => checkStatements rest
-  | .importDecl _ source _ =>
+  | .importDecl _ source _ _ _ =>
     -- Special-case @thales/prelude: inject the in-memory shim bindings.
     -- For all other imports, just continue (no filesystem resolution).
     if source == "@thales/prelude" then
@@ -374,6 +374,15 @@ partial def checkStatement (stmt : TSStatement) (rest : List TSStatement) : Type
               (withScope preludeValues (checkStatements rest)))))
     else
       checkStatements rest
+  | .exportDecl _ inner =>
+    -- Type-check the inner declaration exactly as if it were unexported.
+    checkStatement inner rest
+  | .exportNamedDecl _ _ =>
+    -- Trailing `export { … }` only re-exports already-declared top-level names.
+    checkStatements rest
+  | .exportUnsupported _ _ =>
+    -- Unsupported export form; rejected by the subset checker (TH0089).
+    checkStatements rest
 
 /-- Check a JS statement without processing continuation -/
 partial def checkJSStatementRaw (stmt : Statement) : TypeCheckM Unit := do

--- a/Thales/TypeCheck/Diagnostic.lean
+++ b/Thales/TypeCheck/Diagnostic.lean
@@ -115,6 +115,10 @@ inductive ThalesKind where
   | definednessTestNonIdentifierSubject
   -- Unsupported String.prototype method (TH0087)
   | stringMethodNotSupported (methodName : String)
+  -- Unsupported ESM import/export forms and import cycles (TH0088–TH0090)
+  | unsupportedImportForm (form : String)
+  | unsupportedExportForm (form : String)
+  | importCycle (cyclePath : String)
   -- Directive diagnostics (TH9000–TH9003)
   | directiveUnused
   | directiveCodeMismatch (expected : Nat) (actual : List Nat)
@@ -163,6 +167,9 @@ def ThalesKind.thCode : ThalesKind → Nat
   | .arrayMethodReceiverNotLowerable _ => 85
   | .definednessTestNonIdentifierSubject => 86
   | .stringMethodNotSupported _ => 87
+  | .unsupportedImportForm _ => 88
+  | .unsupportedExportForm _ => 89
+  | .importCycle _ => 90
   | .directiveUnused => 9000
   | .directiveCodeMismatch .. => 9001
   | .emissionBlockedBySuppressedViolation => 9002
@@ -244,6 +251,12 @@ def ThalesKind.message : ThalesKind → String
     "A definedness test against 'undefined'/'null' is only supported when its subject is a variable; bind this expression to a variable first"
   | .stringMethodNotSupported methodName =>
     s!"String method '{methodName}' is not supported; the available string operations are 'startsWith', 'endsWith', and 'split'"
+  | .unsupportedImportForm form =>
+    s!"This import form ({form}) is not supported; use named imports like " ++ "`import { a, b } from './m'`"
+  | .unsupportedExportForm form =>
+    s!"This export form ({form}) is not supported; use inline `export` on a declaration or " ++ "`export { a, b };`"
+  | .importCycle cyclePath =>
+    s!"Circular imports are not supported because the emitted Lean modules cannot form an import cycle ({cyclePath})"
   | .directiveUnused => "Unused `@thales-expect-error` directive"
   | .directiveCodeMismatch expected actual =>
     let fmtCode (n : Nat) : String := s!"TH{padCode n}"
@@ -271,6 +284,9 @@ inductive DiagnosticKind where
   | cannotAssignToConstant (name : String)
   | cannotAssignToReadOnlyProperty (name : String)
   | invalidAssignmentTarget
+  -- Module resolution diagnostics mirroring tsc (ESM imports)
+  | moduleNotFound (spec : String)                 -- TS2307
+  | noExportedMember (modName : String) (name : String)  -- TS2305
   | thales (t : ThalesKind)
 
 /-- Map diagnostic kind to tsc error code -/
@@ -288,6 +304,8 @@ def DiagnosticKind.tscCode : DiagnosticKind → Nat
   | .cannotAssignToConstant _ => 2588
   | .cannotAssignToReadOnlyProperty _ => 2540
   | .invalidAssignmentTarget => 2364
+  | .moduleNotFound _ => 2307
+  | .noExportedMember .. => 2305
   | .thales _ => 0
 
 /-- Format a human-readable message for the diagnostic -/
@@ -318,6 +336,10 @@ def DiagnosticKind.message : DiagnosticKind → String
     s!"Cannot assign to '{name}' because it is a read-only property"
   | .invalidAssignmentTarget =>
     "The left-hand side of an assignment expression must be a variable or a property access"
+  | .moduleNotFound spec =>
+    s!"Cannot find module '{spec}' or its corresponding type declarations."
+  | .noExportedMember modName name =>
+    s!"Module '\"{modName}\"' has no exported member '{name}'."
   | .thales t => t.message
 
 /-- A diagnostic with source location -/

--- a/Thales/TypeCheck/ModuleExports.lean
+++ b/Thales/TypeCheck/ModuleExports.lean
@@ -45,10 +45,46 @@ private def merge (a b : ModuleExports) : ModuleExports :=
     aliases := a.aliases ++ b.aliases
     interfaces := a.interfaces ++ b.interfaces }
 
-/-- A local-name → public-name table for trailing `export { local as public }`.
-    `sp.imported` is the local declared name; `sp.localName` is the exported name. -/
-private def renameTable (specs : List ModuleSpecifier) : List (String × String) :=
-  specs.map fun sp => (sp.imported, sp.localName)
+namespace ModuleExports
+
+/-- Re-export the member named `localName` under `publicName`, searching values,
+    then interfaces, then aliases. Empty when `localName` isn't declared. -/
+def reexportAs (m : ModuleExports) (localName publicName : String) : ModuleExports :=
+  match m.values.find? (·.1 == localName) with
+  | some (_, ty) => { values := [(publicName, ty)] }
+  | none => match m.interfaces.find? (·.1 == localName) with
+    | some (_, idef) => { interfaces := [(publicName, idef)] }
+    | none => match m.aliases.find? (·.1 == localName) with
+      | some (_, adef) => { aliases := [(publicName, adef)] }
+      | none => {}
+
+/-- Is `name` part of this module's exported surface (value, interface, or alias)? -/
+def member? (m : ModuleExports) (name : String) : Bool :=
+  m.values.any (·.1 == name) || m.interfaces.any (·.1 == name) || m.aliases.any (·.1 == name)
+
+/-- Seed `ctx` with this module's exported surface for an importer: bind each
+    explicitly-imported value (and type) name under its local alias, and merge ALL
+    exported types so imported signatures that reference them resolve. Names not
+    exported are left unbound — the import site raises TS2305 for them. -/
+def seedContext (exp : ModuleExports) (ctx : TypeContext)
+    (imp : List ModuleSpecifier) : TypeContext := Id.run do
+  let mut c := ctx
+  -- merge ALL exported types so imported signatures referencing them resolve
+  for (n, idef) in exp.interfaces do c := { c with interfaces := c.interfaces.insert n idef }
+  for (n, adef) in exp.aliases do c := { c with typeAliases := c.typeAliases.insert n adef }
+  -- bind each imported name (value or type) under its local alias
+  for sp in imp do
+    match exp.values.find? (·.1 == sp.imported) with
+    | some (_, ty) => c := { c with bindings := c.bindings.insert sp.localName ty }
+    | none => pure ()
+    match exp.interfaces.find? (·.1 == sp.imported) with
+    | some (_, idef) => c := { c with interfaces := c.interfaces.insert sp.localName idef }
+    | none => match exp.aliases.find? (·.1 == sp.imported) with
+      | some (_, adef) => c := { c with typeAliases := c.typeAliases.insert sp.localName adef }
+      | none => pure ()
+  return c
+
+end ModuleExports
 
 /-- Collect the full exported surface of a parsed module. -/
 def collectModuleExports (prog : TSProgram) : ModuleExports := Id.run do
@@ -58,23 +94,15 @@ def collectModuleExports (prog : TSProgram) : ModuleExports := Id.run do
     match s with
     | .exportDecl _ inner => acc := merge acc (exportOne inner)
     | _ => pure ()
-  -- 2) trailing `export { … }` over already-declared top-level names
-  let renames := prog.body.foldl (fun r s => match s with
-    | .exportNamedDecl _ specs => r ++ renameTable specs
-    | _ => r) []
-  if renames.isEmpty then return acc
-  -- `declared` intentionally indexes ALL top-level decls so a trailing
+  -- 2) trailing `export { local as public }` over already-declared top-level
+  -- names. `declared` intentionally indexes ALL top-level decls so a trailing
   -- `export { g }` can find a `g` that was declared without inline `export`.
   let declared := prog.body.foldl (fun (m : ModuleExports) s => merge m (exportOne s)) {}
-  for (localName, publicName) in renames do
-    match declared.values.find? (·.1 == localName) with
-    | some (_, ty) => acc := merge acc { values := [(publicName, ty)] }
-    | none =>
-      match declared.interfaces.find? (·.1 == localName) with
-      | some (_, idef) => acc := merge acc { interfaces := [(publicName, idef)] }
-      | none => match declared.aliases.find? (·.1 == localName) with
-        | some (_, adef) => acc := merge acc { aliases := [(publicName, adef)] }
-        | none => pure ()
+  for s in prog.body do
+    match s with
+    | .exportNamedDecl _ specs =>
+      for sp in specs do acc := merge acc (declared.reexportAs sp.imported sp.localName)
+    | _ => pure ()
   return acc
 
 end Thales.TypeCheck

--- a/Thales/TypeCheck/ModuleExports.lean
+++ b/Thales/TypeCheck/ModuleExports.lean
@@ -1,0 +1,80 @@
+/-
+  Thales/TypeCheck/ModuleExports.lean
+  Pure collector of a module's publicly-exported signatures.
+
+  Used by the IO resolver in `Main.lean`: when the entry imports `./a`, the
+  resolver parses `a.ts`, calls `collectModuleExports`, and seeds the entry's
+  `TypeContext` with the imported (aliased) bindings and all exported types. Only
+  signatures are harvested — bodies are never re-checked here (each file is
+  type-checked independently by its own `thales` invocation). This mirrors how
+  `tsc -b` consumes a dependency's `.d.ts` rather than its source.
+-/
+import Thales.TypeCheck.TSAST
+import Thales.TypeCheck.TSType
+import Thales.TypeCheck.Context
+
+namespace Thales.TypeCheck
+
+/-- The publicly-exported surface of one module. -/
+structure ModuleExports where
+  values : List (String × TSType) := []          -- exported value bindings (public name → type)
+  aliases : List (String × TypeAliasDef) := []    -- exported type aliases
+  interfaces : List (String × InterfaceDef) := [] -- exported interfaces
+  deriving Inhabited
+
+/-- Build the value type of a function declaration from its annotations (no body check). -/
+private def funcSig (params : List (String × Option TypeAnnotation × Bool × Bool))
+    (returnType : Option TypeAnnotation) : TSType :=
+  let ps := params.map fun (pname, ann, opt, rest_) =>
+    TSParamType.mk pname (ann.elim .any (·.type)) opt rest_
+  TSType.function ps (returnType.elim .any (·.type))
+
+/-- Collect a declaration's exported surface contribution (the inner of `export <decl>`). -/
+private def exportOne (s : TSStatement) : ModuleExports :=
+  match s with
+  | .annotatedFuncDecl _ name _tps params ret _ _ _ _ _ =>
+      { values := [(name, funcSig params ret)] }
+  | .annotatedVarDecl _ _ name (some ann) _ => { values := [(name, ann.type)] }
+  | .annotatedVarDecl _ _ name none (some _) => { values := [(name, .any)] }  -- v1: unannotated export → any
+  | .interfaceDecl _ name tps _ members => { interfaces := [(name, { typeParams := tps, members })] }
+  | .typeAliasDecl _ name tps ty => { aliases := [(name, { typeParams := tps, body := ty })] }
+  | _ => {}
+
+private def merge (a b : ModuleExports) : ModuleExports :=
+  { values := a.values ++ b.values
+    aliases := a.aliases ++ b.aliases
+    interfaces := a.interfaces ++ b.interfaces }
+
+/-- A local-name → public-name table for trailing `export { local as public }`.
+    `sp.imported` is the local declared name; `sp.localName` is the exported name. -/
+private def renameTable (specs : List ModuleSpecifier) : List (String × String) :=
+  specs.map fun sp => (sp.imported, sp.localName)
+
+/-- Collect the full exported surface of a parsed module. -/
+def collectModuleExports (prog : TSProgram) : ModuleExports := Id.run do
+  -- 1) inline exports
+  let mut acc : ModuleExports := {}
+  for s in prog.body do
+    match s with
+    | .exportDecl _ inner => acc := merge acc (exportOne inner)
+    | _ => pure ()
+  -- 2) trailing `export { … }` over already-declared top-level names
+  let renames := prog.body.foldl (fun r s => match s with
+    | .exportNamedDecl _ specs => r ++ renameTable specs
+    | _ => r) []
+  if renames.isEmpty then return acc
+  -- `declared` intentionally indexes ALL top-level decls so a trailing
+  -- `export { g }` can find a `g` that was declared without inline `export`.
+  let declared := prog.body.foldl (fun (m : ModuleExports) s => merge m (exportOne s)) {}
+  for (localName, publicName) in renames do
+    match declared.values.find? (·.1 == localName) with
+    | some (_, ty) => acc := merge acc { values := [(publicName, ty)] }
+    | none =>
+      match declared.interfaces.find? (·.1 == localName) with
+      | some (_, idef) => acc := merge acc { interfaces := [(publicName, idef)] }
+      | none => match declared.aliases.find? (·.1 == localName) with
+        | some (_, adef) => acc := merge acc { aliases := [(publicName, adef)] }
+        | none => pure ()
+  return acc
+
+end Thales.TypeCheck

--- a/Thales/TypeCheck/TSAST.lean
+++ b/Thales/TypeCheck/TSAST.lean
@@ -22,9 +22,9 @@ inductive TSInterfaceMember where
   | method (name : String) (params : List TSParamType) (returnType : TSType) (optional : Bool)
   deriving Inhabited
 
-/-- One named-import / named-export binding: `imported as local`.
+/-- One named-import / named-export binding: `imported as localName`.
     For `import { a } …` both fields are `"a"`; for `import { a as b } …`
-    `imported = "a"`, `local = "b"`. -/
+    `imported = "a"`, `localName = "b"`. -/
 structure ModuleSpecifier where
   imported : String
   localName : String
@@ -39,7 +39,10 @@ inductive ImportForm where
   | sideEffect      -- import '…'
   deriving Repr, Inhabited, BEq
 
-/-- Which ESM export form was written. `.inline` and `.named` are in-subset (v1). -/
+/-- Which unsupported ESM export form was written, carried by `exportUnsupported`
+    so the subset checker can reject it precisely (TH0089). The in-subset forms —
+    inline `export <decl>` and trailing `export { … }` — are their own
+    `TSStatement` constructors (`exportDecl`/`exportNamedDecl`), not listed here. -/
 inductive ExportForm where
   | defaultExport   -- export default …
   | reexport        -- export { … } from '…'  /  export * from '…'

--- a/Thales/TypeCheck/TSAST.lean
+++ b/Thales/TypeCheck/TSAST.lean
@@ -22,6 +22,29 @@ inductive TSInterfaceMember where
   | method (name : String) (params : List TSParamType) (returnType : TSType) (optional : Bool)
   deriving Inhabited
 
+/-- One named-import / named-export binding: `imported as local`.
+    For `import { a } …` both fields are `"a"`; for `import { a as b } …`
+    `imported = "a"`, `local = "b"`. -/
+structure ModuleSpecifier where
+  imported : String
+  localName : String
+  deriving Repr, Inhabited
+
+/-- Which ESM import form was written. Only `.named` is in-subset (v1);
+    the others are parsed so the subset checker can reject them precisely. -/
+inductive ImportForm where
+  | named           -- import { a, b as c } from '…'
+  | defaultImport   -- import D from '…'
+  | namespaceImport -- import * as ns from '…'
+  | sideEffect      -- import '…'
+  deriving Repr, Inhabited, BEq
+
+/-- Which ESM export form was written. `.inline` and `.named` are in-subset (v1). -/
+inductive ExportForm where
+  | defaultExport   -- export default …
+  | reexport        -- export { … } from '…'  /  export * from '…'
+  deriving Repr, Inhabited, BEq
+
 /-- TS-augmented statement: either a plain JS statement or a TS-specific one -/
 inductive TSStatement where
   | js (s : Statement)
@@ -42,10 +65,18 @@ inductive TSStatement where
   | enumDecl (base : NodeBase) (name : String)
       (members : List TSEnumMember) (isConst : Bool)
   | declareStmt (base : NodeBase) (inner : TSStatement)
-  /-- ES module import declaration: `import { Foo, Bar } from './geom';`
-      `source` is the raw module specifier string (e.g. `"./geom"`).
-      `specifiers` holds the local names (empty for side-effect imports). -/
-  | importDecl (base : NodeBase) (source : String) (specifiers : List String)
+  /-- ES module import. `source` is the raw specifier (e.g. `"./geom"`).
+      `specs` are the named bindings (empty for side-effect / namespace).
+      `form` records the written form; `typeOnly` is `import type { … }`. -/
+  | importDecl (base : NodeBase) (source : String)
+      (specs : List ModuleSpecifier) (form : ImportForm) (typeOnly : Bool)
+  /-- Inline export on a declaration: `export function f …`, `export const …`,
+      `export type …`, `export interface …`. Wraps the inner declaration. -/
+  | exportDecl (base : NodeBase) (inner : TSStatement)
+  /-- Trailing named export: `export { f, g as h };`. -/
+  | exportNamedDecl (base : NodeBase) (specs : List ModuleSpecifier)
+  /-- An unsupported export form, parsed only so the subset checker can reject it. -/
+  | exportUnsupported (base : NodeBase) (form : ExportForm)
 
 instance : Inhabited TSStatement := ⟨.js (.emptyStmt {})⟩
 

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -42,51 +42,54 @@ soundness check).
 
 ## Summary
 
-| Code   | Category     | Short Message                                          |
-| ------ | ------------ | ------------------------------------------------------ |
-| TH0001 | Mutation     | Cannot reassign variable                               |
-| TH0002 | Mutation     | Cannot assign to array element                         |
-| TH0003 | Mutation     | Cannot assign to object property                       |
-| TH0004 | Mutation     | Cannot call mutating method                            |
-| TH0005 | Mutation     | Cannot mutate variable captured by enclosing scope     |
-| TH0006 | Mutation     | Assignment only supported in statement position        |
-| TH0007 | Mutation     | Cannot mutate inside `@throws` or `try`/`catch`        |
-| TH0010 | Control flow | Loop not supported                                     |
-| TH0012 | Control flow | async/await not supported                              |
-| TH0020 | Types        | `any` not permitted                                    |
-| TH0021 | Types        | `unknown` not permitted in user code                   |
-| TH0022 | Types        | Union must be discriminated                            |
-| TH0023 | Types        | Intersection types not supported                       |
-| TH0024 | Types        | keyof/conditional/mapped types not supported           |
-| TH0025 | Types        | null/undefined types not supported                     |
-| TH0026 | Types        | Condition must be boolean                              |
-| TH0030 | Declarations | `class` not supported                                  |
-| TH0031 | Declarations | Inheritance (`extends`) not supported                  |
-| TH0032 | Declarations | Shadowing declaration not supported                    |
-| TH0040 | Matching     | Non-exhaustive switch on discriminated union           |
-| TH0041 | Matching     | Switch shape not lowerable                             |
-| TH0050 | Recursion    | Cannot verify termination                              |
-| TH0066 | Totality     | `@total` and `@throws` declared together               |
-| TH0067 | Totality     | `@total` function has uncaught throw                   |
-| TH0068 | Totality     | `@total` function contains an unverifiable loop        |
-| TH0070 | Totality     | `@total` asserted but Lean rejects termination         |
-| TH0060 | Exceptions   | Unannotated `throw`                                    |
-| TH0061 | Exceptions   | Unused `@throws` annotation                            |
-| TH0063 | Exceptions   | Thrown value must be a record type                     |
-| TH0064 | Exceptions   | Undeclared propagation                                 |
-| TH0080 | Refinement   | Literal value out of range for refinement type         |
-| TH0081 | Refinement   | Value not assignable to refinement without evidence    |
-| TH0082 | Subset       | Possibly-undefined operand; narrow before use          |
-| TH0083 | Subset       | Computed index access only supported on arrays         |
-| TH0084 | Subset       | Definedness test on a binding of undeterminable type   |
-| TH0085 | Subset       | Array method on a receiver of unlowerable element type |
-| TH0086 | Subset       | Definedness test on a non-identifier subject           |
-| TH0087 | Subset       | Unsupported `String.prototype` method                  |
-| TH9000 | Directive    | Unused `@thales-expect-error` directive                |
-| TH9001 | Directive    | Directive code mismatch                                |
-| TH9002 | Directive    | Cannot emit: subset violations suppressed              |
-| TH9003 | Directive    | Malformed `@thales-expect-error` directive             |
-| TH9004 | Directive    | Emitted Lean code contains `sorry`                     |
+| Code   | Category     | Short Message                                             |
+| ------ | ------------ | --------------------------------------------------------- |
+| TH0001 | Mutation     | Cannot reassign variable                                  |
+| TH0002 | Mutation     | Cannot assign to array element                            |
+| TH0003 | Mutation     | Cannot assign to object property                          |
+| TH0004 | Mutation     | Cannot call mutating method                               |
+| TH0005 | Mutation     | Cannot mutate variable captured by enclosing scope        |
+| TH0006 | Mutation     | Assignment only supported in statement position           |
+| TH0007 | Mutation     | Cannot mutate inside `@throws` or `try`/`catch`           |
+| TH0010 | Control flow | Loop not supported                                        |
+| TH0012 | Control flow | async/await not supported                                 |
+| TH0020 | Types        | `any` not permitted                                       |
+| TH0021 | Types        | `unknown` not permitted in user code                      |
+| TH0022 | Types        | Union must be discriminated                               |
+| TH0023 | Types        | Intersection types not supported                          |
+| TH0024 | Types        | keyof/conditional/mapped types not supported              |
+| TH0025 | Types        | null/undefined types not supported                        |
+| TH0026 | Types        | Condition must be boolean                                 |
+| TH0030 | Declarations | `class` not supported                                     |
+| TH0031 | Declarations | Inheritance (`extends`) not supported                     |
+| TH0032 | Declarations | Shadowing declaration not supported                       |
+| TH0040 | Matching     | Non-exhaustive switch on discriminated union              |
+| TH0041 | Matching     | Switch shape not lowerable                                |
+| TH0050 | Recursion    | Cannot verify termination                                 |
+| TH0066 | Totality     | `@total` and `@throws` declared together                  |
+| TH0067 | Totality     | `@total` function has uncaught throw                      |
+| TH0068 | Totality     | `@total` function contains an unverifiable loop           |
+| TH0070 | Totality     | `@total` asserted but Lean rejects termination            |
+| TH0060 | Exceptions   | Unannotated `throw`                                       |
+| TH0061 | Exceptions   | Unused `@throws` annotation                               |
+| TH0063 | Exceptions   | Thrown value must be a record type                        |
+| TH0064 | Exceptions   | Undeclared propagation                                    |
+| TH0080 | Refinement   | Literal value out of range for refinement type            |
+| TH0081 | Refinement   | Value not assignable to refinement without evidence       |
+| TH0082 | Subset       | Possibly-undefined operand; narrow before use             |
+| TH0083 | Subset       | Computed index access only supported on arrays            |
+| TH0084 | Subset       | Definedness test on a binding of undeterminable type      |
+| TH0085 | Subset       | Array method on a receiver of unlowerable element type    |
+| TH0086 | Subset       | Definedness test on a non-identifier subject              |
+| TH0087 | Subset       | Unsupported `String.prototype` method                     |
+| TH0088 | Subset       | Unsupported `import` form (default/namespace/side-effect) |
+| TH0089 | Subset       | Unsupported `export` form (default/re-export)             |
+| TH0090 | Subset       | Circular imports                                          |
+| TH9000 | Directive    | Unused `@thales-expect-error` directive                   |
+| TH9001 | Directive    | Directive code mismatch                                   |
+| TH9002 | Directive    | Cannot emit: subset violations suppressed                 |
+| TH9003 | Directive    | Malformed `@thales-expect-error` directive                |
+| TH9004 | Directive    | Emitted Lean code contains `sorry`                        |
 
 ## Future of this table
 
@@ -990,3 +993,75 @@ console.log(s.toUpperCase());
 Fix: restructure to avoid the method, or use one of the supported operations.
 Sound lowerings (UTF-16-faithful where it matters) are future stdlib work
 (issue #28).
+
+### TH0088 — Unsupported `import` form
+
+**Message:** `This import form (<form>) is not supported; use named imports like `import { a, b } from './m'``
+
+Only **named** imports — `import { a, b as c } from './m'` — are in the subset.
+Default imports (`import D from './m'`), namespace imports
+(`import * as ns from './m'`), and side-effect imports (`import './m'`) are
+rejected. The subset binds each imported name to a specific exported
+declaration, which the named form makes explicit; the other forms either bind a
+module's default/whole-namespace object (no Lean analogue in the selective-`open`
+lowering) or import purely for side effects (the subset has none at module
+scope). `import type { … }` is accepted. `tsc` accepts all of these forms.
+
+Example (rejected):
+
+```typescript
+// @thales-expect-error TH0088
+import * as ns from './a';
+export const v: bigint = 1n;
+```
+
+Fix: rewrite as a named import listing the specific bindings you use.
+
+### TH0089 — Unsupported `export` form
+
+**Message:** `This export form (<form>) is not supported; use inline `export`on a declaration or`export { a, b };``
+
+Only inline `export` on a declaration (`export function f …`, `export const …`,
+`export interface …`, `export type …`) and trailing named exports
+(`export { a, b as c };`) are in the subset. `export default …` and re-exports
+(`export { … } from './m'`, `export * from './m'`) are rejected: a default
+export has no named binding for the selective-`open` lowering, and re-exports
+would require threading another module's surface through this one. `tsc` accepts
+these forms.
+
+Example (rejected):
+
+```typescript
+// @thales-expect-error TH0089
+export default function f(): bigint {
+  return 1n;
+}
+```
+
+Fix: give the declaration a name and export it inline or via `export { … }`.
+
+### TH0090 — Circular imports
+
+**Message:** `Circular imports are not supported because the emitted Lean modules cannot form an import cycle (<path>)`
+
+Each TypeScript module lowers to one Lean module, and Lean's module import graph
+must be acyclic. When the resolver follows imports and re-enters a file already
+on the current import chain, it reports the cycle rather than emit Lean modules
+that cannot compile. `tsc` accepts circular imports (its module graph permits
+cycles), so this is a Thales-only restriction.
+
+Example (rejected): `a.ts` imports from `./entry` while `entry.ts` imports from
+`./a`.
+
+```typescript
+// entry.ts
+// @thales-expect-error TH0090
+import { a } from './a';
+export function b(): bigint {
+  return 1n;
+}
+console.log(a());
+```
+
+Fix: break the cycle by moving the shared declarations into a third module that
+both import, so the dependency graph is acyclic.

--- a/docs/subset.md
+++ b/docs/subset.md
@@ -60,21 +60,21 @@ under `tests/conformance/reject/` for one canonical demonstration per `TH####` c
 
 ## In-scope features
 
-| Kind         | Detail                                                                                                                                           |
-| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Primitives   | `boolean`, `string`, `number` (→ Lean `Float`), `bigint` (→ Lean `Int`)                                                                          |
-| Records      | `interface` and `type` aliases — nominal by declaration                                                                                          |
-| Arrays       | `T[]` as immutable `Array T`; `arr[i]` returns `Option<T>`                                                                                       |
-| Tuples       | `[A, B]`, `[A, B, C]`, ... → Lean `×` / fixed structures                                                                                         |
-| Unions       | Discriminated unions (shared `kind` field of string-literal type) → Lean inductive; nullable unions (`T \| null`, `T \| undefined`) → `Option T` |
-| Generics     | Parametric only (`<T>`, `<T, U>`)                                                                                                                |
-| Values       | `const`, `let`, `var`; function-local non-escaping mutation (`x = e`, `x OP= e`, `x++`/`x--`) emitted as `Id.run do` with `let mut` (#24)        |
-| Functions    | `function` declarations and `const f = (...) => ...` arrows                                                                                      |
-| Recursion    | Structural or with `@decreasing` hint; all functions must terminate in 0.5                                                                       |
-| Control flow | `if`/`else`, ternary, `switch` (exhaustive on a discriminated union)                                                                             |
-| Modules      | `import`/`export` of values and types                                                                                                            |
-| Stdlib       | `Option<T>`, `Result<T, E>`, array `.map`/`.filter`/`.reduce`/`.concat`/`.length`/`.slice`                                                       |
-| Refinements  | `Integer`, `Natural`, `Byte`, `Bit` from `@thales/prelude` — Lean Subtypes of `Float`; chain `Bit ⊆ Byte ⊆ Natural ⊆ Integer ⊆ number`           |
+| Kind         | Detail                                                                                                                                                                                                                          |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Primitives   | `boolean`, `string`, `number` (→ Lean `Float`), `bigint` (→ Lean `Int`)                                                                                                                                                         |
+| Records      | `interface` and `type` aliases — nominal by declaration                                                                                                                                                                         |
+| Arrays       | `T[]` as immutable `Array T`; `arr[i]` returns `Option<T>`                                                                                                                                                                      |
+| Tuples       | `[A, B]`, `[A, B, C]`, ... → Lean `×` / fixed structures                                                                                                                                                                        |
+| Unions       | Discriminated unions (shared `kind` field of string-literal type) → Lean inductive; nullable unions (`T \| null`, `T \| undefined`) → `Option T`                                                                                |
+| Generics     | Parametric only (`<T>`, `<T, U>`)                                                                                                                                                                                               |
+| Values       | `const`, `let`, `var`; function-local non-escaping mutation (`x = e`, `x OP= e`, `x++`/`x--`) emitted as `Id.run do` with `let mut` (#24)                                                                                       |
+| Functions    | `function` declarations and `const f = (...) => ...` arrows                                                                                                                                                                     |
+| Recursion    | Structural or with `@decreasing` hint; all functions must terminate in 0.5                                                                                                                                                      |
+| Control flow | `if`/`else`, ternary, `switch` (exhaustive on a discriminated union)                                                                                                                                                            |
+| Modules      | Named `import { a, b as c }`, inline `export`, trailing `export { … }`, `import type` of values and types (same-directory siblings); default/namespace/side-effect imports, re-exports, and cycles are rejected (TH0088–TH0090) |
+| Stdlib       | `Option<T>`, `Result<T, E>`, array `.map`/`.filter`/`.reduce`/`.concat`/`.length`/`.slice`                                                                                                                                      |
+| Refinements  | `Integer`, `Natural`, `Byte`, `Bit` from `@thales/prelude` — Lean Subtypes of `Float`; chain `Bit ⊆ Byte ⊆ Natural ⊆ Integer ⊆ number`                                                                                          |
 
 ## Out-of-scope features
 

--- a/scripts/lib/harness.js
+++ b/scripts/lib/harness.js
@@ -18,6 +18,20 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 export const repoRoot = path.resolve(__dirname, '..', '..');
 export const thalesBin = path.join(repoRoot, '.lake', 'build', 'bin', 'thales');
 
+// Lake's LEAN_PATH (toolchain + dependency lib dirs), resolved once. Multi-file
+// fixtures prepend the emit temp dir to this so a dependency's `import X`
+// resolves to the freshly-built `X.olean`.
+let _leanPath = null;
+export function leanEnvPath() {
+  if (_leanPath !== null) return _leanPath;
+  const r = spawnSync('lake', ['env', 'sh', '-c', 'echo $LEAN_PATH'], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  });
+  _leanPath = (r.status === 0 ? (r.stdout || '').trim() : '') || '';
+  return _leanPath;
+}
+
 // ---- diagnostics ----
 
 /**
@@ -250,31 +264,54 @@ export function checkNoSorry(leanPath) {
   return null;
 }
 
+// `thales -o <dir> foo.ts` writes `<dir>/Foo.lean` — basename capitalized,
+// extension stripped, non-alphanumerics removed (matches inputToModuleName).
+function moduleNameOf(p) {
+  const base = path.basename(p).replace(/\.[mc]?ts$/, '');
+  return (
+    base.charAt(0).toUpperCase() + base.slice(1).replace(/[^A-Za-z0-9]/g, '')
+  );
+}
+
 /**
- * Emit inputPath with thales --overwrite into a fresh temp dir, then run the resulting
- * .lean via lake env lean. Always cleans up the temp dir on exit.
+ * Emit inputPath with thales --overwrite into a fresh temp dir, then run the
+ * resulting .lean via lake env lean. Always cleans up the temp dir on exit.
+ *
+ * Multi-file (directory) fixtures: when `opts.dir` is set, every `*.ts` in that
+ * directory is emitted, each non-entry module is compiled to a `.olean` (so the
+ * entry's `import X` resolves), and the entry runs with the temp dir prepended
+ * to LEAN_PATH. Dependency oleans are compiled in filename order, which suffices
+ * for the flat (entry → siblings) module graphs the corpus uses; a deeper graph
+ * would need topological ordering.
  */
 export function runThcThenLean(inputPath, opts = {}) {
   const outDir = fs.mkdtempSync(path.join(os.tmpdir(), 'thales-emit-'));
   try {
-    const r1 = runCapture(thalesBin, ['--overwrite', '-o', outDir, inputPath], {
-      timeout: opts.timeout,
-    });
-    if (r1.code !== 0) {
-      return {
-        code: r1.code,
-        stdout: r1.stdout,
-        stderr: r1.stderr,
-        stage: 'emit',
-        timedOut: r1.timedOut,
-      };
+    const tsFiles = opts.dir
+      ? fs
+          .readdirSync(opts.dir)
+          .filter((f) => /\.[mc]?ts$/.test(f))
+          .sort()
+          .map((f) => path.join(opts.dir, f))
+      : [inputPath];
+
+    for (const f of tsFiles) {
+      const r = runCapture(thalesBin, ['--overwrite', '-o', outDir, f], {
+        timeout: opts.timeout,
+      });
+      if (r.code !== 0) {
+        return {
+          code: r.code,
+          stdout: r.stdout,
+          stderr: r.stderr,
+          stage: 'emit',
+          timedOut: r.timedOut,
+        };
+      }
     }
-    // `thales -o <dir> foo.ts` writes `<dir>/Foo.lean` — basename capitalized, extension stripped,
-    // non-alphanumerics removed (matches thales's inputToModuleName).
-    const base = path.basename(inputPath).replace(/\.[mc]?ts$/, '');
-    const moduleName =
-      base.charAt(0).toUpperCase() + base.slice(1).replace(/[^A-Za-z0-9]/g, '');
-    const leanPath = path.join(outDir, moduleName + '.lean');
+
+    const entryModule = moduleNameOf(inputPath);
+    const leanPath = path.join(outDir, entryModule + '.lean');
     // TH9004: post-emit noSorry check — applied only to files emitted by thales.
     const sorryFail = checkNoSorry(leanPath);
     if (sorryFail) {
@@ -286,6 +323,50 @@ export function runThcThenLean(inputPath, opts = {}) {
         timedOut: false,
       };
     }
+
+    if (opts.dir) {
+      const baseLeanPath = leanEnvPath();
+      const env = {
+        ...process.env,
+        LEAN_PATH: baseLeanPath ? `${outDir}:${baseLeanPath}` : outDir,
+      };
+      // Build dependency oleans so the entry's `import X` resolves. `lean --root
+      // <outDir>` names each module after its basename relative to outDir; a bare
+      // `lean -o` rejects an input file outside the repo root.
+      for (const f of tsFiles) {
+        const mod = moduleNameOf(f);
+        if (mod === entryModule) continue;
+        const dep = path.join(outDir, mod + '.lean');
+        if (!fs.existsSync(dep)) continue;
+        const c = runCapture(
+          'lean',
+          ['--root', outDir, '-o', path.join(outDir, mod + '.olean'), dep],
+          { cwd: repoRoot, env, timeout: opts.timeout },
+        );
+        if (c.code !== 0) {
+          return {
+            code: c.code,
+            stdout: c.stdout,
+            stderr: c.stderr,
+            stage: 'deps',
+            timedOut: c.timedOut,
+          };
+        }
+      }
+      const r2 = runCapture('lake', ['env', 'lean', leanPath], {
+        cwd: repoRoot,
+        env,
+        timeout: opts.timeout,
+      });
+      return {
+        code: r2.code,
+        stdout: r2.stdout,
+        stderr: r2.stderr,
+        stage: 'run',
+        timedOut: r2.timedOut,
+      };
+    }
+
     const r2 = runCapture('lake', ['env', 'lean', leanPath], {
       cwd: repoRoot,
       timeout: opts.timeout,

--- a/scripts/run-examples.js
+++ b/scripts/run-examples.js
@@ -252,7 +252,7 @@ function runThcIgnoringDirectives(inputPath) {
  *                       |'tsc-unexpected'|'directive-check'|'directive-coverage',
  *     detail: string}
  */
-function evaluateCase(inputPath) {
+function evaluateCase(inputPath, opts = {}) {
   if (hasDirective(inputPath)) {
     // Subset-rejected example (with @thales-expect-error directives): tsc must
     // be clean, thales --no-emit must exit 0 silent (directives suppressed all
@@ -330,7 +330,7 @@ function evaluateCase(inputPath) {
   }
 
   const tsx = runTsx(inputPath);
-  const ours = runThcThenLean(inputPath);
+  const ours = runThcThenLean(inputPath, { dir: opts.dir });
 
   // Relaxed throw-iff equivalence for programs that use @thales/prelude.
   //
@@ -403,10 +403,23 @@ function collectCases(rootDir, mode) {
       if (!fs.existsSync(bucketDir)) continue;
       const files = fs.readdirSync(bucketDir).sort();
       for (const name of files) {
+        const full = path.join(bucketDir, name);
+        // A bucket subdirectory containing `entry.ts` is a multi-file case.
+        if (fs.statSync(full).isDirectory()) {
+          const entry = path.join(full, 'entry.ts');
+          if (!fs.existsSync(entry)) continue; // not a recognized fixture
+          cases.push({
+            label: `${bucket}/${name}`,
+            inputPath: entry,
+            dir: full,
+            multiFile: true,
+          });
+          continue;
+        }
         if (!name.endsWith('.ts')) continue;
         cases.push({
           label: `${bucket}/${name}`,
-          inputPath: path.join(bucketDir, name),
+          inputPath: full,
         });
       }
     }
@@ -417,10 +430,17 @@ function collectCases(rootDir, mode) {
       if (!fs.statSync(dir).isDirectory()) continue;
       const inputPath = path.join(dir, 'input.ts');
       if (!fs.existsSync(inputPath)) continue;
+      // A self-test fixture with sibling `.ts` files beyond `input.ts` is a
+      // multi-file case (entry = input.ts).
+      const siblingTs = fs
+        .readdirSync(dir)
+        .filter((f) => /\.[mc]?ts$/.test(f) && f !== 'input.ts');
+      const multiFile = siblingTs.length > 0;
       cases.push({
         label: name,
         inputPath,
         expectedPath: path.join(dir, 'expected-outcome.txt'),
+        ...(multiFile ? { dir, multiFile: true } : {}),
       });
     }
   }
@@ -439,7 +459,7 @@ function runCorpus(rootDir, opts = {}) {
     process.stdout.write(`${c.label}: `);
     let outcome;
     try {
-      outcome = evaluateCase(c.inputPath);
+      outcome = evaluateCase(c.inputPath, { dir: c.dir });
     } catch (e) {
       outcome = { kind: 'fail', label: 'crash', detail: e.stack || e.message };
     }

--- a/tests/conformance/accept/export-alias/a.ts
+++ b/tests/conformance/accept/export-alias/a.ts
@@ -1,0 +1,4 @@
+function internalAdd(x: bigint, y: bigint): bigint {
+  return x + y;
+}
+export { internalAdd as add };

--- a/tests/conformance/accept/export-alias/entry.ts
+++ b/tests/conformance/accept/export-alias/entry.ts
@@ -1,0 +1,2 @@
+import { add } from './a';
+console.log(add(40n, 2n));

--- a/tests/conformance/accept/import-alias/a.ts
+++ b/tests/conformance/accept/import-alias/a.ts
@@ -1,0 +1,3 @@
+export function makeVal(x: bigint): bigint {
+  return x * 2n;
+}

--- a/tests/conformance/accept/import-alias/entry.ts
+++ b/tests/conformance/accept/import-alias/entry.ts
@@ -1,0 +1,2 @@
+import { makeVal as build } from './a';
+console.log(build(21n));

--- a/tests/conformance/accept/import-basic/a.ts
+++ b/tests/conformance/accept/import-basic/a.ts
@@ -1,0 +1,3 @@
+export function inc(x: bigint): bigint {
+  return x + 1n;
+}

--- a/tests/conformance/accept/import-basic/entry.ts
+++ b/tests/conformance/accept/import-basic/entry.ts
@@ -1,0 +1,2 @@
+import { inc } from './a';
+console.log(inc(41n));

--- a/tests/conformance/accept/import-type/entry.ts
+++ b/tests/conformance/accept/import-type/entry.ts
@@ -1,0 +1,2 @@
+import { addMeters } from './measures';
+console.log(addMeters(40n, 2n));

--- a/tests/conformance/accept/import-type/measures.ts
+++ b/tests/conformance/accept/import-type/measures.ts
@@ -1,0 +1,4 @@
+export type Meters = bigint;
+export function addMeters(a: Meters, b: Meters): Meters {
+  return a + b;
+}

--- a/tests/conformance/mirror/import-missing-module.ts
+++ b/tests/conformance/mirror/import-missing-module.ts
@@ -1,0 +1,2 @@
+import { f } from './missing';
+console.log(f());

--- a/tests/conformance/mirror/import-no-member/a.ts
+++ b/tests/conformance/mirror/import-no-member/a.ts
@@ -1,0 +1,3 @@
+export function f(): bigint {
+  return 1n;
+}

--- a/tests/conformance/mirror/import-no-member/entry.ts
+++ b/tests/conformance/mirror/import-no-member/entry.ts
@@ -1,0 +1,2 @@
+import { g } from './a';
+console.log(g());

--- a/tests/conformance/reject/0088-side-effect-import.ts
+++ b/tests/conformance/reject/0088-side-effect-import.ts
@@ -1,0 +1,2 @@
+// @thales-expect-error TH0088
+import '@thales/prelude';

--- a/tests/conformance/reject/0089-default-export.ts
+++ b/tests/conformance/reject/0089-default-export.ts
@@ -1,0 +1,4 @@
+// @thales-expect-error TH0089
+export default function f(): bigint {
+  return 1n;
+}

--- a/tests/conformance/reject/0090-import-cycle/a.ts
+++ b/tests/conformance/reject/0090-import-cycle/a.ts
@@ -1,0 +1,4 @@
+import { b } from './entry';
+export function a(): bigint {
+  return b();
+}

--- a/tests/conformance/reject/0090-import-cycle/entry.ts
+++ b/tests/conformance/reject/0090-import-cycle/entry.ts
@@ -1,0 +1,6 @@
+// @thales-expect-error TH0090
+import { a } from './a';
+export function b(): bigint {
+  return 1n;
+}
+console.log(a());


### PR DESCRIPTION
Adds a v1 ESM module surface so multi-file TypeScript programs type-check, emit, and run in Thales. Supports named `import { a, b as c }`, inline `export` on declarations, trailing `export { … }`, and `import type`, with aliasing on both seams. Each `.ts` file still lowers to one `.lean` file: non-exported top-level decls become `private`, named imports emit `open A (…)` / `open A renaming x → y`, and export aliases emit a public `def`. Module resolution lives in `Main.lean` (the only IO layer) — it reads each imported sibling, harvests its exported signatures into an augmented type context, and a recursive resolver with an in-progress set detects import cycles (which Lean's acyclic module graph cannot represent). The conformance harness gains a directory-fixture mode that emits every sibling, builds dependency `.olean`s, and runs the entry.

Unsupported forms are rejected precisely rather than miscompiled: default/namespace/side-effect imports (TH0088), `export default`/re-exports (TH0089), and cycles (TH0090); missing modules and members mirror tsc as TS2307/TS2305. Two limitations are intentional and documented: fixtures use same-directory specifiers, and a sibling's body errors are caught when that file is compiled on its own rather than re-attributed at the entry. Follow-ups filed for a `tsc -b`-style project build mode (#80) and emitter object-literal construction (#81), the latter being why the imported-type fixture uses a type alias. Closes #18.