### PR TITLE
Top-level mutation and loops (#49)

### DIFF
--- a/Test/Emit/ControlFlowCheckTest.lean
+++ b/Test/Emit/ControlFlowCheckTest.lean
@@ -19,6 +19,16 @@ def expectCFCode (src : String) (code : Nat) : IO Unit := do
       let fmt := (diags.map (·.format "")).toList
       throw (IO.userError s!"expected TH{code}, got: {fmt}")
 
+/-- Verify that the given code does NOT fire (the construct is in-subset). -/
+def expectNoCFCode (src : String) (code : Nat) : IO Unit := do
+  match parseTSSourceNative src with
+  | .error e => throw (IO.userError s!"parse: {e}")
+  | .ok prog =>
+    let diags := subsetCheck prog
+    if diags.any (·.thalesCode? = some code) then
+      let fmt := (diags.map (·.format "")).toList
+      throw (IO.userError s!"expected no TH{code}, got: {fmt}")
+
 /-- Verify that throwsAnnotationCheck (TH0060) fires for the given source. -/
 def expectThrowsCode (src : String) (code : Nat) : IO Unit := do
   match parseTSSourceNative src with
@@ -29,11 +39,14 @@ def expectThrowsCode (src : String) (code : Nat) : IO Unit := do
       let fmt := (diags.map (·.format "")).toList
       throw (IO.userError s!"expected TH{code}, got: {fmt}")
 
-def testForLoop : IO Unit := expectCFCode "for (let i = 0; i < 3; i++) {}" 10
-def testForOfLoop : IO Unit := expectCFCode "for (const x of [1,2,3]) {}" 10
+-- Module-level loops are now in-subset, lowered into the `main` IO do-block
+-- on the same terms as a function body (#49) — no TH0010. `for…in` stays out
+-- of subset (no lowering), so it still draws TH0010.
+def testForLoop : IO Unit := expectNoCFCode "for (let i = 0; i < 3; i++) {}" 10
+def testForOfLoop : IO Unit := expectNoCFCode "for (const x of [1,2,3]) {}" 10
 def testForInLoop : IO Unit := expectCFCode "for (const k in {a:1}) {}" 10
-def testWhileLoop : IO Unit := expectCFCode "while (true) {}" 10
-def testDoWhileLoop : IO Unit := expectCFCode "do {} while (false);" 10
+def testWhileLoop : IO Unit := expectNoCFCode "while (true) {}" 10
+def testDoWhileLoop : IO Unit := expectNoCFCode "do {} while (false);" 10
 
 -- TH0060 fires only for throws inside an `annotatedFuncDecl` whose
 -- `throwsAnn = .absent`, so the test source wraps the throw in a function.

--- a/Test/Emit/LeanEmitTopLevelTest.lean
+++ b/Test/Emit/LeanEmitTopLevelTest.lean
@@ -1,6 +1,15 @@
-import Thales.Emit.LeanSyntax
+/-
+  Test/Emit/LeanEmitTopLevelTest.lean
+  Exercises the top-level `def main` IO do-block: the `ioDo`/`doExpr` IR
+  rendering, and the `emitIOBodyDo`/partition lowering of module-level
+  mutation, loops, and `console.log` (#49).
+-/
+import Thales.Emit.Lean
+import Thales.Parser.Native
 
+open Thales.Emit
 open Thales.Emit.LeanSyntax
+open Thales.Parser
 
 -- `ioDo` renders a plain `do` block; `doExpr` renders a bare action.
 /-- info: do
@@ -10,3 +19,61 @@ open Thales.Emit.LeanSyntax
 #eval IO.println (renderExpr (.ioDo [
   .doExpr (.app (.var "consoleLog") [.var "x"]),
   .doExpr (.app (.var "IO.println") [.str "hi"]) ]))
+
+/-- Parse a top-level program, emit it, and assert every needle appears. -/
+def expectEmitTop (src moduleName : String) (needles : List String) : IO Unit := do
+  match parseTSSourceNative src with
+  | .error e => throw (IO.userError s!"parse: {e}")
+  | .ok prog =>
+    let out := emit prog moduleName
+    for n in needles do
+      unless (out.splitOn n).length ≥ 2 do
+        throw (IO.userError s!"missing '{n}' in:\n{out}")
+
+/-- Assert a needle does NOT appear in the emitted output. -/
+def expectEmitTopAbsent (src moduleName : String) (needle : String) : IO Unit := do
+  match parseTSSourceNative src with
+  | .error e => throw (IO.userError s!"parse: {e}")
+  | .ok prog =>
+    let out := emit prog moduleName
+    if (out.splitOn needle).length ≥ 2 then
+      throw (IO.userError s!"unexpected '{needle}' in:\n{out}")
+
+-- A mutated top-level `let` becomes a `let mut` inside `def main`; a plain `=`
+-- reassignment becomes `:=`.
+def testTopLevelMutLet : IO Unit :=
+  expectEmitTop "let total = 0; total = total + 1; console.log(total);" "M"
+    ["def main : IO Unit", "let mut total", "total := (total +", "consoleLog total"]
+
+-- A for-of over an array literal becomes `for x in … do`; the `+=` body
+-- becomes a `:=` reassignment.
+def testTopLevelForOf : IO Unit :=
+  expectEmitTop "let total = 0; for (const x of [1, 2, 3]) { total += x; } console.log(total);" "M"
+    ["let mut total", "for x in", "total := (total + x)", "consoleLog total"]
+
+-- A canonical `for` becomes `for i in [0:…] do`.
+def testTopLevelCanonicalFor : IO Unit :=
+  expectEmitTop "for (let i = 0; i < 3; i++) { console.log(i); }" "M"
+    ["def main : IO Unit", "for i in", "consoleLog"]
+
+-- A bare top-level `console.log` is preserved as a `consoleLog` action inside
+-- `main` (not dropped, unlike the pure function-body path).
+def testTopLevelConsoleLog : IO Unit :=
+  expectEmitTop "console.log(42);" "M"
+    ["def main : IO Unit", "consoleLog", "#eval main"]
+
+-- A non-mutated `const` is hoisted as a top-level `def`, NOT lowered into
+-- `main` as a `let`.
+def testTopLevelConstHoisted : IO Unit :=
+  expectEmitTop "const base = 3; console.log(base);" "M"
+    ["def base", "def main : IO Unit", "consoleLog base"]
+
+def testTopLevelConstNotInMain : IO Unit :=
+  expectEmitTopAbsent "const base = 3; console.log(base);" "M" "let base"
+
+#eval testTopLevelMutLet
+#eval testTopLevelForOf
+#eval testTopLevelCanonicalFor
+#eval testTopLevelConsoleLog
+#eval testTopLevelConstHoisted
+#eval testTopLevelConstNotInMain

--- a/Test/Emit/LeanEmitTopLevelTest.lean
+++ b/Test/Emit/LeanEmitTopLevelTest.lean
@@ -1,0 +1,12 @@
+import Thales.Emit.LeanSyntax
+
+open Thales.Emit.LeanSyntax
+
+-- `ioDo` renders a plain `do` block; `doExpr` renders a bare action.
+/-- info: do
+  (consoleLog x)
+  (IO.println "hi") -/
+#guard_msgs in
+#eval IO.println (renderExpr (.ioDo [
+  .doExpr (.app (.var "consoleLog") [.var "x"]),
+  .doExpr (.app (.var "IO.println") [.str "hi"]) ]))

--- a/Test/Emit/LoopSubsetCheckTest.lean
+++ b/Test/Emit/LoopSubsetCheckTest.lean
@@ -204,10 +204,11 @@ def testGeneralForContinueTH0010 : IO Unit := expectTH
   "function f(n: number): number { let t = 0; for (let i = n; i > 0; i -= 2) { if (i > 4) { continue; } t += i; } return t; }"
   ["TH0010"]
 
--- ── Case 26: module-level while → TH0010 (no function context) ──
-def testTopLevelWhileTH0010 : IO Unit := expectTH
+-- ── Case 26: module-level while is now admitted — lowered into the `main`
+-- IO do-block on the same terms as a function body (#49). No TH0010. ──
+def testTopLevelWhileAdmitted : IO Unit := expectTH
   "while (false) { }"
-  ["TH0010"]
+  []
 
 #eval testForOfAdmitted
 #eval testCanonicalForAdmitted
@@ -234,4 +235,4 @@ def testTopLevelWhileTH0010 : IO Unit := expectTH
 #eval testGeneralForAdmitted
 #eval testTotalGeneralForTH0068
 #eval testGeneralForContinueTH0010
-#eval testTopLevelWhileTH0010
+#eval testTopLevelWhileAdmitted

--- a/Test/Emit/MutationCheckTest.lean
+++ b/Test/Emit/MutationCheckTest.lean
@@ -31,11 +31,12 @@ def expectNoCode (src : String) (code : Nat) : IO Unit := do
       let formatted := (diags.map (·.format "test.ts")).toList
       throw (IO.userError s!"expected no TH{code}, got: {formatted}")
 
--- Module-level mutation: always TH0001
-def testReassignment : IO Unit := expectCode "let x = 0; x = 1;" 1
-def testCompoundAssignment : IO Unit := expectCode "let x = 0; x += 1;" 1
-def testIncrement : IO Unit := expectCode "let x = 0; x++;" 1
-def testDecrement : IO Unit := expectCode "let x = 0; --x;" 1
+-- Module-level mutation: now in-subset, lowered into the `main` IO do-block
+-- on the same terms as a function body (#49) — no TH0001.
+def testReassignment : IO Unit := expectNoCode "let x = 0; x = 1;" 1
+def testCompoundAssignment : IO Unit := expectNoCode "let x = 0; x += 1;" 1
+def testIncrement : IO Unit := expectNoCode "let x = 0; x++;" 1
+def testDecrement : IO Unit := expectNoCode "let x = 0; --x;" 1
 
 -- Member/method mutation: unchanged
 def testArrayIndexWrite : IO Unit := expectCode "const arr = [1]; arr[0] = 2;" 2

--- a/Test/Examples/fixtures/directive-in-string/input.ts
+++ b/Test/Examples/fixtures/directive-in-string/input.ts
@@ -1,7 +1,7 @@
 const warning = `
-  // @thales-expect-error TH0001 (template literal; must not register)
+  // @thales-expect-error TH0003 (template literal; must not register)
 `;
-let x = 0;
-// @thales-expect-error TH0001
-x = 1;
+const o = { a: 0 };
+// @thales-expect-error TH0003
+o.a = 1;
 console.log(warning);

--- a/Test/Examples/fixtures/directive-match/input.ts
+++ b/Test/Examples/fixtures/directive-match/input.ts
@@ -1,3 +1,3 @@
-let x = 0;
-// @thales-expect-error TH0001
-x = 1;
+const o = { a: 0 };
+// @thales-expect-error TH0003
+o.a = 1;

--- a/Test/Examples/fixtures/directive-no-code/input.ts
+++ b/Test/Examples/fixtures/directive-no-code/input.ts
@@ -1,3 +1,3 @@
-let x = 0;
+const o = { a: 0 };
 // @thales-expect-error
-x = 1;
+o.a = 1;

--- a/Test/Examples/fixtures/subset-rejected/input.ts
+++ b/Test/Examples/fixtures/subset-rejected/input.ts
@@ -1,3 +1,3 @@
-let counter: number = 0;
-counter = counter + 1;
-console.log(counter);
+const o = { a: 0 };
+o.a = 1;
+console.log(o.a);

--- a/Thales/Emit/Lean.lean
+++ b/Thales/Emit/Lean.lean
@@ -2037,6 +2037,26 @@ private def ldeclName : LDecl → Option String
   | .abbrev_ n .. => some n
   | _ => none
 
+/-- The JS statement a top-level item contributes to `def main`, or `none` if
+    it is a hoisted declaration (function / type / interface / enum, a `const`,
+    or a non-mutated `let` — all emitted as top-level `def`s). A `let` mutated
+    somewhere at module level (`mutatedTop`) is reconstructed as a
+    `.variableDecl` so `emitIOVarDeclDo` lowers it to a `let mut` inside `main`
+    (#49). -/
+private def mainStreamStmt (mutatedTop : Std.HashSet String) : TSStatement → Option Statement
+  | .js (.variableDecl _) => none  -- top-level var decls arrive as annotatedVarDecl
+  | .js s =>
+      match s with
+      | .exprStmt _ _ | .ifStmt _ _ _ _ | .tryStmt _ _ _ _
+      | .forOfStmt _ _ _ _ _ | .forStmt _ _ _ _ _
+      | .whileStmt _ _ _ | .doWhileStmt _ _ _ | .blockStmt _ _ => some s
+      | _ => none
+  | .annotatedVarDecl b _kind name typeAnn (some init) =>
+      if mutatedTop.contains name then
+        some (.variableDecl (.mk b [.mk b (.identifier { name }) (some init) (typeAnn.map (·.type))] .let_))
+      else none
+  | _ => none
+
 /-- Walk the program and produce a Lean module (structural form). -/
 def buildModule (prog : TSProgram) (moduleName : String) : LModule :=
   let resolvedAliases := resolveAliases prog.body
@@ -2111,7 +2131,16 @@ def buildModule (prog : TSProgram) (moduleName : String) : LModule :=
   let bodyForEmit : List TSStatement := prog.body.map fun s => match s with
     | .exportDecl _ inner => inner
     | other => other
-  let decls : List LDecl := bodyForEmit.zipIdx.flatMap fun (ts, idx) =>
+  -- Module-level mutation/loop analysis over the executable top-level JS
+  -- statements, treated as one block (no params at module level). Drives the
+  -- `let mut` vs hoisted-`def` split for top-level `let`s (#49).
+  let topJsStmts : List Statement := bodyForEmit.filterMap fun
+    | .js s => some s
+    | _ => none
+  let moduleInfo : EscapeAnalysis.MutationInfo :=
+    EscapeAnalysis.analyze [] (.blockStmt {} topJsStmts)
+  let mutatedTop : Std.HashSet String := moduleInfo.mutated
+  let decls : List LDecl := bodyForEmit.flatMap fun ts =>
     match ts with
     | .typeAliasDecl _ name tps ty =>
         let bodyTy := resolvedAliases.getD name ty
@@ -2129,6 +2158,8 @@ def buildModule (prog : TSProgram) (moduleName : String) : LModule :=
           | .absent      => []
         optToList (emitFuncDecl resolvedAliases name (typeParamNames tps) simpleParams retTy body throws funcThrowsEnv funcParamTypes total funcRetTypes topBindingsNorm structFields)
     | .annotatedVarDecl _ _kind name typeAnn (some init) =>
+        if mutatedTop.contains name then []   -- mutated let → lowered inside `main`
+        else
         match init with
         | .arrowFunctionExpr _ arrowParams body _isExpr async arrowRetAnn =>
             if async then []
@@ -2159,114 +2190,9 @@ def buildModule (prog : TSProgram) (moduleName : String) : LModule :=
                 -- `(unsupported expr)` would not elaborate).
                 let initExpr := emitExprEnv topEnv other
                 [.def_ name [] [] .inferred initExpr]
-    -- Bare top-level call expression like `asBit(2);`. The TS surface
-    -- semantics is "evaluate for its side effect (throw)". Lean has no
-    -- direct top-level statements, so we emit `#eval (...)` so any panic
-    -- surfaces at module elaboration. Skip when the callee is `console.log`
-    -- (handled below) or an identifier we haven't seen.
-    | .js (.exprStmt _ (call@(.callExpr _ (.identifier _ fname) callArgs _))) =>
-        -- Bare `f(args);` at top level is a side-effect statement. For the
-        -- throwing prelude constructors `asInteger`/`asNatural`/`asByte`/
-        -- `asBit`, emit the IO-effect form which `IO.Process.exit 1`s on
-        -- failure (so the harness sees a nonzero exit, matching tsx's
-        -- RangeError). For `@throws` callees, match on the Except. Otherwise
-        -- evaluate the call for any panic side-effect from `as<T>`.
-        let asEffectName : Option String := match fname with
-          | "asInteger" => some "asIntegerEffect"
-          | "asNatural" => some "asNaturalEffect"
-          | "asByte" => some "asByteEffect"
-          | "asBit" => some "asBitEffect"
-          | _ => none
-        match asEffectName with
-        | some effFn =>
-            let leanArgs := callArgs.map (emitExprEnv topEnv)
-            [.eval_ (.app (.var effFn) leanArgs)]
-        | none =>
-        match funcThrowsEnv.get? fname with
-        | some _ =>
-            let callLExpr := emitExprEnv topEnv call
-            let okArm : LPattern × LExpr := (.ctor "ok" [.wildcard], .app (.var "pure") [.var "()"])
-            let errArm : LPattern × LExpr := (.ctor "error" [.wildcard],
-              .app (.var "panic!") [.str s!"throw from {fname}"])
-            [.eval_ (.match_ callLExpr [okArm, errArm])]
-        | none =>
-            [.eval_ (emitExprEnv topEnv call)]
-    -- Top-level `console.log(arg)` → `#eval consoleLog arg`. When `arg` is a
-    -- call to a `@throws` function, match on the Except to extract the value.
-    -- Multi-arg `console.log(a, b, c)` lowers to `consoleLogN [show a, …]`
-    -- which prints space-separated values, matching JS behavior.
-    | .js (.exprStmt _ (.callExpr _
-        (.memberExpr _ (.identifier _ "console") (.identifier _ "log") false _)
-        args _)) =>
-        match args with
-        | [arg] =>
-            let calleeNameOpt : Option String := match arg with
-              | .callExpr _ (.identifier _ fname) _ _ => funcThrowsEnv.get? fname |>.map (fun _ => fname)
-              | _ => none
-            let argExpr := emitExprEnv topEnv arg
-            match calleeNameOpt with
-            | some _fname =>
-                let okArm : LPattern × LExpr := (.ctor "ok" [.var "v__"], .app (.var "consoleLog") [.var "v__"])
-                let errArm : LPattern × LExpr := (.ctor "error" [.wildcard], .app (.var "pure") [.var "()"])
-                [.eval_ (.match_ argExpr [okArm, errArm])]
-            | none =>
-                [.eval_ (.app (.var "consoleLog") [argExpr])]
-        | _ :: _ =>
-            -- Multi-arg console.log: lower each arg to `JSShow.jsShow` and
-            -- intercalate with spaces, then `IO.println`. We construct this
-            -- via Thales.TS.consoleLogN, defined alongside `consoleLog` in
-            -- Runtime.lean.
-            let argExprs := args.map (emitExprEnv topEnv)
-            let listLit := mkListLit (argExprs.map fun e => .app (.var "JSShow.jsShow") [e])
-            [.eval_ (.app (.var "consoleLogN") [listLit])]
-        | _     => []
-    -- Top-level `try { console.log(f(args)) } catch (e) { console.log(g) }`,
-    -- where `f` is `@throws`, lowers to a `#eval match` over the Except result.
-    | .js (.tryStmt _
-        (tryBlock)
-        (some (CatchClause.mk _ paramOpt catchBody _catchType))
-        _finalizer) =>
-        let tryStmts := match tryBlock with
-          | .blockStmt _ stmts => stmts
-          | other => [other]
-        let catchVar : String := match paramOpt with
-          | some (.identifier id) => id.name
-          | _ => "e__"
-        let catchStmts := match catchBody with
-          | .blockStmt _ stmts => stmts
-          | other => [other]
-        let catchEffect : Option LExpr := catchStmts.findSome? fun s =>
-          match s with
-          | .exprStmt _ (.callExpr _
-              (.memberExpr _ (.identifier _ "console") (.identifier _ "log") false _)
-              [catchArg] _) =>
-              some (.app (.var "consoleLog") [emitExprEnv topEnv catchArg])
-          | _ => none
-        optToList <| tryStmts.findSome? fun s =>
-          match s with
-          | .exprStmt _ (.callExpr _
-              (.memberExpr _ (.identifier _ "console") (.identifier _ "log") false _)
-              [(.callExpr _ (.identifier _ calleeName) _ _)] _) =>
-              match funcThrowsEnv.get? calleeName with
-              | some _ =>
-                  let callLExpr := match s with
-                    | .exprStmt _ (.callExpr _ _ [cArg] _) => emitExprEnv topEnv cArg
-                    | _ => .var "()"
-                  let okArm : LPattern × LExpr :=
-                    (.ctor "ok" [.var "v__"], .app (.var "consoleLog") [.var "v__"])
-                  let errArm : LPattern × LExpr :=
-                    (.ctor "error" [.var catchVar],
-                     catchEffect.getD (.app (.var "pure") [.var "()"]))
-                  some (.eval_ (.match_ callLExpr [okArm, errArm]))
-              | none => none
-          | _ => none
-    -- Top-level `if (cond) { … }` lowers to `#eval <IO action>`, preserving
-    -- `console.log`s inside the branch and any refinement-narrowing. Seed the
-    -- dite-binder counter per item so distinct top-level `if`s get distinct
-    -- binder names (`h0`, `h16`, …) and never collide.
-    | .js (.ifStmt _ cond thn elsOpt) =>
-        let ifEnv : EmitEnv := { topEnv with diteBinderCounter := idx * 16 }
-        [.eval_ (emitIfIO ifEnv cond thn elsOpt [])]
+    -- Executable top-level statements (bare calls, `console.log`, `try`/`catch`,
+    -- `if`, loops, mutation) are no longer emitted here as scattered `#eval`s;
+    -- they flow into the single `def main` do-block below (#49).
     | _ => []
   -- For each trailing `export { local as public }` (local ≠ public), emit a
   -- public alias `def public := local`, appended after the originals so the
@@ -2286,6 +2212,26 @@ def buildModule (prog : TSProgram) (moduleName : String) : LModule :=
         | some n => if exportedNames.contains n then d else .private_ d
         | none => d
     else decls
+  -- Collect executable top-level statements (source order) into `def main`,
+  -- appended after the hoisted decls (so `main` can reference them) and after
+  -- the `private`-marking pass (so `main` and its `#eval` stay public). A
+  -- module with no executable statements is a pure library: no `main`, no
+  -- `#eval` (#49).
+  let mainStmts : List Statement := bodyForEmit.filterMap (mainStreamStmt mutatedTop)
+  let mainDo : List LDoStmt := emitIOBodyDo topEnv moduleInfo mainStmts
+  -- The entry point's name must not collide with a user `const main`/`function
+  -- main` (a common idiom: `const main = () => …; console.log(main())`), so
+  -- pick the first candidate that is not a top-level declared name.
+  let topNames : Std.HashSet String := bodyForEmit.foldl (fun acc s =>
+    match declName s with | some n => acc.insert n | none => acc) {}
+  let entryName : String :=
+    (["main", "_thalesMain", "_thalesEntry", "_thalesMain'"].find?
+      (fun n => !topNames.contains n)).getD "_thalesMain"
+  let decls : List LDecl :=
+    if mainDo.isEmpty then decls
+    else decls
+      ++ [ .def_ entryName [] [] (.const "IO Unit") (.ioDo mainDo),
+           .eval_ (.var entryName) ]
   let body : LDecl :=
     if moduleName.isEmpty then .namespace_ "Input" decls
     else .namespace_ moduleName decls

--- a/Thales/Emit/Lean.lean
+++ b/Thales/Emit/Lean.lean
@@ -1544,6 +1544,107 @@ private partial def stmtsHaveIO : List Statement → Bool
         | _ => false
       hereIO || stmtsHaveIO rest
 
+/-- Top-level `console.log(arg)` as a do-element (#49). A faithful port of
+    `buildModule`'s `console.log` arm: a single argument that is a `@throws`
+    call matches on its `Except`; a single plain argument is `consoleLog arg`;
+    multiple arguments lower to `consoleLogN [JSShow.jsShow …]`. Returns `none`
+    if `e` is not a `console.log` call (or has no arguments). -/
+private def consoleLogDoStmt (env : EmitEnv) (e : Expression) : Option LDoStmt :=
+  match e with
+  | .callExpr _
+      (.memberExpr _ (.identifier _ "console") (.identifier _ "log") false _)
+      args _ =>
+      match args with
+      | [arg] =>
+          let calleeNameOpt : Option String := match arg with
+            | .callExpr _ (.identifier _ fname) _ _ => env.funcThrowsEnv.get? fname |>.map (fun _ => fname)
+            | _ => none
+          let argExpr := emitExprEnv env arg
+          match calleeNameOpt with
+          | some _ =>
+              let okArm : LPattern × List LDoStmt :=
+                (.ctor "ok" [.var "v__"], [.doExpr (.app (.var "consoleLog") [.var "v__"])])
+              let errArm : LPattern × List LDoStmt :=
+                (.ctor "error" [.wildcard], [.doExpr (.app (.var "pure") [.var "()"])])
+              some (.matchDo argExpr [okArm, errArm])
+          | none => some (.doExpr (.app (.var "consoleLog") [argExpr]))
+      | _ :: _ =>
+          let argExprs := args.map (emitExprEnv env)
+          let listLit := mkListLit (argExprs.map fun e => .app (.var "JSShow.jsShow") [e])
+          some (.doExpr (.app (.var "consoleLogN") [listLit]))
+      | [] => none
+  | _ => none
+
+/-- Bare top-level call as a do-element (#49). A faithful port of
+    `buildModule`'s bare-call arm: the throwing-prelude constructors run their
+    `*Effect`; `@throws` callees match on the `Except` (panicking on `.error`);
+    plain calls are evaluated for side effects. `none` if `e` is not an
+    identifier-headed call. -/
+private def bareCallDoStmt (env : EmitEnv) (e : Expression) : Option LDoStmt :=
+  match e with
+  | .callExpr _ (.identifier _ fname) callArgs _ =>
+      let asEffectName : Option String := match fname with
+        | "asInteger" => some "asIntegerEffect"
+        | "asNatural" => some "asNaturalEffect"
+        | "asByte" => some "asByteEffect"
+        | "asBit" => some "asBitEffect"
+        | _ => none
+      match asEffectName with
+      | some effFn => some (.doExpr (.app (.var effFn) (callArgs.map (emitExprEnv env))))
+      | none =>
+        match env.funcThrowsEnv.get? fname with
+        | some _ =>
+            let callLExpr := emitExprEnv env e
+            let okArm : LPattern × List LDoStmt :=
+              (.ctor "ok" [.wildcard], [.doExpr (.app (.var "pure") [.var "()"])])
+            let errArm : LPattern × List LDoStmt :=
+              (.ctor "error" [.wildcard], [.doExpr (.app (.var "panic!") [.str s!"throw from {fname}"])])
+            some (.matchDo callLExpr [okArm, errArm])
+        | none => some (.doExpr (emitExprEnv env e))
+  | _ => none
+
+/-- Top-level `try { console.log(f(args)) } catch (e) { console.log(g) }` where
+    `f` is `@throws`, as a do-element (#49). A faithful port of `buildModule`'s
+    try/catch arm: a `match` on the `Except`, with the catch body's
+    `console.log` as the `.error` action. `none` if no such shape. -/
+private def tryCatchDoStmt (env : EmitEnv) : Statement → Option LDoStmt
+  | .tryStmt _ tryBlock (some (CatchClause.mk _ paramOpt catchBody _catchType)) _finalizer =>
+      let tryStmts := match tryBlock with
+        | .blockStmt _ stmts => stmts
+        | other => [other]
+      let catchVar : String := match paramOpt with
+        | some (.identifier id) => id.name
+        | _ => "e__"
+      let catchStmts := match catchBody with
+        | .blockStmt _ stmts => stmts
+        | other => [other]
+      let catchEffect : Option LExpr := catchStmts.findSome? fun s =>
+        match s with
+        | .exprStmt _ (.callExpr _
+            (.memberExpr _ (.identifier _ "console") (.identifier _ "log") false _)
+            [catchArg] _) =>
+            some (.app (.var "consoleLog") [emitExprEnv env catchArg])
+        | _ => none
+      tryStmts.findSome? fun s =>
+        match s with
+        | .exprStmt _ (.callExpr _
+            (.memberExpr _ (.identifier _ "console") (.identifier _ "log") false _)
+            [(.callExpr _ (.identifier _ calleeName) _ _)] _) =>
+            match env.funcThrowsEnv.get? calleeName with
+            | some _ =>
+                let callLExpr := match s with
+                  | .exprStmt _ (.callExpr _ _ [cArg] _) => emitExprEnv env cArg
+                  | _ => .var "()"
+                let okArm : LPattern × List LDoStmt :=
+                  (.ctor "ok" [.var "v__"], [.doExpr (.app (.var "consoleLog") [.var "v__"])])
+                let errArm : LPattern × List LDoStmt :=
+                  (.ctor "error" [.var catchVar],
+                   [.doExpr (catchEffect.getD (.app (.var "pure") [.var "()"]))])
+                some (.matchDo callLExpr [okArm, errArm])
+            | none => none
+        | _ => none
+  | _ => none
+
 mutual
 
 /-- IO-aware sibling of `emitBodyEnv`: lower a top-level statement list into a
@@ -1602,6 +1703,131 @@ partial def emitIfIO (env : EmitEnv) (cond : Expression) (thn : Statement)
         .ite (emitExprEnv env cond) (emitIOBodyEnv env thnStmts) elseExpr
   if stmtsHaveIO rest then .doSeq [ifAct, emitIOBodyEnv env rest]
   else ifAct
+
+end
+
+mutual
+
+/-- Lower a top-level statement list into the statements of `def main : IO Unit
+    := do …` (#49). The single host for all executable module-level code.
+    Mirrors `emitBodyDo` (the `Id.run do` emitter for function bodies) but:
+    (a) targets a plain IO `do`, so it keeps `console.log` and bare calls
+    instead of dropping them; (b) has no `return` value; (c) handles top-level
+    `try`/`catch`. The mutation/loop arms are verbatim ports of `emitBodyDo`'s
+    with the recursion retargeted to `emitIOBodyDo`. -/
+partial def emitIOBodyDo (env : EmitEnv) (info : EscapeAnalysis.MutationInfo)
+    : List Statement → List LDoStmt
+  | [] => []
+  | .variableDecl (.mk _ decls _) :: rest =>
+      emitIOVarDeclDo env info decls rest
+  -- `x = e` / `x OP= e`
+  | .exprStmt _ (.assignmentExpr b op (.identifier _ name) rhs) :: rest =>
+      let value : LExpr :=
+        match op.compoundToBinary with
+        | some binOp => emitExprEnv env (.binaryExpr b binOp (.identifier b name) rhs)
+        | none => emitExprEnv env rhs
+      .assign name value :: emitIOBodyDo env info rest
+  -- `x++` / `x--`
+  | .exprStmt _ (.updateExpr b op (.identifier _ name) _) :: rest =>
+      let one : Expression := .literal b (.number 1) "1"
+      let binOp : BinaryOperator := match op with | .inc => .add | .dec => .sub
+      .assign name (emitExprEnv env (.binaryExpr b binOp (.identifier b name) one))
+        :: emitIOBodyDo env info rest
+  | .blockStmt _ inner :: rest => emitIOBodyDo env info (inner ++ rest)
+  -- top-level try/catch (port of buildModule's `#eval match` arm)
+  | (s@(.tryStmt _ _ _ _)) :: rest =>
+      match tryCatchDoStmt env s with
+      | some stmt => stmt :: emitIOBodyDo env info rest
+      | none => emitIOBodyDo env info rest
+  -- `if`: a plain boolean condition threads mutation via `ifDo`; a narrowing
+  -- condition (refinement predicate or null-test) reuses `emitIfIO` embedded
+  -- as a bare IO action (parity path — preserves the `dite` narrowing).
+  | .ifStmt _ cond thn elsOpt :: rest =>
+      match detectRefinementPredicate cond, nullCheckVar cond with
+      | none, none =>
+          let thnDo := emitIOBodyDo env info (blockStmts thn)
+          let elsDo := match elsOpt with
+            | some els => emitIOBodyDo env info (blockStmts els)
+            | none => []
+          .ifDo (emitExprEnv env cond) thnDo elsDo :: emitIOBodyDo env info rest
+      | _, _ =>
+          .doExpr (emitIfIO env cond thn elsOpt []) :: emitIOBodyDo env info rest
+  -- console.log / bare calls / other expr statements (KEPT, unlike emitBodyDo)
+  | .exprStmt _ e :: rest =>
+      match consoleLogDoStmt env e with
+      | some s => s :: emitIOBodyDo env info rest
+      | none =>
+        match bareCallDoStmt env e with
+        | some s => s :: emitIOBodyDo env info rest
+        | none => emitIOBodyDo env info rest   -- effect-free expr: drop
+  -- #25 loops — verbatim ports of emitBodyDo arms with emitIOBodyDo recursion
+  | s@(.forOfStmt _ _ _ _ _) :: rest | s@(.forStmt _ _ _ _ _) :: rest =>
+      match LoopShape.classifyLoop s with
+      | .forOf x rhs rhsExpr body =>
+          let bodyEnv? : Option EmitEnv :=
+            match rhs with
+            | .arrayLit _ => some env
+            | .ident arrName =>
+                (arrayElemTy? env arrName).map fun et =>
+                  { env with bindingEnv := env.bindingEnv.insert x et }
+          match bodyEnv? with
+          | none => unloweredDoStmt
+          | some env' =>
+              .forDo x (emitExprEnv env rhsExpr) (emitIOBodyDo env' info (blockStmts body))
+                :: emitIOBodyDo env info rest
+      | .canonicalFor i bound body =>
+          let iter? : Option LExpr :=
+            match bound with
+            | .inl n => some (.rangeTo (.int (Int.ofNat n)))
+            | .inr arrName =>
+                if (arrayElemTy? env arrName).isSome then
+                  some (.rangeTo (.proj (.var arrName) "size")) else none
+          match iter? with
+          | none => unloweredDoStmt
+          | some iterExpr =>
+              let shim : LDoStmt := .letPure i (some (.const "Float")) (.proj (.var i) "toFloat")
+              let env' : EmitEnv := { env with bindingEnv := env.bindingEnv.insert i .number }
+              .forDo i iterExpr (shim :: emitIOBodyDo env' info (blockStmts body))
+                :: emitIOBodyDo env info rest
+      | .notLowerable =>
+          match LoopShape.desugarGeneralFor s with
+          | some desugared => emitIOBodyDo env info (desugared ++ rest)
+          | none => unloweredDoStmt
+  | .whileStmt _ test body :: rest =>
+      if LoopShape.hasLabeledBreakOrContinue body then unloweredDoStmt
+      else .whileDo (emitExprEnv env test) (emitIOBodyDo env info (blockStmts body))
+        :: emitIOBodyDo env info rest
+  | .doWhileStmt _ body test :: rest =>
+      if LoopShape.hasLabeledBreakOrContinue body
+          || LoopShape.hasOwnUnlabeledContinue body then unloweredDoStmt
+      else
+        match emitExprEnv env test with
+        | .bool true => .whileDo (.bool true) (emitIOBodyDo env info (blockStmts body))
+            :: emitIOBodyDo env info rest
+        | leanTest => .repeatUntilDo (emitIOBodyDo env info (blockStmts body))
+            (.app (.var "not") [leanTest]) :: emitIOBodyDo env info rest
+  | .breakStmt _ none :: _ => [.breakDo]
+  | .continueStmt _ none :: _ => [.continueDo]
+  | .emptyStmt _ :: rest | .debuggerStmt _ :: rest => emitIOBodyDo env info rest
+  | _ :: _ => unloweredDoStmt
+
+/-- Top-level declarator lowering (#49): mutated names become `let mut`,
+    everything else an immutable `let`. Mirrors `emitVarDeclDo`. -/
+partial def emitIOVarDeclDo (env : EmitEnv) (info : EscapeAnalysis.MutationInfo)
+    (decls : List VariableDeclarator) (rest : List Statement) : List LDoStmt :=
+  match decls with
+  | [] => emitIOBodyDo env info rest
+  | .mk _ (.identifier id) init typeAnnotation :: moreDecls =>
+      let ty := typeAnnotation.map emitType
+      let initExpr := match init with
+        | some e => emitExprWithExpectedTy env typeAnnotation e
+        | none   => .var "()"
+      let env' := recordDeclBinding env id.name typeAnnotation init
+      let bind := if info.mutated.contains id.name
+        then LDoStmt.letMut id.name ty initExpr
+        else LDoStmt.letPure id.name ty initExpr
+      bind :: emitIOVarDeclDo env' info moreDecls rest
+  | _ :: moreDecls => emitIOVarDeclDo env info moreDecls rest
 
 end
 

--- a/Thales/Emit/Lean.lean
+++ b/Thales/Emit/Lean.lean
@@ -2131,14 +2131,14 @@ def buildModule (prog : TSProgram) (moduleName : String) : LModule :=
   let bodyForEmit : List TSStatement := prog.body.map fun s => match s with
     | .exportDecl _ inner => inner
     | other => other
-  -- Module-level mutation/loop analysis over the executable top-level JS
-  -- statements, treated as one block (no params at module level). Drives the
-  -- `let mut` vs hoisted-`def` split for top-level `let`s (#49).
-  let topJsStmts : List Statement := bodyForEmit.filterMap fun
-    | .js s => some s
-    | _ => none
+  -- Module-level mutation/loop analysis over the executable top-level
+  -- statements (var decls reconstructed so their bindings are seen), treated
+  -- as one block (no params at module level). The SAME block the subset
+  -- checker analyzes (#49). Drives the `let mut` vs hoisted-`def` split for
+  -- top-level `let`s.
+  let moduleStmts : List Statement := moduleExecutableStatements prog.body
   let moduleInfo : EscapeAnalysis.MutationInfo :=
-    EscapeAnalysis.analyze [] (.blockStmt {} topJsStmts)
+    EscapeAnalysis.analyze [] (.blockStmt {} moduleStmts)
   let mutatedTop : Std.HashSet String := moduleInfo.mutated
   let decls : List LDecl := bodyForEmit.flatMap fun ts =>
     match ts with

--- a/Thales/Emit/LeanSyntax.lean
+++ b/Thales/Emit/LeanSyntax.lean
@@ -413,7 +413,14 @@ mutual
           | none   => ""
         s!"let {escapeIdent n}{annot} := {renderExpr v}"
     | .assign n v => s!"{escapeIdent n} := {renderExpr v}"
-    | .doExpr v => renderExpr v
+    -- A bare IO action must render as a SINGLE do-element. A multi-line action
+    -- (a `dite`/`match`/`let` chain from an embedded `emitIfIO`) is wrapped in
+    -- parens so its layout cannot leak into the whitespace-sensitive do-block
+    -- and orphan a trailing `else`; single-line actions (already-parenthesized
+    -- `app`s like `consoleLog x`) render as-is.
+    | .doExpr v =>
+        let s := renderExpr v
+        if s.any (· == '\n') then s!"({s})" else s
     | .ret v => s!"return {renderExpr v}"
     | .ifDo c thn [] =>
         s!"if {renderExpr c} then\n{indent (renderDoStmts thn)}"

--- a/Thales/Emit/LeanSyntax.lean
+++ b/Thales/Emit/LeanSyntax.lean
@@ -74,6 +74,9 @@ inductive LExpr where
   -- end in a `ret` (the emitter guarantees this; a fall-through path would
   -- render a do-block with no value).
   | idRunDo (stmts : List LDoStmt)
+  -- A plain `do …` block (IO, not `Id.run`). Hosts all executable top-level
+  -- statements lowered into `def main : IO Unit := do …` (#49).
+  | ioDo (stmts : List LDoStmt)
   -- Integer range `[0:n]` for `for` loops (#25). Renders as `[0:{n}]`.
   -- Bracket-delimited, so atomic — renderExprAtom must NOT wrap it in parens.
   | rangeTo (stop : LExpr)
@@ -86,6 +89,7 @@ inductive LDoStmt where
   | letMut (name : String) (ty : Option LType) (value : LExpr)   -- let mut n := e
   | letPure (name : String) (ty : Option LType) (value : LExpr)  -- let n := e
   | assign (name : String) (value : LExpr)                       -- n := e
+  | doExpr (value : LExpr)                                       -- bare IO action: e
   | ret (value : LExpr)                                          -- return e
   -- `if c then …` / `if c then … else …`; an empty branch renders `pure ()`
   | ifDo (cond : LExpr) (thn : List LDoStmt) (els : List LDoStmt)
@@ -212,10 +216,11 @@ mutual
     | .dite_ _ c t e        => c.collectUnsupported ++ t.collectUnsupported ++ e.collectUnsupported
     | .doSeq stmts          => stmts.foldl (fun a e => a ++ e.collectUnsupported) []
     | .idRunDo stmts        => stmts.foldl (fun a s => a ++ s.collectUnsupported) []
+    | .ioDo stmts           => stmts.foldl (fun a s => a ++ s.collectUnsupported) []
     | .rangeTo stop         => stop.collectUnsupported
     | .var _ | .int _ | .float _ | .str _ | .bool _ => []
   partial def LDoStmt.collectUnsupported : LDoStmt → List String
-    | .letMut _ _ v | .letPure _ _ v | .assign _ v | .ret v => v.collectUnsupported
+    | .letMut _ _ v | .letPure _ _ v | .assign _ v | .ret v | .doExpr v => v.collectUnsupported
     | .ifDo c thn els       => c.collectUnsupported
                                  ++ thn.foldl (fun a s => a ++ s.collectUnsupported) []
                                  ++ els.foldl (fun a s => a ++ s.collectUnsupported) []
@@ -386,6 +391,8 @@ mutual
         s!"(do\n{indent body})"
     | .idRunDo stmts =>
         s!"Id.run do\n{indent (renderDoStmts stmts)}"
+    | .ioDo stmts =>
+        s!"do\n{indent (renderDoStmts stmts)}"
     | .rangeTo stop =>
         s!"[0:{renderExpr stop}]"
 
@@ -406,6 +413,7 @@ mutual
           | none   => ""
         s!"let {escapeIdent n}{annot} := {renderExpr v}"
     | .assign n v => s!"{escapeIdent n} := {renderExpr v}"
+    | .doExpr v => renderExpr v
     | .ret v => s!"return {renderExpr v}"
     | .ifDo c thn [] =>
         s!"if {renderExpr c} then\n{indent (renderDoStmts thn)}"

--- a/Thales/Emit/SubsetCheck.lean
+++ b/Thales/Emit/SubsetCheck.lean
@@ -994,6 +994,17 @@ def checkTSStmtSwitch (aliasEnv : Std.HashMap String TSType) (ts : TSStatement)
   | .js s => checkSwitchStmt { aliasEnv, bindingEnv := {} } s
   | _ => #[]
 
+/-- A hoisted top-level declaration's source location and the free identifiers
+    referenced by its body/initializer, or `none` if the item is not a hoisted
+    declaration. A hoisted decl (`function`, or a `const`/`let` emitted as a
+    top-level `def`) is elaborated OUTSIDE `main`, so any reference it makes to
+    a top-level mutable `let` (a `main`-local `let mut`) is out of scope (#49). -/
+private partial def hoistedRefs : TSStatement → Option (Option SourceLocation × List String)
+  | .annotatedFuncDecl b _ _ _ _ body _ _ _ _ => some (b.loc, EscapeAnalysis.identsStmt body)
+  | .annotatedVarDecl b _ _ _ (some init) => some (b.loc, EscapeAnalysis.identsExpr init)
+  | .exportDecl _ inner => hoistedRefs inner
+  | _ => none
+
 /-- Walk a TSProgram and return all Thales-subset violations (raw,
     without directive post-processing). -/
 def subsetCheckRaw (prog : TSProgram) : Array Diagnostic :=
@@ -1002,8 +1013,20 @@ def subsetCheckRaw (prog : TSProgram) : Array Diagnostic :=
   -- Module-level mutation/loop info over the reconstructed executable top-level
   -- block — the SAME block `buildModule` lowers into `main` (#49).
   let moduleInfo := EscapeAnalysis.analyze [] (.blockStmt {} (moduleExecutableStatements prog.body))
+  -- TH0093: a hoisted declaration that reads a top-level mutated `let` would
+  -- emit a `def` referencing a `main`-local binding — reject up front rather
+  -- than emit uncompilable Lean.
+  let th0093 : Array Diagnostic := prog.body.foldl (fun acc ts =>
+    match hoistedRefs ts with
+    | some (loc, refs) =>
+        let refSet : Std.HashSet String := refs.foldl (·.insert ·) {}
+        refSet.fold (fun a n =>
+          if moduleInfo.mutated.contains n
+          then a.push (mkThalesDiag (.topLevelMutableReferencedByHoisted n) loc)
+          else a) acc
+    | none => acc) #[]
   prog.body.foldl (fun acc ts =>
-    acc ++ checkTSStmt aliasEnv topRecvEnv moduleInfo ts ++ checkTSStmtSwitch aliasEnv ts) #[]
+    acc ++ checkTSStmt aliasEnv topRecvEnv moduleInfo ts ++ checkTSStmtSwitch aliasEnv ts) th0093
 
 /-- Subset check with `@thales-expect-error` directives applied.
     Suppresses TH diagnostics on lines covered by matching directives and

--- a/Thales/Emit/SubsetCheck.lean
+++ b/Thales/Emit/SubsetCheck.lean
@@ -916,9 +916,19 @@ private def buildParamEnv
     `aliasEnv` is threaded in for for-of array-type resolution; `topRecvEnv`
     carries module-level annotation types for the TH0085 receiver check. -/
 def checkTSStmt (aliasEnv : Std.HashMap String TSType)
-    (topRecvEnv : Std.HashMap String TSType) (ts : TSStatement) : Array Diagnostic :=
+    (topRecvEnv : Std.HashMap String TSType)
+    (moduleInfo : EscapeAnalysis.MutationInfo) (ts : TSStatement) : Array Diagnostic :=
   match ts with
-  | .js s => checkStmt { aliasEnv := aliasEnv, recvEnv := topRecvEnv } s ++ shadowStmts {} [s]
+  | .js s =>
+    -- Module-level executable statement: admit the same mutation (#24) and
+    -- loop (#25) subset as a function body, using the whole-module mutation
+    -- info. `bindingEnv` is empty (no params at module level), so for-of over
+    -- a named array stays out of v1 — array literals still lower (#49).
+    let ctx : MutCtx :=
+      { aliasEnv := aliasEnv, recvEnv := topRecvEnv,
+        info := some moduleInfo, allowEligible := true,
+        noMutZone := false, inTotalFn := false, bindingEnv := {} }
+    checkStmt ctx s ++ shadowStmts {} [s]
   | .annotatedVarDecl b _ _ typeAnn initOpt =>
     checkAnn b.loc typeAnn
       ++ (match initOpt with
@@ -954,14 +964,14 @@ def checkTSStmt (aliasEnv : Std.HashMap String TSType)
           acc ++ pd ++ checkType b.loc ret) #[]
   | .typeAliasDecl b _ _ ty => checkType b.loc ty
   | .enumDecl _ _ _ _ => #[]
-  | .declareStmt _ inner => checkTSStmt aliasEnv topRecvEnv inner
+  | .declareStmt _ inner => checkTSStmt aliasEnv topRecvEnv moduleInfo inner
   | .importDecl b _ _ form _ =>
     match form with
     | .named => #[]
     | .defaultImport => #[mkThalesDiag (.unsupportedImportForm "default import") b.loc]
     | .namespaceImport => #[mkThalesDiag (.unsupportedImportForm "import * as ns") b.loc]
     | .sideEffect => #[mkThalesDiag (.unsupportedImportForm "side-effect import") b.loc]
-  | .exportDecl _ inner => checkTSStmt aliasEnv topRecvEnv inner
+  | .exportDecl _ inner => checkTSStmt aliasEnv topRecvEnv moduleInfo inner
   | .exportNamedDecl _ _ => #[]
   | .exportUnsupported b form =>
     match form with
@@ -989,8 +999,11 @@ def checkTSStmtSwitch (aliasEnv : Std.HashMap String TSType) (ts : TSStatement)
 def subsetCheckRaw (prog : TSProgram) : Array Diagnostic :=
   let aliasEnv := buildAliasEnv prog.body
   let topRecvEnv := buildTopRecvEnv prog.body
+  -- Module-level mutation/loop info over the reconstructed executable top-level
+  -- block — the SAME block `buildModule` lowers into `main` (#49).
+  let moduleInfo := EscapeAnalysis.analyze [] (.blockStmt {} (moduleExecutableStatements prog.body))
   prog.body.foldl (fun acc ts =>
-    acc ++ checkTSStmt aliasEnv topRecvEnv ts ++ checkTSStmtSwitch aliasEnv ts) #[]
+    acc ++ checkTSStmt aliasEnv topRecvEnv moduleInfo ts ++ checkTSStmtSwitch aliasEnv ts) #[]
 
 /-- Subset check with `@thales-expect-error` directives applied.
     Suppresses TH diagnostics on lines covered by matching directives and

--- a/Thales/TypeCheck/Diagnostic.lean
+++ b/Thales/TypeCheck/Diagnostic.lean
@@ -123,6 +123,9 @@ inductive ThalesKind where
   | regexLiteral
   -- Unsupported unary operator (TH0092): typeof/void/delete, in any position
   | unsupportedUnaryOperator (op : String)
+  -- TH0093: a hoisted top-level declaration references a top-level mutable
+  -- `let` (which lowers to a `main`-local binding the declaration cannot see)
+  | topLevelMutableReferencedByHoisted (name : String)
   -- Directive diagnostics (TH9000–TH9003)
   | directiveUnused
   | directiveCodeMismatch (expected : Nat) (actual : List Nat)
@@ -180,6 +183,7 @@ def ThalesKind.thCode : ThalesKind → Nat
   | .importCycle _ => 90
   | .regexLiteral => 91
   | .unsupportedUnaryOperator _ => 92
+  | .topLevelMutableReferencedByHoisted _ => 93
   | .directiveUnused => 9000
   | .directiveCodeMismatch .. => 9001
   | .emissionBlockedBySuppressedViolation => 9002
@@ -272,6 +276,8 @@ def ThalesKind.message : ThalesKind → String
     "Regex literals are not supported"
   | .unsupportedUnaryOperator op =>
     s!"The '{op}' operator is not supported"
+  | .topLevelMutableReferencedByHoisted name =>
+    s!"Top-level mutable variable '{name}' cannot be referenced by a hoisted declaration (function or const)"
   | .directiveUnused => "Unused `@thales-expect-error` directive"
   | .directiveCodeMismatch expected actual =>
     let fmtCode (n : Nat) : String := s!"TH{padCode n}"

--- a/Thales/TypeCheck/TSAST.lean
+++ b/Thales/TypeCheck/TSAST.lean
@@ -110,4 +110,21 @@ structure TSProgram where
   expectErrorDirectives : Array Thales.Parser.ExpectErrorDirective := #[]
   deriving Inhabited
 
+/-- The executable top-level statements of a module, reconstructed as plain JS
+    `Statement`s in source order: an `annotatedVarDecl` becomes a `let`/`const`
+    `variableDecl` (so escape analysis sees the binding, not just later
+    mutations of it), a `.js` statement is unwrapped, `export <decl>` is
+    unwrapped first, and pure declarations (functions, types, interfaces, enums,
+    imports) are dropped. Feeds module-level mutation/escape analysis the SAME
+    block the emitter lowers into `def main`, so the subset checker and the
+    emitter never disagree on what is lowerable (#49). -/
+def moduleExecutableStatements (body : List TSStatement) : List Statement :=
+  (body.map fun s => match s with | .exportDecl _ inner => inner | other => other).filterMap
+    fun ts => match ts with
+    | .js (.variableDecl _) => none  -- top-level var decls arrive as annotatedVarDecl
+    | .js s => some s
+    | .annotatedVarDecl b kind name typeAnn init =>
+        some (.variableDecl (.mk b [.mk b (.identifier { name }) init (typeAnn.map (·.type))] kind))
+    | _ => none
+
 end Thales.TypeCheck

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -87,6 +87,7 @@ soundness check).
 | TH0090 | Subset       | Circular imports                                          |
 | TH0091 | Subset       | Regex literals are not supported                          |
 | TH0092 | Subset       | Unsupported unary operator (`typeof`/`void`/`delete`)     |
+| TH0093 | Subset       | Top-level mutable referenced by a hoisted declaration     |
 | TH9000 | Directive    | Unused `@thales-expect-error` directive                   |
 | TH9001 | Directive    | Directive code mismatch                                   |
 | TH9002 | Directive    | Cannot emit: subset violations suppressed                 |
@@ -1109,4 +1110,23 @@ function f(x: string): boolean {
   }
   return false;
 }
+```
+
+### TH0093 — Top-level mutable variable referenced by a hoisted declaration
+
+A top-level `let` that is mutated at module level is lowered into the `main`
+`IO` do-block, where it is a local `let mut`. A hoisted declaration — a
+`function`, or a `const` emitted as a top-level `def` — is elaborated outside
+`main` and so cannot reference it. Move the value into a `const`, or compute it
+where it is used. (Widening this is a future task.)
+
+```ts
+let total = 0;
+for (const x of [1, 2, 3]) {
+  total += x;
+}
+function report(): number {
+  return total; // TH0093: `total` is a `main`-local `let mut`
+}
+console.log(report());
 ```

--- a/scripts/run-examples.js
+++ b/scripts/run-examples.js
@@ -511,7 +511,7 @@ function runDirectHarnessChecks() {
   const check = path.join(tmp, 'input.ts');
   fs.writeFileSync(
     check,
-    'let x = 0;\n// @thales-expect-error TH0001\nx = 1;\n',
+    'const o = { a: 0 };\n// @thales-expect-error TH0003\no.a = 1;\n',
   );
   try {
     // Emit mode should fail with TH9002 and write no .lean sidecar.

--- a/tests/conformance/accept/toplevel-c-for.ts
+++ b/tests/conformance/accept/toplevel-c-for.ts
@@ -1,0 +1,4 @@
+// Top-level canonical for (issue #49): prints 0,1,2 on separate lines.
+for (let i = 0; i < 3; i++) {
+  console.log(i);
+}

--- a/tests/conformance/accept/toplevel-for-of-sum.ts
+++ b/tests/conformance/accept/toplevel-for-of-sum.ts
@@ -1,0 +1,6 @@
+// Top-level mutation + for-of (issue #49): accepted and compiles, prints 6.
+let total = 0;
+for (const x of [1, 2, 3]) {
+  total += x;
+}
+console.log(total);

--- a/tests/conformance/accept/toplevel-log-order.ts
+++ b/tests/conformance/accept/toplevel-log-order.ts
@@ -1,0 +1,9 @@
+// Output order is preserved across the hoist boundary (issue #49): a, 6, b.
+console.log('a');
+const base = 3;
+let total = 0;
+for (const x of [1, 2, 3]) {
+  total += x;
+}
+console.log(total);
+console.log('b');

--- a/tests/conformance/accept/toplevel-reassign.ts
+++ b/tests/conformance/accept/toplevel-reassign.ts
@@ -1,0 +1,4 @@
+// Top-level reassignment (issue #49): accepted; prints 1.
+let counter = 0;
+counter = counter + 1;
+console.log(counter);

--- a/tests/conformance/accept/toplevel-while-break.ts
+++ b/tests/conformance/accept/toplevel-while-break.ts
@@ -1,0 +1,9 @@
+// Top-level while with break/continue (issue #49): prints 0,1,2.
+let i = 0;
+while (true) {
+  if (i >= 3) {
+    break;
+  }
+  console.log(i);
+  i = i + 1;
+}

--- a/tests/conformance/accept/toplevel-while-false.ts
+++ b/tests/conformance/accept/toplevel-while-false.ts
@@ -1,0 +1,4 @@
+// Top-level while (issue #49): accepted; loop body never runs, prints nothing.
+while (false) {
+  console.log('unreachable');
+}

--- a/tests/conformance/reject/0001-reassign-variable.ts
+++ b/tests/conformance/reject/0001-reassign-variable.ts
@@ -1,7 +1,0 @@
-// Subset-rejected example: module-level variable reassignment (TH0001).
-// tsc accepts; thales rejects because top-level bindings stay immutable —
-// only function-local non-escaping mutation is in the subset (#24).
-let counter = 0;
-// @thales-expect-error TH0001
-counter = counter + 1;
-console.log(counter);

--- a/tests/conformance/reject/0010-for-loop.ts
+++ b/tests/conformance/reject/0010-for-loop.ts
@@ -1,7 +1,0 @@
-// Subset-rejected example: module-level while loop (TH0010). Loops are
-// only admitted inside do-mode-lowerable declared functions (#26 admits
-// while/do-while there); at module level every loop stays rejected.
-// @thales-expect-error TH0010
-while (false) {
-  console.log('unreachable');
-}

--- a/tests/conformance/reject/0093-hoisted-reads-mutable.ts
+++ b/tests/conformance/reject/0093-hoisted-reads-mutable.ts
@@ -1,0 +1,12 @@
+// TH0093: a hoisted function reads a top-level mutable `let`. The `let` is
+// lowered into the `main` IO do-block (a `let mut`), so a hoisted `def report`
+// elaborated outside `main` cannot see it. Out of v1 scope.
+let total = 0;
+for (const x of [1, 2, 3]) {
+  total += x;
+}
+// @thales-expect-error TH0093
+function report(): number {
+  return total;
+}
+console.log(report());


### PR DESCRIPTION
Makes the module top level admit the same mutation (#24) and loop (#25) subset that function bodies already support, by always lowering executable top-level statements into a single `def main : IO Unit := do …` block, with `const`/function/type declarations hoisted above it.

Two phases. Phase A is a pure parity refactor: top level is rewritten to flow every executable statement into one `main` do-block, reproducing every prior lowering so the conformance corpus stays runtime-identical. Phase B widens the language: a whole-module `MutationInfo` is threaded into the subset checker (shared with the emitter via `moduleExecutableStatements`, so the two never disagree on lowerability), admitting module-level mutation and loops. Because Phase A already lowers them, there is no accept→uncompilable intermediate state.

A new code TH0093 rejects the one pathological case: a hoisted declaration (a function, or a `const` emitted as a top-level `def`) that reads a top-level mutable `let`, which lowers to a `main`-local `let mut` it cannot see.

test262 for-of/for slices are unchanged from baseline: the widening admits top-level array-literal loops and mutation (covered by the conformance corpus), while test262's loop tests remain out of subset for unrelated reasons (iterator protocols, `var`, destructuring, named iterables).

Closes #49.