### PR TITLE
Close the (unsupported …) placeholder holes (#30)

### DIFF
--- a/Test/Emit/UnsupportedSentinelTest.lean
+++ b/Test/Emit/UnsupportedSentinelTest.lean
@@ -1,0 +1,39 @@
+/-
+  Test/Emit/UnsupportedSentinelTest.lean
+  The structural sentinel (#30): LModule.unsupportedReasons detects any
+  LExpr.unsupported placeholder, so Main's TH9005 gate can refuse to emit.
+-/
+import Thales.Emit.LeanSyntax
+
+open Thales.Emit.LeanSyntax
+
+-- A module whose single def body contains an `.unsupported` node, nested under
+-- a namespace and an `ite` to exercise the recursive traversal.
+private def dirtyModule : LModule :=
+  { imports := ["Thales.TS.Runtime"]
+    opens := ["Thales.TS"]
+    decls :=
+      [ .namespace_ "M"
+          [ .def_ "f" [] [("x", .const "Int")] (.const "Int")
+              (.ite (.bool true) (.unsupported "regex literal") (.var "x")) false ] ] }
+
+-- A clean module with no placeholder.
+private def cleanModule : LModule :=
+  { imports := ["Thales.TS.Runtime"]
+    opens := ["Thales.TS"]
+    decls :=
+      [ .namespace_ "M"
+          [ .def_ "g" [] [("x", .const "Int")] (.const "Int") (.var "x") false ] ] }
+
+def testDetectsUnsupported : IO Unit := do
+  let reasons := dirtyModule.unsupportedReasons
+  unless reasons == ["regex literal"] do
+    throw (IO.userError s!"expected [\"regex literal\"], got {reasons}")
+
+def testCleanModuleHasNone : IO Unit := do
+  let reasons := cleanModule.unsupportedReasons
+  unless reasons == [] do
+    throw (IO.userError s!"expected [], got {reasons}")
+
+#eval testDetectsUnsupported
+#eval testCleanModuleHasNone

--- a/Test/Emit/UnsupportedUnaryCheckTest.lean
+++ b/Test/Emit/UnsupportedUnaryCheckTest.lean
@@ -1,0 +1,58 @@
+/-
+  Test/Emit/UnsupportedUnaryCheckTest.lean
+  Verifies the value-level unary/literal rejections that keep the emitter from
+  ever lowering a construct it has no Lean form for:
+    - TH0091: regex literal
+    - TH0092: `typeof` / `void` / `delete`
+  The `typeof` cases include guard positions (`if (typeof x === …)`,
+  `switch (typeof x)`). Those were once carved out as "narrowing consumes them,"
+  but the emitter cannot lower `typeof` in any position, so a carve-out let an
+  accepted program trip the TH9005 emit gate (#30). These assertions lock the
+  carve-out out: `typeof` must be rejected wherever it appears.
+-/
+import Thales.Emit.SubsetCheck
+import Thales.Parser.Native
+
+open Thales.Emit Thales.Parser Thales.TypeCheck
+
+/-- Assert `subsetCheck` reports `code` for `src`. Uses `.any`, so it tolerates
+    additional codes (e.g. `switch (typeof x)` also raises TH0041). -/
+def expectUnaryCode (src : String) (code : Nat) : IO Unit := do
+  match parseTSSourceNative src with
+  | .error e => throw (IO.userError s!"parse: {e}")
+  | .ok prog =>
+    let diags := subsetCheck prog
+    unless diags.any (·.thalesCode? = some code) do
+      let fmt := (diags.map (·.format "")).toList
+      throw (IO.userError s!"expected TH{code}, got: {fmt}")
+
+-- TH0091: regex literal in value position.
+def testRegexLiteral : IO Unit := expectUnaryCode "const r = /abc/g;" 91
+
+-- TH0092: value-position typeof / void / delete.
+def testValueTypeof : IO Unit := expectUnaryCode "const t = typeof 1;" 92
+def testValueVoid : IO Unit := expectUnaryCode "const u = void 0;" 92
+def testValueDelete : IO Unit :=
+  expectUnaryCode "const o: { a?: number } = { a: 1 }; const r = delete o.a;" 92
+
+-- TH0092: guard-position typeof — the regression these tests exist to prevent.
+-- `===` and `!==` both go through the same rejection now (no carve-out).
+def testGuardTypeofSeq : IO Unit :=
+  expectUnaryCode
+    "function f(x: string): number { if (typeof x === \"string\") { return 1; } return 0; }" 92
+def testGuardTypeofSneq : IO Unit :=
+  expectUnaryCode
+    "function f(x: string): number { if (typeof x !== \"string\") { return 1; } return 0; }" 92
+
+-- TH0092: typeof as a `switch` discriminant (also raises TH0041; `.any` is fine).
+def testSwitchTypeof : IO Unit :=
+  expectUnaryCode
+    "function f(x: string): number { switch (typeof x) { default: return 0; } }" 92
+
+#eval testRegexLiteral
+#eval testValueTypeof
+#eval testValueVoid
+#eval testValueDelete
+#eval testGuardTypeofSeq
+#eval testGuardTypeofSneq
+#eval testSwitchTypeof

--- a/Thales/Emit/Lean.lean
+++ b/Thales/Emit/Lean.lean
@@ -589,7 +589,7 @@ private def refinementKindPredicate : RefinementKind → String
     dropped. `SubsetCheck`'s `doModeLowerable` gate should make this
     unreachable; reaching it means the two have drifted. -/
 private def unloweredDoStmt : List LDoStmt :=
-  [.ret (.var "(unsupported: statement not lowerable in do-mode)")]
+  [.ret (.unsupported "statement not lowerable in do-mode")]
 
 /-- Unwrap a block into its statement list; a single statement becomes a
     singleton list. -/
@@ -671,7 +671,7 @@ private def recordDeclBinding (env : EmitEnv) (name : String)
 mutual
 
 /-- Translate a JS `Expression` to a Lean `LExpr`. Unsupported constructs
-    emit `.var "(unsupported expr)"`; SubsetCheck rejects them upstream.
+    emit `.unsupported "expression"`; SubsetCheck rejects them upstream.
     `env` carries the binding-type table so refinement-typed identifiers
     can be `.val`-projected when used in arithmetic. -/
 partial def emitExprEnv (env : EmitEnv) : Expression → LExpr
@@ -681,7 +681,7 @@ partial def emitExprEnv (env : EmitEnv) : Expression → LExpr
   | .literal _ (.string s) _ => .str s
   | .literal _ (.boolean b) _ => .bool b
   | .literal _ .null _       => .ctor "none" []
-  | .literal _ (.regex _ _) _ => .var "(unsupported: regex literal)"
+  | .literal _ (.regex _ _) _ => .unsupported "regex literal"
   -- Identifier. The JS numeric globals `NaN`/`Infinity` are `number`-typed but
   -- have no bare Lean counterpart, so lower them to the runtime `Float`
   -- constants (`-Infinity` lowers as the negation of `Infinity`).
@@ -747,9 +747,9 @@ partial def emitExprEnv (env : EmitEnv) : Expression → LExpr
   | .unaryExpr _ .pos _ arg => emitExprEnv env arg
   | .unaryExpr _ .not _ arg => .app (.var "not") [emitExprEnv env arg]
   | .unaryExpr _ .bitnot _ arg => .app (.var "Complement.complement") [emitExprEnv env arg]
-  | .unaryExpr _ _ _ _ => .var "(unsupported: unary op)"
+  | .unaryExpr _ _ _ _ => .unsupported "unary op"
   -- Update (++/--): SubsetCheck rejects; placeholder
-  | .updateExpr _ _ _ _ => .var "(unsupported: update expr)"
+  | .updateExpr _ _ _ _ => .unsupported "update expr"
   -- Conditional (ternary)
   | .conditionalExpr _ cond thn els =>
       .ite (emitExprEnv env cond) (emitExprEnv env thn) (emitExprEnv env els)
@@ -926,7 +926,7 @@ partial def emitExprEnv (env : EmitEnv) : Expression → LExpr
       .app (.var "List.toArray") [mkListLit exprs]
   -- Arrow function expression
   | .arrowFunctionExpr _ params body _ async _ =>
-      if async then .var "(unsupported: async arrow)"
+      if async then .unsupported "async arrow"
       else
         let leanParams := params.filterMap fun
           | .simple id => some (id.name, none)
@@ -938,7 +938,7 @@ partial def emitExprEnv (env : EmitEnv) : Expression → LExpr
           | .inr stmt  => emitBodyEnv env [stmt]
         .lam leanParams bodyExpr
   -- Assignment: SubsetCheck rejects; placeholder
-  | .assignmentExpr _ _ _ _ => .var "(unsupported: assignment)"
+  | .assignmentExpr _ _ _ _ => .unsupported "assignment"
   -- Object literal with a `kind: "..."` discriminator: emit as an anonymous
   -- constructor `.kindVal <other-field-values>` and let Lean resolve which
   -- inductive via context. Field values are emitted in literal order, which
@@ -960,7 +960,7 @@ partial def emitExprEnv (env : EmitEnv) : Expression → LExpr
       | some ctor =>
           let otherFields := regularProps.filter fun (k, _) => k != "kind"
           .ctor ctor (otherFields.map fun (_, v) => emitExprEnv env v)
-      | none => .var "(unsupported expr)"
+      | none => .unsupported "expression"
   -- Template literal: `q0${e0}q1${e1}...qn`
   -- Emitted as string concatenation: "q0" ++ JSShow.jsShow e0 ++ "q1" ++ ...
   -- Quasis has (n+1) elements for n expressions; gaps with empty strings are skipped.
@@ -984,7 +984,7 @@ partial def emitExprEnv (env : EmitEnv) : Expression → LExpr
       | [single] => single
       | first :: rest => rest.foldl (fun acc p => .binOp "++" acc p) first
   -- Everything else
-  | _ => .var "(unsupported expr)"
+  | _ => .unsupported "expression"
 
 /-- Backwards-compatible wrapper used by the few sites that have no env
     available (e.g. the top-level `console.log` lowering). Calls
@@ -1105,7 +1105,7 @@ partial def emitBodyEnv (env : EmitEnv) : List Statement → LExpr
       -- shape with all-return arms, so the code after the switch is dead
       -- and a fallback that DROPS the switch is never correct — the
       -- unresolved cases render the loud marker instead (#44).
-      let unlowered : LExpr := .var "(unsupported: switch not lowerable)"
+      let unlowered : LExpr := .unsupported "switch not lowerable"
       match discriminant with
       | .memberExpr _ (.identifier _ scrutName) (.identifier _ _fieldName) false _ =>
           match env.bindingEnv.get? scrutName with
@@ -1150,7 +1150,7 @@ partial def emitBodyEnv (env : EmitEnv) : List Statement → LExpr
   | .throwStmt _ arg :: _ =>
       if env.throwTypes.isEmpty then
         -- SubsetCheck already flagged TH0060.
-        .var "(unsupported: throw without @throws)"
+        .unsupported "throw without @throws"
       else
         -- Heuristic: `new E(args)` thrown at index `idx` of `@throws`.
         let thrownTypeName : String := match arg with
@@ -1738,8 +1738,8 @@ private def ldeclName : LDecl → Option String
   | .abbrev_ n .. => some n
   | _ => none
 
-/-- Walk the program and produce a Lean module string. -/
-def emit (prog : TSProgram) (moduleName : String) : String :=
+/-- Walk the program and produce a Lean module (structural form). -/
+def buildModule (prog : TSProgram) (moduleName : String) : LModule :=
   let resolvedAliases := resolveAliases prog.body
   let funcThrowsEnv := buildFuncThrowsEnv prog.body
   let funcParamTypes := buildFuncParamTypesEnv prog.body
@@ -1973,10 +1973,14 @@ def emit (prog : TSProgram) (moduleName : String) : String :=
   let body : LDecl :=
     if moduleName.isEmpty then .namespace_ "Input" decls
     else .namespace_ moduleName decls
-  renderModule {
+  {
     imports := "Thales.TS.Runtime" :: tsImports
     opens := "Thales.TS" :: collectOpens prog.body
     decls := [body]
   }
+
+/-- Walk the program and produce a Lean module string. -/
+def emit (prog : TSProgram) (moduleName : String) : String :=
+  renderModule (buildModule prog moduleName)
 
 end Thales.Emit

--- a/Thales/Emit/LeanSyntax.lean
+++ b/Thales/Emit/LeanSyntax.lean
@@ -31,6 +31,11 @@ mutual
 /-- Lean term. Only the subset the emitter uses. -/
 inductive LExpr where
   | var (name : String)
+  -- A typed placeholder for a construct the emitter cannot lower. It must never
+  -- reach a written file: Main's TH9005 gate (LModule.unsupportedReasons) refuses
+  -- to emit when any of these survive. Replaces the old `.var "(unsupported …)"`
+  -- string placeholders so the leak is detectable structurally, not by substring.
+  | unsupported (reason : String)
   | int (n : Int)
   | float (n : Float)
   | str (s : String)
@@ -185,6 +190,56 @@ structure LModule where
   decls : List LDecl
   deriving Inhabited
 
+/-! ### Unsupported-placeholder collector (#30)
+
+Gathers the `reason` of every `LExpr.unsupported` node in a module. Main uses this
+to refuse emission (TH9005) rather than write a `.lean` file that cannot elaborate. -/
+
+mutual
+  partial def LExpr.collectUnsupported : LExpr → List String
+    | .unsupported r        => [r]
+    | .app fn args          => fn.collectUnsupported ++ args.foldl (fun a e => a ++ e.collectUnsupported) []
+    | .lam _ body           => body.collectUnsupported
+    | .letE _ _ v b         => v.collectUnsupported ++ b.collectUnsupported
+    | .match_ s arms        => s.collectUnsupported ++ arms.foldl (fun a (_, e) => a ++ e.collectUnsupported) []
+    | .ite c t e            => c.collectUnsupported ++ t.collectUnsupported ++ e.collectUnsupported
+    | .binOp _ l r          => l.collectUnsupported ++ r.collectUnsupported
+    | .ctor _ args          => args.foldl (fun a e => a ++ e.collectUnsupported) []
+    | .proj o _             => o.collectUnsupported
+    | .structLit _ fields   => fields.foldl (fun a (_, e) => a ++ e.collectUnsupported) []
+    | .anonCtor args _      => args.foldl (fun a e => a ++ e.collectUnsupported) []
+    | .indexOpt arr idx     => arr.collectUnsupported ++ idx.collectUnsupported
+    | .dite_ _ c t e        => c.collectUnsupported ++ t.collectUnsupported ++ e.collectUnsupported
+    | .doSeq stmts          => stmts.foldl (fun a e => a ++ e.collectUnsupported) []
+    | .idRunDo stmts        => stmts.foldl (fun a s => a ++ s.collectUnsupported) []
+    | .rangeTo stop         => stop.collectUnsupported
+    | .var _ | .int _ | .float _ | .str _ | .bool _ => []
+  partial def LDoStmt.collectUnsupported : LDoStmt → List String
+    | .letMut _ _ v | .letPure _ _ v | .assign _ v | .ret v => v.collectUnsupported
+    | .ifDo c thn els       => c.collectUnsupported
+                                 ++ thn.foldl (fun a s => a ++ s.collectUnsupported) []
+                                 ++ els.foldl (fun a s => a ++ s.collectUnsupported) []
+    | .matchDo s arms       => s.collectUnsupported
+                                 ++ arms.foldl (fun a (_, ss) => a ++ ss.foldl (fun a2 s => a2 ++ s.collectUnsupported) []) []
+    | .forDo _ it body      => it.collectUnsupported ++ body.foldl (fun a s => a ++ s.collectUnsupported) []
+    | .whileDo c body       => c.collectUnsupported ++ body.foldl (fun a s => a ++ s.collectUnsupported) []
+    | .repeatUntilDo body c => body.foldl (fun a s => a ++ s.collectUnsupported) [] ++ c.collectUnsupported
+    | .breakDo | .continueDo => []
+end
+
+partial def LDecl.collectUnsupported : LDecl → List String
+  | .def_ _ _ _ _ body _   => body.collectUnsupported
+  | .struct ..             => []
+  | .inductive_ ..         => []
+  | .abbrev_ ..            => []
+  | .namespace_ _ body     => body.foldl (fun a d => a ++ d.collectUnsupported) []
+  | .eval_ e               => e.collectUnsupported
+  | .instance_ _ _ body    => body.collectUnsupported
+  | .private_ inner        => inner.collectUnsupported
+
+def LModule.unsupportedReasons (m : LModule) : List String :=
+  m.decls.foldl (fun a d => a ++ d.collectUnsupported) []
+
 /-! ### Pretty printer -/
 
 /-- Concatenate with newlines. -/
@@ -254,6 +309,7 @@ mutual
 
   partial def renderExpr : LExpr → String
     | .var n    => n
+    | .unsupported reason => s!"(unsupported: {reason})"
     | .int n    => if n < 0 then s!"({n})" else toString n
     | .float f  => renderFloat f
     | .str s    => s!"\"{escapeString s}\""

--- a/Thales/Emit/SubsetCheck.lean
+++ b/Thales/Emit/SubsetCheck.lean
@@ -6,6 +6,7 @@
 -/
 import Thales.TypeCheck.TSAST
 import Thales.TypeCheck.Diagnostic
+import Thales.TypeCheck.Narrowing
 import Thales.Emit.DirectiveApply
 import Thales.Emit.EscapeAnalysis
 import Thales.Emit.LoopShape
@@ -258,8 +259,14 @@ partial def checkExpr (ctx : MutCtx) (expr : Expression) : Array Diagnostic :=
           checkExpr ctx callee
       | _ => checkExpr ctx callee
     calleeDiags ++ (arguments.foldl (fun acc arg => acc ++ checkExpr ctx arg) #[])
-  | .unaryExpr _ _ _ argument =>
-    checkExpr ctx argument
+  | .unaryExpr base op _ argument =>
+    let opDiag : Array Diagnostic :=
+      match op with
+      | .typeof => #[mkThalesDiag (.unsupportedUnaryOperator "typeof") base.loc]
+      | .void   => #[mkThalesDiag (.unsupportedUnaryOperator "void") base.loc]
+      | .delete => #[mkThalesDiag (.unsupportedUnaryOperator "delete") base.loc]
+      | _       => #[]
+    opDiag ++ checkExpr ctx argument
   | .binaryExpr b _ left right =>
     -- TH0084: a definedness test on a body-local whose type the emitter
     -- cannot record (not a param, not in `typedDecls`) can be neither
@@ -286,7 +293,22 @@ partial def checkExpr (ctx : MutCtx) (expr : Expression) : Array Diagnostic :=
       if EscapeAnalysis.definednessTestHasNonIdentifierSubject expr then
         #[mkThalesDiag .definednessTestNonIdentifierSubject b.loc]
       else #[]
-    th84 ++ th86 ++ checkExpr ctx left ++ checkExpr ctx right
+    -- TH0092 carve-out: in a recognized `typeof` guard the `typeof` operand is
+    -- consumed by narrowing (Narrowing.extractGuard), not value-position, so do
+    -- not let it collect a spurious TH0092. Delegating to extractGuard keeps the
+    -- accepted set definitionally equal to what narrowing consumes (incl. the
+    -- template-literal / seq-vs-sneq asymmetry) so the two cannot drift.
+    let isTypeofGuard : Bool :=
+      match Narrowing.extractGuard expr with
+      | some (.typeofEquals _ _)        => true
+      | some (.not (.typeofEquals _ _)) => true
+      | _                               => false
+    let isTypeofNode : Expression → Bool
+      | .unaryExpr _ .typeof _ (.identifier _ _) => true
+      | _                                        => false
+    let leftDiags  := if isTypeofGuard && isTypeofNode left  then #[] else checkExpr ctx left
+    let rightDiags := if isTypeofGuard && isTypeofNode right then #[] else checkExpr ctx right
+    th84 ++ th86 ++ leftDiags ++ rightDiags
   | .logicalExpr _ _ left right =>
     checkExpr ctx left ++ checkExpr ctx right
   | .memberExpr _ obj prop _ _ =>
@@ -478,7 +500,14 @@ partial def checkStmt (ctx : MutCtx) (stmt : Statement) : Array Diagnostic :=
       | none => #[]
     blockDiags ++ handlerDiags
   | .switchStmt _ discriminant cases =>
-    checkExpr ctx discriminant
+    -- TH0092 carve-out: `switch (typeof x)` is a recognized discriminant
+    -- (Narrowing.analyzeSwitchDiscriminant), so its `typeof` operand is not
+    -- value-position. Skip checking the discriminant in that case only.
+    let discDiags : Array Diagnostic :=
+      match Narrowing.analyzeSwitchDiscriminant discriminant with
+      | .typeofVar _ => #[]
+      | _            => checkExpr ctx discriminant
+    discDiags
       ++ cases.foldl (fun acc (SwitchCase.mk _ _ stmts) =>
            stmts.foldl (fun acc2 s => acc2 ++ checkStmt ctx s) acc) #[]
   | .labeledStmt _ _ body =>

--- a/Thales/Emit/SubsetCheck.lean
+++ b/Thales/Emit/SubsetCheck.lean
@@ -350,6 +350,7 @@ partial def checkExpr (ctx : MutCtx) (expr : Expression) : Array Diagnostic :=
     | none => baseDiag
   -- Leaf nodes with no sub-expressions
   | .identifier _ _ => #[]
+  | .literal base (.regex _ _) _ => #[mkThalesDiag .regexLiteral base.loc]
   | .literal _ _ _ => #[]
   | .thisExpr _ => #[]
   | .super_ _ => #[]

--- a/Thales/Emit/SubsetCheck.lean
+++ b/Thales/Emit/SubsetCheck.lean
@@ -6,7 +6,6 @@
 -/
 import Thales.TypeCheck.TSAST
 import Thales.TypeCheck.Diagnostic
-import Thales.TypeCheck.Narrowing
 import Thales.Emit.DirectiveApply
 import Thales.Emit.EscapeAnalysis
 import Thales.Emit.LoopShape
@@ -293,22 +292,7 @@ partial def checkExpr (ctx : MutCtx) (expr : Expression) : Array Diagnostic :=
       if EscapeAnalysis.definednessTestHasNonIdentifierSubject expr then
         #[mkThalesDiag .definednessTestNonIdentifierSubject b.loc]
       else #[]
-    -- TH0092 carve-out: in a recognized `typeof` guard the `typeof` operand is
-    -- consumed by narrowing (Narrowing.extractGuard), not value-position, so do
-    -- not let it collect a spurious TH0092. Delegating to extractGuard keeps the
-    -- accepted set definitionally equal to what narrowing consumes (incl. the
-    -- template-literal / seq-vs-sneq asymmetry) so the two cannot drift.
-    let isTypeofGuard : Bool :=
-      match Narrowing.extractGuard expr with
-      | some (.typeofEquals _ _)        => true
-      | some (.not (.typeofEquals _ _)) => true
-      | _                               => false
-    let isTypeofNode : Expression → Bool
-      | .unaryExpr _ .typeof _ (.identifier _ _) => true
-      | _                                        => false
-    let leftDiags  := if isTypeofGuard && isTypeofNode left  then #[] else checkExpr ctx left
-    let rightDiags := if isTypeofGuard && isTypeofNode right then #[] else checkExpr ctx right
-    th84 ++ th86 ++ leftDiags ++ rightDiags
+    th84 ++ th86 ++ checkExpr ctx left ++ checkExpr ctx right
   | .logicalExpr _ _ left right =>
     checkExpr ctx left ++ checkExpr ctx right
   | .memberExpr _ obj prop _ _ =>
@@ -500,14 +484,7 @@ partial def checkStmt (ctx : MutCtx) (stmt : Statement) : Array Diagnostic :=
       | none => #[]
     blockDiags ++ handlerDiags
   | .switchStmt _ discriminant cases =>
-    -- TH0092 carve-out: `switch (typeof x)` is a recognized discriminant
-    -- (Narrowing.analyzeSwitchDiscriminant), so its `typeof` operand is not
-    -- value-position. Skip checking the discriminant in that case only.
-    let discDiags : Array Diagnostic :=
-      match Narrowing.analyzeSwitchDiscriminant discriminant with
-      | .typeofVar _ => #[]
-      | _            => checkExpr ctx discriminant
-    discDiags
+    checkExpr ctx discriminant
       ++ cases.foldl (fun acc (SwitchCase.mk _ _ stmts) =>
            stmts.foldl (fun acc2 s => acc2 ++ checkStmt ctx s) acc) #[]
   | .labeledStmt _ _ body =>

--- a/Thales/Main.lean
+++ b/Thales/Main.lean
@@ -334,13 +334,25 @@ def main (args : List String) : IO UInt32 := do
 
       if cli.emit then
         let moduleName := inputToModuleName filename
+        -- TH9005: structural emit-soundness gate. Build the module once; if it
+        -- contains any LExpr.unsupported placeholder, refuse to write a file that
+        -- cannot elaborate. Non-suppressible — this is an internal integrity check.
+        let mod := Thales.Emit.buildModule tsProg moduleName
+        let unsupported := mod.unsupportedReasons
+        if !unsupported.isEmpty then
+          let diag : Diagnostic :=
+            { kind := .thales (.emittedCodeContainsUnsupported (String.intercalate "; " unsupported)),
+              location := some { start := { line := 1, column := 0 },
+                                 «end» := { line := 1, column := 0 } } }
+          IO.println (diag.format filename)
+          return 1
         let outDir := cli.outDir.getD (dirnameOf filename)
         IO.FS.createDirAll outDir
         let outPath := outDir ++ "/" ++ moduleName ++ ".lean"
         if (← System.FilePath.pathExists outPath) && !cli.overwrite then
           IO.eprintln s!"Error: {outPath} already exists. Pass --overwrite to replace it."
           return 1
-        let leanSrc := Thales.Emit.emit tsProg moduleName
+        let leanSrc := Thales.Emit.LeanSyntax.renderModule mod
         IO.FS.writeFile outPath leanSrc
         IO.eprintln s!"emitted: {outPath}"
       return 0

--- a/Thales/TypeCheck/Diagnostic.lean
+++ b/Thales/TypeCheck/Diagnostic.lean
@@ -121,7 +121,7 @@ inductive ThalesKind where
   | importCycle (cyclePath : String)
   -- Regex literal in value position (TH0091)
   | regexLiteral
-  -- Unsupported unary operator in value position (TH0092): typeof/void/delete
+  -- Unsupported unary operator (TH0092): typeof/void/delete, in any position
   | unsupportedUnaryOperator (op : String)
   -- Directive diagnostics (TH9000–TH9003)
   | directiveUnused
@@ -271,7 +271,7 @@ def ThalesKind.message : ThalesKind → String
   | .regexLiteral =>
     "Regex literals are not supported"
   | .unsupportedUnaryOperator op =>
-    s!"The '{op}' operator is not supported in value position"
+    s!"The '{op}' operator is not supported"
   | .directiveUnused => "Unused `@thales-expect-error` directive"
   | .directiveCodeMismatch expected actual =>
     let fmtCode (n : Nat) : String := s!"TH{padCode n}"

--- a/Thales/TypeCheck/Diagnostic.lean
+++ b/Thales/TypeCheck/Diagnostic.lean
@@ -130,6 +130,10 @@ inductive ThalesKind where
   | directiveMalformed
   -- Emit-soundness diagnostic (TH9004)
   | emittedCodeContainsSorry (filename : String)
+  -- Emit-soundness diagnostic (TH9005): emitter produced an unlowerable
+  -- placeholder. Untriggerable from valid TS by design (subset checks reject
+  -- first); a firing means a genuine, previously-unknown subset gap.
+  | emittedCodeContainsUnsupported (reasons : String)
   deriving Repr
 
 /-- Map a ThalesKind to its numeric TH code -/
@@ -181,6 +185,7 @@ def ThalesKind.thCode : ThalesKind → Nat
   | .emissionBlockedBySuppressedViolation => 9002
   | .directiveMalformed => 9003
   | .emittedCodeContainsSorry _ => 9004
+  | .emittedCodeContainsUnsupported _ => 9005
 
 /-- Zero-pad a numeric code to 4 digits -/
 private def padCode (n : Nat) : String :=
@@ -278,6 +283,8 @@ def ThalesKind.message : ThalesKind → String
     "Malformed `@thales-expect-error` directive"
   | .emittedCodeContainsSorry filename =>
     s!"Emitted Lean code in '{filename}' contains 'sorry' or 'sorryAx'; emit must be sorry-free"
+  | .emittedCodeContainsUnsupported reasons =>
+    s!"Internal: the emitter produced unlowerable construct(s) ({reasons}); this is a subset gap — the program was accepted but cannot be emitted. Please report it."
 
 /-- Diagnostic error kinds with tsc error code mapping -/
 inductive DiagnosticKind where

--- a/Thales/TypeCheck/Diagnostic.lean
+++ b/Thales/TypeCheck/Diagnostic.lean
@@ -119,6 +119,10 @@ inductive ThalesKind where
   | unsupportedImportForm (form : String)
   | unsupportedExportForm (form : String)
   | importCycle (cyclePath : String)
+  -- Regex literal in value position (TH0091)
+  | regexLiteral
+  -- Unsupported unary operator in value position (TH0092): typeof/void/delete
+  | unsupportedUnaryOperator (op : String)
   -- Directive diagnostics (TH9000–TH9003)
   | directiveUnused
   | directiveCodeMismatch (expected : Nat) (actual : List Nat)
@@ -170,6 +174,8 @@ def ThalesKind.thCode : ThalesKind → Nat
   | .unsupportedImportForm _ => 88
   | .unsupportedExportForm _ => 89
   | .importCycle _ => 90
+  | .regexLiteral => 91
+  | .unsupportedUnaryOperator _ => 92
   | .directiveUnused => 9000
   | .directiveCodeMismatch .. => 9001
   | .emissionBlockedBySuppressedViolation => 9002
@@ -257,6 +263,10 @@ def ThalesKind.message : ThalesKind → String
     s!"This export form ({form}) is not supported; use inline `export` on a declaration or " ++ "`export { a, b };`"
   | .importCycle cyclePath =>
     s!"Circular imports are not supported because the emitted Lean modules cannot form an import cycle ({cyclePath})"
+  | .regexLiteral =>
+    "Regex literals are not supported"
+  | .unsupportedUnaryOperator op =>
+    s!"The '{op}' operator is not supported in value position"
   | .directiveUnused => "Unused `@thales-expect-error` directive"
   | .directiveCodeMismatch expected actual =>
     let fmtCode (n : Nat) : String := s!"TH{padCode n}"

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -85,6 +85,7 @@ soundness check).
 | TH0088 | Subset       | Unsupported `import` form (default/namespace/side-effect) |
 | TH0089 | Subset       | Unsupported `export` form (default/re-export)             |
 | TH0090 | Subset       | Circular imports                                          |
+| TH0091 | Subset       | Regex literals are not supported                          |
 | TH9000 | Directive    | Unused `@thales-expect-error` directive                   |
 | TH9001 | Directive    | Directive code mismatch                                   |
 | TH9002 | Directive    | Cannot emit: subset violations suppressed                 |
@@ -1065,3 +1066,13 @@ console.log(a());
 
 Fix: break the cycle by moving the shared declarations into a third module that
 both import, so the dependency graph is acyclic.
+
+### TH0091 — Regex literals are not supported
+
+Thales has no Lean lowering for `RegExp` values, so a regex literal such as
+`/abc/g` cannot be emitted. The emitter previously wrote an `(unsupported: …)`
+placeholder for it; it is now rejected up front.
+
+```ts
+const re = /abc/g; // TH0091
+```

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -86,7 +86,7 @@ soundness check).
 | TH0089 | Subset       | Unsupported `export` form (default/re-export)             |
 | TH0090 | Subset       | Circular imports                                          |
 | TH0091 | Subset       | Regex literals are not supported                          |
-| TH0092 | Subset       | Unsupported unary operator in value position              |
+| TH0092 | Subset       | Unsupported unary operator (`typeof`/`void`/`delete`)     |
 | TH9000 | Directive    | Unused `@thales-expect-error` directive                   |
 | TH9001 | Directive    | Directive code mismatch                                   |
 | TH9002 | Directive    | Cannot emit: subset violations suppressed                 |
@@ -1090,14 +1090,23 @@ placeholder for it; it is now rejected up front.
 const re = /abc/g; // TH0091
 ```
 
-### TH0092 — Unsupported unary operator in value position
+### TH0092 — Unsupported unary operator
 
-`typeof`, `void`, and `delete` have no value-position Lean lowering. Guard-position
-`typeof` (e.g. `typeof x === "string"`, or a `switch (typeof x)` discriminant) is
-recognized by the narrowing layer and is not flagged here; every other occurrence is
-rejected.
+`typeof`, `void`, and `delete` have no Lean lowering, so they are rejected wherever
+they appear. This includes `typeof` used inside a guard such as
+`if (typeof x === "string")` or a `switch (typeof x)` discriminant: the emitter
+cannot lower the `typeof` test, so it is rejected rather than accepted and silently
+miscompiled.
 
 ```ts
 const t = typeof 1; // TH0092
 const u = void 0; // TH0092
+
+function f(x: string): boolean {
+  if (typeof x === 'string') {
+    // TH0092
+    return true;
+  }
+  return false;
+}
 ```

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -86,6 +86,7 @@ soundness check).
 | TH0089 | Subset       | Unsupported `export` form (default/re-export)             |
 | TH0090 | Subset       | Circular imports                                          |
 | TH0091 | Subset       | Regex literals are not supported                          |
+| TH0092 | Subset       | Unsupported unary operator in value position              |
 | TH9000 | Directive    | Unused `@thales-expect-error` directive                   |
 | TH9001 | Directive    | Directive code mismatch                                   |
 | TH9002 | Directive    | Cannot emit: subset violations suppressed                 |
@@ -1075,4 +1076,16 @@ placeholder for it; it is now rejected up front.
 
 ```ts
 const re = /abc/g; // TH0091
+```
+
+### TH0092 — Unsupported unary operator in value position
+
+`typeof`, `void`, and `delete` have no value-position Lean lowering. Guard-position
+`typeof` (e.g. `typeof x === "string"`, or a `switch (typeof x)` discriminant) is
+recognized by the narrowing layer and is not flagged here; every other occurrence is
+rejected.
+
+```ts
+const t = typeof 1; // TH0092
+const u = void 0; // TH0092
 ```

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -20,8 +20,8 @@ displayed in diagnostics for human readability.
 See `docs/superpowers/specs/2026-04-21-conformance-harness-design.md` for
 the full contract and harness details.
 
-This reference lists all subset `TH####` codes plus the 5 directive
-codes (TH9000–TH9004) with minimal detail. For full explanation,
+This reference lists all subset `TH####` codes plus the directive
+codes (TH9000–TH9005) with minimal detail. For full explanation,
 rationale, and idiomatic replacements, see [subset.md](./subset.md).
 
 The codes are divided into categories:
@@ -92,6 +92,7 @@ soundness check).
 | TH9002 | Directive    | Cannot emit: subset violations suppressed                 |
 | TH9003 | Directive    | Malformed `@thales-expect-error` directive                |
 | TH9004 | Directive    | Emitted Lean code contains `sorry`                        |
+| TH9005 | Internal     | Emitted Lean would contain an unlowerable placeholder     |
 
 ## Future of this table
 
@@ -751,6 +752,17 @@ soundness regression, not a user error. Do not work around by adding
 
 This check applies only to `.lean` files that `thales` emits (not to
 `Test/` WIP proofs or the runtime library).
+
+---
+
+### TH9005 — Emitted Lean would contain an unlowerable placeholder
+
+A structural emit-soundness gate. If the emitter produces an `LExpr.unsupported`
+placeholder for a construct it cannot lower, Thales refuses to write the `.lean`
+file rather than ship code that will not elaborate. This is **not** user-suppressible
+and has no `@thales-expect-error` form: the subset checks reject every known
+out-of-subset construct first, so a TH9005 firing indicates a genuine subset gap in
+the compiler and should be reported.
 
 ---
 

--- a/tests/conformance/reject/0022-undiscriminated-union.ts
+++ b/tests/conformance/reject/0022-undiscriminated-union.ts
@@ -1,7 +1,9 @@
-// Subset-rejected example: undiscriminated primitive union (TH0022).
+// Subset-rejected example: undiscriminated primitive union (TH0022). A
+// `string | number` parameter shares no discriminant, so thales has no Lean
+// representation for it. (Telling the two apart at runtime would need `typeof`,
+// which is itself outside the subset — see TH0092.)
 // @thales-expect-error TH0022
-function double(x: string | number): string | number {
-  if (typeof x === 'number') return x * 2;
-  return x + x;
+function describe(x: string | number): string {
+  return 'value';
 }
-console.log(double(21));
+console.log(describe(21));

--- a/tests/conformance/reject/0091-regex-literal.ts
+++ b/tests/conformance/reject/0091-regex-literal.ts
@@ -1,0 +1,4 @@
+// Subset-rejected example: regex literals are not supported (TH0091).
+// @thales-expect-error TH0091
+const re = /abc/g;
+console.log(re.test('abc'));

--- a/tests/conformance/reject/0092-unsupported-unary-op.ts
+++ b/tests/conformance/reject/0092-unsupported-unary-op.ts
@@ -7,6 +7,10 @@ const t = typeof 1;
 // @thales-expect-error TH0092
 const u = void 0;
 
+const obj: { a?: number } = { a: 1 };
+// @thales-expect-error TH0092
+const removed = delete obj.a;
+
 function f(x: string): boolean {
   // @thales-expect-error TH0092
   if (typeof x === 'string') {

--- a/tests/conformance/reject/0092-unsupported-unary-op.ts
+++ b/tests/conformance/reject/0092-unsupported-unary-op.ts
@@ -1,0 +1,24 @@
+// Subset-rejected example: `typeof`, `void`, and `delete` are not supported
+// anywhere (TH0092) — neither in value position nor inside a guard. A `typeof`
+// test such as `typeof x === "string"` is rejected just like any other use.
+
+// @thales-expect-error TH0092
+const t = typeof 1;
+// @thales-expect-error TH0092
+const u = void 0;
+
+function f(x: string): boolean {
+  // @thales-expect-error TH0092
+  if (typeof x === 'string') {
+    return true;
+  }
+  // @thales-expect-error TH0092
+  if (typeof x !== 'string') {
+    return false;
+  }
+  return false;
+}
+
+console.log(t);
+console.log(u);
+console.log(f('a'));

--- a/tests/conformance/reject/0092-value-position-unary.ts
+++ b/tests/conformance/reject/0092-value-position-unary.ts
@@ -1,0 +1,7 @@
+// Subset-rejected example: typeof/void in value position are not supported (TH0092).
+// @thales-expect-error TH0092
+const t = typeof 1;
+// @thales-expect-error TH0092
+const u = void 0;
+console.log(t);
+console.log(u);

--- a/tests/conformance/reject/0092-value-position-unary.ts
+++ b/tests/conformance/reject/0092-value-position-unary.ts
@@ -1,7 +1,0 @@
-// Subset-rejected example: typeof/void in value position are not supported (TH0092).
-// @thales-expect-error TH0092
-const t = typeof 1;
-// @thales-expect-error TH0092
-const u = void 0;
-console.log(t);
-console.log(u);


### PR DESCRIPTION
Accepted programs could previously emit uncompilable Lean containing `(unsupported: …)` placeholders for a handful of constructs the emitter cannot lower. This rejects those constructs up front and adds a structural backstop so the emitter can never silently ship a placeholder again.

- **TH0091** rejects regex literals in value position.
- **TH0092** rejects `typeof`, `void`, and `delete` in every position — value and guard alike. An earlier commit on this branch carved out guard-position `typeof` (`typeof x === "string"`, `switch (typeof x)`) by delegating to the narrowing detectors, but that was unsound: the emitter has no lowering for `typeof` anywhere, so a carved-out guard passed `--no-emit` and then tripped the TH9005 gate — the exact accept-then-fail hole this PR exists to close. `typeof` is now rejected uniformly. `reject/0022`, which had leaned on a `typeof` guard, is rewritten to demonstrate TH0022 without one. Follow-up #85 tracks actually supporting `typeof` guards.
- A typed `LExpr.unsupported` constructor replaces the ~10 string placeholders, with a structural `LModule.unsupportedReasons` collector.
- **TH9005** is a non-suppressible gate in `Main`: it builds the module, and if any `LExpr.unsupported` survives, refuses to write the file rather than emit Lean that cannot elaborate. The subset checks reject every known construct first, so no accepted TS reaches it and a firing signals a genuine subset gap. Covered by a unit test.

Out of scope: constructs that emit valid-but-wrong Lean rather than placeholders are tracked separately and are not affected by the gate. Following up on regex specifically, #83 tracks actually supporting regex literals via the already-vendored lean-regex.

Verification: full `lake build`, `lake build ThalesTest` (incl. the new sentinel test), format check, harness self-test, and the full conformance corpus all pass; the corpus grows by the two new reject fixtures.
